### PR TITLE
Add Slime Java Commons to Gradle build and create a GitHub Actions workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
+    - name: Test with Gradle
+      run: ./gradlew clean test
+      
     - name: Build with Gradle
       run: ./gradlew clean serverJar
       

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,45 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build SlimeVR Server with Gradle
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+    
+    - name: Clone Slime Java Commons
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: Eirenliel/slime-java-commons
+        # Relative path under $GITHUB_WORKSPACE to place the repository
+        path: Slime Java Commons
+    
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2.1.0
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew clean serverJar
+      
+    - name: Upload the Server JAR as a Build Artifact
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        # Artifact name
+        name: "SlimeVR-Server" # optional, default is artifact
+        # A file, directory or wildcard pattern that describes what to upload
+        path: build/libs/*

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 }
 
 dependencies {
+	compile project(':Slime Java Commons')
+
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
     api 'org.yaml:snakeyaml:1.25'
@@ -32,4 +34,14 @@ dependencies {
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'io.eiren.vr.Main'
+    }
+    
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-jar {
+subprojects.each { subproject -> evaluationDependsOn(subproject.path) }
+task serverJar (type: Jar, dependsOn: subprojects.tasks['build']) {
     manifest {
         attributes 'Main-Class': 'io.eiren.vr.Main'
     }
@@ -44,4 +45,5 @@ jar {
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    with jar
 }


### PR DESCRIPTION
- Added Slime Java Commons as a dependency to the Gradle build script
- Added `serverJar` Gradle task to build a runnable server JAR with packed dependencies
- Added GitHub Actions workflow to run unit tests and compile a server jar with `serverJar`