### PR TITLE
Automatically detect and set the Slime Java Commons subproject location

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: Eirenliel/slime-java-commons
         # Relative path under $GITHUB_WORKSPACE to place the repository
-        path: Slime Java Commons
+        path: ../Slime Java Commons
     
     - name: Set up JDK 11
       uses: actions/setup-java@v2.1.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: Eirenliel/slime-java-commons
         # Relative path under $GITHUB_WORKSPACE to place the repository
-        path: ../Slime Java Commons
+        path: Slime Java Commons
     
     - name: Set up JDK 11
       uses: actions/setup-java@v2.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,16 @@ dependencies {
 
 subprojects.each { subproject -> evaluationDependsOn(subproject.path) }
 task serverJar (type: Jar, dependsOn: subprojects.tasks['build']) {
+    // Make the JAR runnable
     manifest {
         attributes 'Main-Class': 'io.eiren.vr.Main'
     }
     
+    // Pack all dependencies within the JAR
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
+
+    // Add this project's classes in the JAR
     with jar
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,8 +19,8 @@ def commonsDirs = [
 
 for (commonsDir in commonsDirs) {
     if (commonsDir.isDirectory()) {
-        project(':Slime Java Commons').projectDir = commonsDir
         logger.info('\"Slime Java Commons\" subproject detected at \"{}\"', commonsDir.getCanonicalPath())
+        project(':Slime Java Commons').projectDir = commonsDir
         break
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,18 @@
 
 rootProject.name = 'SlimeVR Server'
 include('Slime Java Commons')
-project(':Slime Java Commons').projectDir = new File(settingsDir, '../Slime Java Commons')
+
+def commonsDirs = [
+    new File(settingsDir, 'Slime Java Commons'),
+    new File(settingsDir, 'slime-java-commons'),
+    new File(settingsDir, '../Slime Java Commons'),
+    new File(settingsDir, '../slime-java-commons')
+]
+
+for (commonsDir in commonsDirs) {
+    if (commonsDir.isDirectory()) {
+        project(':Slime Java Commons').projectDir = commonsDir
+        logger.info('\"Slime Java Commons\" subproject detected at \"{}\"', commonsDir.getCanonicalPath())
+        break
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,4 @@
 
 rootProject.name = 'SlimeVR Server'
 include('Slime Java Commons')
+project(':Slime Java Commons').projectDir = new File(settingsDir, '../Slime Java Commons')


### PR DESCRIPTION
Automatically checks the following relative locations for a project directory:
 - `Slime Java Commons`
 - `slime-java-commons`
 - `../Slime Java Commons`
 - `../slime-java-commons`