### PR TITLE
Keyboard keybindings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,12 @@ dependencies {
 	compile 'com.fazecast:jSerialComm:[2.0.0,3.0.0)'
 	compile 'com.google.protobuf:protobuf-java:3.17.3'
 	compile "org.java-websocket:Java-WebSocket:1.5.1"
+	compile 'com.melloware:jintellitype:1.4.0'
 
 	// This dependency is used internally, and not exposed to consumers on their own compile classpath.
 	implementation 'com.google.guava:guava:28.2-jre'
+
+	implementation 'org.json:json:20210307'
 
 	// Use JUnit test framework
 	testImplementation platform('org.junit:junit-bom:5.7.2')

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,6 @@ dependencies {
 	// This dependency is used internally, and not exposed to consumers on their own compile classpath.
 	implementation 'com.google.guava:guava:28.2-jre'
 
-	implementation 'org.json:json:20210307'
-
 	// Use JUnit test framework
 	testImplementation platform('org.junit:junit-bom:5.7.2')
 	testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/src/main/java/io/eiren/vr/Keybinding.java
+++ b/src/main/java/io/eiren/vr/Keybinding.java
@@ -1,0 +1,52 @@
+package io.eiren.vr;
+
+import com.melloware.jintellitype.JIntellitype;
+import com.melloware.jintellitype.HotkeyListener;
+import io.eiren.util.ann.AWTThread;
+import io.eiren.util.logging.LogManager;
+
+public class Keybinding implements HotkeyListener {
+	public final VRServer server;
+	private static final int RESET = 1;
+	private static final int QUICK_RESET = 2;
+
+	@AWTThread
+	public Keybinding(VRServer server) {
+		this.server = server;
+
+		if(JIntellitype.isJIntellitypeSupported()) {
+			JIntellitype.getInstance().addHotKeyListener(this);
+
+			String resetBinding = this.server.config.getString("keybindings.reset");
+			if(resetBinding == null) {
+				resetBinding = "CTRL+ALT+SHIFT+Y";
+				this.server.config.setProperty("keybindings.reset", resetBinding);
+			}
+			JIntellitype.getInstance().registerHotKey(RESET, resetBinding);
+			LogManager.log.info("[Keybinding] Bound reset to " + resetBinding);
+
+			String quickResetBinding = this.server.config.getString("keybindings.quickReset");
+			if(quickResetBinding == null) {
+				quickResetBinding = "CTRL+ALT+SHIFT+U";
+				this.server.config.setProperty("keybindings.quickReset", quickResetBinding);
+			}
+			JIntellitype.getInstance().registerHotKey(QUICK_RESET, quickResetBinding);
+			LogManager.log.info("[Keybinding] Bound quick reset to " + quickResetBinding);
+		}
+	}
+
+	@AWTThread
+	@Override
+	public void onHotKey(int identifier) {
+		switch(identifier) {
+		case RESET:
+			LogManager.log.info("[Keybinding] Reset pressed");
+			server.resetTrackersYaw();
+			break;
+		case QUICK_RESET:
+			LogManager.log.info("[Keybinding] Quick reset pressed");
+			server.resetTrackers();
+			break;
+		}
+	}
+}

--- a/src/main/java/io/eiren/vr/Main.java
+++ b/src/main/java/io/eiren/vr/Main.java
@@ -26,6 +26,7 @@ public class Main {
 		try {
 			vrServer = new VRServer();
 			vrServer.start();
+			new Keybinding(vrServer);
 			new VRServerGUI(vrServer);
 		} catch(Throwable e) {
 			e.printStackTrace();


### PR DESCRIPTION
Adding support for using global keyboard shortcuts to do reset and quick reset actions.

* Windows only
* No timer on reset. For my purpose this works better, but maybe option should be added?
* No UI, bindings can be edited in the config file however.

Combining this with a tool like OVR Advanced Settings makes it so resetting can be done using custom bindings for vr controllers.