### PR TITLE
Keybinding: If JIntellitype fails to load, still allow server to run

### DIFF
--- a/src/main/java/io/eiren/vr/Keybinding.java
+++ b/src/main/java/io/eiren/vr/Keybinding.java
@@ -16,7 +16,7 @@ public class Keybinding implements HotkeyListener {
 		this.server = server;
 
 		try {
-			if(JIntellitype.isJIntellitypeSupported()) {
+			if(JIntellitype.getInstance() instanceof JIntellitype) {
 				JIntellitype.getInstance().addHotKeyListener(this);
 
 				String resetBinding = this.server.config.getString("keybindings.reset");
@@ -37,6 +37,10 @@ public class Keybinding implements HotkeyListener {
 			}
 		}
 		catch (JIntellitypeException je)
+		{
+			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
+		}
+		catch (ExceptionInInitializerError e)
 		{
 			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
 		}

--- a/src/main/java/io/eiren/vr/Keybinding.java
+++ b/src/main/java/io/eiren/vr/Keybinding.java
@@ -1,6 +1,7 @@
 package io.eiren.vr;
 
 import com.melloware.jintellitype.JIntellitype;
+import com.melloware.jintellitype.JIntellitypeException;
 import com.melloware.jintellitype.HotkeyListener;
 import io.eiren.util.ann.AWTThread;
 import io.eiren.util.logging.LogManager;
@@ -14,24 +15,30 @@ public class Keybinding implements HotkeyListener {
 	public Keybinding(VRServer server) {
 		this.server = server;
 
-		if(JIntellitype.isJIntellitypeSupported()) {
-			JIntellitype.getInstance().addHotKeyListener(this);
+		try {
+			if(JIntellitype.isJIntellitypeSupported()) {
+				JIntellitype.getInstance().addHotKeyListener(this);
 
-			String resetBinding = this.server.config.getString("keybindings.reset");
-			if(resetBinding == null) {
-				resetBinding = "CTRL+ALT+SHIFT+Y";
-				this.server.config.setProperty("keybindings.reset", resetBinding);
-			}
-			JIntellitype.getInstance().registerHotKey(RESET, resetBinding);
-			LogManager.log.info("[Keybinding] Bound reset to " + resetBinding);
+				String resetBinding = this.server.config.getString("keybindings.reset");
+				if(resetBinding == null) {
+					resetBinding = "CTRL+ALT+SHIFT+Y";
+					this.server.config.setProperty("keybindings.reset", resetBinding);
+				}
+				JIntellitype.getInstance().registerHotKey(RESET, resetBinding);
+				LogManager.log.info("[Keybinding] Bound reset to " + resetBinding);
 
-			String quickResetBinding = this.server.config.getString("keybindings.quickReset");
-			if(quickResetBinding == null) {
-				quickResetBinding = "CTRL+ALT+SHIFT+U";
-				this.server.config.setProperty("keybindings.quickReset", quickResetBinding);
+				String quickResetBinding = this.server.config.getString("keybindings.quickReset");
+				if(quickResetBinding == null) {
+					quickResetBinding = "CTRL+ALT+SHIFT+U";
+					this.server.config.setProperty("keybindings.quickReset", quickResetBinding);
+				}
+				JIntellitype.getInstance().registerHotKey(QUICK_RESET, quickResetBinding);
+				LogManager.log.info("[Keybinding] Bound quick reset to " + quickResetBinding);
 			}
-			JIntellitype.getInstance().registerHotKey(QUICK_RESET, quickResetBinding);
-			LogManager.log.info("[Keybinding] Bound quick reset to " + quickResetBinding);
+		}
+		catch (JIntellitypeException je)
+		{
+			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
 		}
 	}
 


### PR DESCRIPTION
I thought that simply using the function "isJIntellitypeSupported" would be enough, but a user error in discord shows that JIntellitype is not to be trusted. Wrapping the init code in a try catch should resolve any issues tho. Hopefully.