### PR TITLE
Hip tracker support

### DIFF
--- a/src/main/java/dev/slimevr/autobone/AutoBone.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBone.java
@@ -91,15 +91,15 @@ public class AutoBone {
 		// Load waist configs
 		staticConfigs.put("Head", server.config.getFloat("body.headShift", HumanSkeletonWithWaist.HEAD_SHIFT_DEFAULT));
 		staticConfigs.put("Neck", server.config.getFloat("body.neckLength", HumanSkeletonWithWaist.NECK_LENGTH_DEFAULT));
-		configs.put("Waist", server.config.getFloat("body.waistDistance", 0.85f));
+		configs.put("Waist", server.config.getFloat("body.waistDistance", 0.64f));
 		
 		if(server.config.getBoolean("autobone.forceChestTracker", false) || (frame != null && TrackerUtils.findTrackerForBodyPosition(frame, TrackerPosition.CHEST) != null) || TrackerUtils.findTrackerForBodyPosition(server.getAllTrackers(), TrackerPosition.CHEST) != null) {
 			// If force enabled or has a chest tracker
-			configs.put("Chest", server.config.getFloat("body.chestDistance", 0.42f));
+			configs.put("Chest", server.config.getFloat("body.chestDistance", 0.32f));
 		} else {
 			// Otherwise, make sure it's not used
 			configs.remove("Chest");
-			staticConfigs.put("Chest", server.config.getFloat("body.chestDistance", 0.42f));
+			staticConfigs.put("Chest", server.config.getFloat("body.chestDistance", 0.32f));
 		}
 		
 		// Load leg configs

--- a/src/main/java/dev/slimevr/autobone/AutoBone.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBone.java
@@ -72,8 +72,7 @@ public class AutoBone {
 	public final HashMap<String, Float> configs = new HashMap<String, Float>();
 	public final HashMap<String, Float> staticConfigs = new HashMap<String, Float>();
 	
-	public final FastList<String> heightConfigs = new FastList<String>(new String[]{"Neck", "Waist", "Legs length"
-	});
+	public final FastList<String> heightConfigs = new FastList<String>(new String[]{"Neck", "Waist", "Hip", "Legs length"});
 	
 	public AutoBone(VRServer server) {
 		this.server = server;
@@ -91,15 +90,22 @@ public class AutoBone {
 		// Load waist configs
 		staticConfigs.put("Head", server.config.getFloat("body.headShift", HumanSkeletonWithWaist.HEAD_SHIFT_DEFAULT));
 		staticConfigs.put("Neck", server.config.getFloat("body.neckLength", HumanSkeletonWithWaist.NECK_LENGTH_DEFAULT));
-		configs.put("Waist", server.config.getFloat("body.waistDistance", 0.64f));
-		
+		configs.put("Waist", server.config.getFloat("body.waistDistance", 0.6f));
 		if(server.config.getBoolean("autobone.forceChestTracker", false) || (frame != null && TrackerUtils.findTrackerForBodyPosition(frame, TrackerPosition.CHEST) != null) || TrackerUtils.findTrackerForBodyPosition(server.getAllTrackers(), TrackerPosition.CHEST) != null) {
 			// If force enabled or has a chest tracker
-			configs.put("Chest", server.config.getFloat("body.chestDistance", 0.32f));
+			configs.put("Chest", server.config.getFloat("body.chestDistance", 0.35f));
 		} else {
 			// Otherwise, make sure it's not used
 			configs.remove("Chest");
-			staticConfigs.put("Chest", server.config.getFloat("body.chestDistance", 0.32f));
+			staticConfigs.put("Chest", server.config.getFloat("body.chestDistance", 0.35f));
+		}
+		if(server.config.getBoolean("autobone.forceHipTracker", false) || (frame != null && TrackerUtils.findTrackerForBodyPosition(frame, TrackerPosition.HIP) != null) || TrackerUtils.findTrackerForBodyPosition(server.getAllTrackers(), TrackerPosition.HIP) != null) {
+			// If force enabled or has a hip tracker
+			configs.put("Hip", server.config.getFloat("body.hipDistance", 0.1f));
+		} else {
+			// Otherwise, make sure it's not used
+			configs.remove("Hip");
+			staticConfigs.put("Hip", server.config.getFloat("body.hipDistance", 0.1f));
 		}
 		
 		// Load leg configs
@@ -150,6 +156,7 @@ public class AutoBone {
 		setConfig("Neck", "body.neckLength");
 		setConfig("Waist", "body.waistDistance");
 		setConfig("Chest", "body.chestDistance");
+		setConfig("Hip", "body.hipDistance");
 		setConfig("Hips width", "body.hipsWidth");
 		setConfig("Legs length", "body.legsLength");
 		setConfig("Knee height", "body.kneeHeight");

--- a/src/main/java/dev/slimevr/autobone/SimpleSkeleton.java
+++ b/src/main/java/dev/slimevr/autobone/SimpleSkeleton.java
@@ -23,12 +23,17 @@ public class SimpleSkeleton {
 	protected final TransformNode neckNode = new TransformNode("Neck", false);
 	protected final TransformNode waistNode = new TransformNode("Waist", false);
 	protected final TransformNode chestNode = new TransformNode("Chest", false);
+	protected final TransformNode hipNode = new TransformNode("Hip", false);
 	
-	protected float chestDistance = 0.42f;
+	protected float chestDistance = 0.32f;
 	/**
 	 * Distance from eyes to waist
 	 */
-	protected float waistDistance = 0.85f;
+	protected float waistDistance = 0.64f;
+	/**
+	 * Distance from waist to hip
+	 */
+	protected float hipDistance = 0.05f;
 	/**
 	 * Distance from eyes to the base of the neck
 	 */

--- a/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
+++ b/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
@@ -342,6 +342,7 @@ public class AutoBoneWindow extends JFrame {
 												Float neckLength = autoBone.getConfig("Neck");
 												Float chestLength = autoBone.getConfig("Chest");
 												Float waistLength = autoBone.getConfig("Waist");
+												Float hipLength = autoBone.getConfig("Hip");
 												Float hipWidth = autoBone.getConfig("Hips width");
 												Float legsLength = autoBone.getConfig("Legs length");
 												Float kneeHeight = autoBone.getConfig("Knee height");

--- a/src/main/java/dev/slimevr/gui/SkeletonConfig.java
+++ b/src/main/java/dev/slimevr/gui/SkeletonConfig.java
@@ -117,6 +117,13 @@ public class SkeletonConfig extends EJBagNoStretch {
 			add(new TimedResetButton("Reset", "Waist"), c(4, row, 2));
 			row++;
 
+			add(new JLabel("Hip"), c(0, row, 2));
+			add(new AdjButton("+", "Hip", 0.01f), c(1, row, 2));
+			add(new SkeletonLabel("Hip"), c(2, row, 2));
+			add(new AdjButton("-", "Hip", -0.01f), c(3, row, 2));
+			add(new ResetButton("Reset", "Hip"), c(4, row, 2));
+			row++;
+
 			add(new JLabel("Hips width"), c(0, row, 2));
 			add(new AdjButton("+", "Hips width", 0.01f), c(1, row, 2));
 			add(new SkeletonLabel("Hips width"), c(2, row, 2));

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
@@ -167,7 +167,7 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 			hmdTracker.getPosition(vec);
 			float height = vec.y;
 			if(height > 0.5f) { // Reset only if floor level is right, todo: read floor level from SteamVR if it's not 0
-				setSkeletonConfig(joint, height - neckLength - waistDistance - DEFAULT_FLOOR_OFFSET);
+				setSkeletonConfig(joint, height - neckLength - waistDistance - hipDistance - DEFAULT_FLOOR_OFFSET);
 			}
 			resetSkeletonConfig("Knee height");
 			break;

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
@@ -72,11 +72,11 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 	public HumanSkeletonWithLegs(VRServer server, List<ComputedHumanPoseTracker> computedTrackers) {
 		super(server, computedTrackers);
 		List<Tracker> allTracekrs = server.getAllTrackers();
-		this.leftLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_LEG, TrackerPosition.LEFT_ANKLE);
-		this.leftAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_ANKLE, TrackerPosition.LEFT_LEG);
+		this.leftLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_LEG, TrackerPosition.LEFT_ANKLE, null);
+		this.leftAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_ANKLE, TrackerPosition.LEFT_LEG, null);
 		this.leftFootTracker = TrackerUtils.findTrackerForBodyPosition(allTracekrs, TrackerPosition.LEFT_FOOT);
-		this.rightLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_LEG, TrackerPosition.RIGHT_ANKLE);
-		this.rightAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_ANKLE, TrackerPosition.RIGHT_LEG);
+		this.rightLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_LEG, TrackerPosition.RIGHT_ANKLE, null);
+		this.rightAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_ANKLE, TrackerPosition.RIGHT_LEG, null);
 		this.rightFootTracker = TrackerUtils.findTrackerForBodyPosition(allTracekrs, TrackerPosition.RIGHT_FOOT);
 		ComputedHumanPoseTracker lat = null;
 		ComputedHumanPoseTracker rat = null;
@@ -370,7 +370,7 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 		super.resetTrackersFull();
 		// Start with waist, it was reset in the parent
 		Quaternion referenceRotation = new Quaternion();
-		this.waistTracker.getRotation(referenceRotation);
+		this.hipTracker.getRotation(referenceRotation);
 		
 		this.leftLegTracker.resetFull(referenceRotation);
 		this.rightLegTracker.resetFull(referenceRotation);
@@ -401,7 +401,7 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 		super.resetTrackersYaw();
 		// Start with waist, it was reset in the parent
 		Quaternion referenceRotation = new Quaternion();
-		this.waistTracker.getRotation(referenceRotation);
+		this.hipTracker.getRotation(referenceRotation);
 		
 		this.leftLegTracker.resetYaw(referenceRotation);
 		this.rightLegTracker.resetYaw(referenceRotation);

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
@@ -291,8 +291,8 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 			chestNode.localTransform.getRotation(hipBuf);
 			kneeBuf.nlerp(hipBuf, 0.3333333f);
 			hipNode.localTransform.setRotation(kneeBuf);
-			// TODO : Use vectors to add like 50% of wasit tracker yaw to waist node to reduce drift and let user take weird poses
-			// TODO Set virtual waist node yaw to that of waist node
+			trackerWaistNode.localTransform.setRotation(kneeBuf);
+			// TODO : Use vectors to add like 50% of waist tracker yaw to waist node to reduce drift and let user take weird poses
 		}
 	}
 	

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
@@ -71,13 +71,13 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 
 	public HumanSkeletonWithLegs(VRServer server, List<ComputedHumanPoseTracker> computedTrackers) {
 		super(server, computedTrackers);
-		List<Tracker> allTracekrs = server.getAllTrackers();
-		this.leftLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_LEG, TrackerPosition.LEFT_ANKLE, null);
-		this.leftAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.LEFT_ANKLE, TrackerPosition.LEFT_LEG, null);
-		this.leftFootTracker = TrackerUtils.findTrackerForBodyPosition(allTracekrs, TrackerPosition.LEFT_FOOT);
-		this.rightLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_LEG, TrackerPosition.RIGHT_ANKLE, null);
-		this.rightAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.RIGHT_ANKLE, TrackerPosition.RIGHT_LEG, null);
-		this.rightFootTracker = TrackerUtils.findTrackerForBodyPosition(allTracekrs, TrackerPosition.RIGHT_FOOT);
+		List<Tracker> allTrackers = server.getAllTrackers();
+		this.leftLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.LEFT_LEG, TrackerPosition.LEFT_ANKLE, null);
+		this.leftAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.LEFT_ANKLE, TrackerPosition.LEFT_LEG, null);
+		this.leftFootTracker = TrackerUtils.findTrackerForBodyPosition(allTrackers, TrackerPosition.LEFT_FOOT);
+		this.rightLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.RIGHT_LEG, TrackerPosition.RIGHT_ANKLE, null);
+		this.rightAnkleTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.RIGHT_ANKLE, TrackerPosition.RIGHT_LEG, null);
+		this.rightFootTracker = TrackerUtils.findTrackerForBodyPosition(allTrackers, TrackerPosition.RIGHT_FOOT);
 		ComputedHumanPoseTracker lat = null;
 		ComputedHumanPoseTracker rat = null;
 		ComputedHumanPoseTracker rkt = null;
@@ -291,7 +291,8 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 			chestNode.localTransform.getRotation(hipBuf);
 			kneeBuf.nlerp(hipBuf, 0.3333333f);
 			hipNode.localTransform.setRotation(kneeBuf);
-			trackerWaistNode.localTransform.setRotation(kneeBuf);
+			//trackerWaistNode.localTransform.setRotation(kneeBuf); // <== Provides cursed results from my test in VRChat when sitting or laying down -Erimel
+			// TODO : Correct the trackerWaistNode without getting cursed results (only correct yaw?)
 			// TODO : Use vectors to add like 50% of waist tracker yaw to waist node to reduce drift and let user take weird poses
 		}
 	}

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithLegs.java
@@ -111,10 +111,10 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 		//extendedPelvisModel = server.config.getBoolean("body.model.extendedPelvis", extendedPelvisModel);
 		extendedKneeModel = server.config.getBoolean("body.model.extendedKnee", extendedKneeModel);
 		
-		waistNode.attachChild(leftHipNode);
+		hipNode.attachChild(leftHipNode);
 		leftHipNode.localTransform.setTranslation(-hipsWidth / 2, 0, 0);
 		
-		waistNode.attachChild(rightHipNode);
+		hipNode.attachChild(rightHipNode);
 		rightHipNode.localTransform.setTranslation(hipsWidth / 2, 0, 0);
 		
 		leftHipNode.attachChild(leftKneeNode);
@@ -290,7 +290,7 @@ public class HumanSkeletonWithLegs extends HumanSkeletonWithWaist {
 			kneeBuf.nlerp(hipBuf, 0.5f);
 			chestNode.localTransform.getRotation(hipBuf);
 			kneeBuf.nlerp(hipBuf, 0.3333333f);
-			waistNode.localTransform.setRotation(kneeBuf);
+			hipNode.localTransform.setRotation(kneeBuf);
 			// TODO : Use vectors to add like 50% of wasit tracker yaw to waist node to reduce drift and let user take weird poses
 			// TODO Set virtual waist node yaw to that of waist node
 		}

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
@@ -41,15 +41,15 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 	protected final TransformNode trackerWaistNode = new TransformNode("Waist-Tracker", false);
 	protected final TransformNode hipNode = new TransformNode("Hip", false);
 	
-	protected float chestDistance = 0.32f;
+	protected float chestDistance = 0.35f;
 	/**
 	 * Distance from eyes to waist
 	 */
-	protected float waistDistance = 0.64f;
+	protected float waistDistance = 0.6f;
 	/**
 	 * Distance from waist to hip
 	 */
-	protected float hipDistance = 0.05f;
+	protected float hipDistance = 0.1f;
 	/**
 	 * Distance from eyes to waist, defines reported
 	 * tracker position, if you want to move resulting
@@ -66,10 +66,10 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 	protected float headShift = HEAD_SHIFT_DEFAULT;
 	
 	public HumanSkeletonWithWaist(VRServer server, List<ComputedHumanPoseTracker> computedTrackers) {
-		List<Tracker> allTracekrs = server.getAllTrackers();
-		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.WAIST, TrackerPosition.CHEST, TrackerPosition.HIP);
-		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.CHEST, TrackerPosition.WAIST, TrackerPosition.HIP);
-		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.HIP, TrackerPosition.WAIST, TrackerPosition.CHEST);
+		List<Tracker> allTrackers = server.getAllTrackers();
+		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.WAIST, TrackerPosition.CHEST, TrackerPosition.HIP);
+		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.CHEST, TrackerPosition.WAIST, TrackerPosition.HIP);
+		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTrackers, TrackerPosition.HIP, TrackerPosition.WAIST, TrackerPosition.CHEST);
 		this.hmdTracker = server.hmdTracker;
 		this.server = server;
 		ComputedHumanPoseTracker cwt = null;
@@ -137,18 +137,18 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 		case "Virtual waist":
 			setSkeletonConfig(joint, 0.0f);
 			break;
-		case "Chest":
-			setSkeletonConfig(joint, (waistDistance / 2.0f) - hipDistance);
+		case "Chest": //Chest is half of the upper body (half of the waist with the hip)
+			setSkeletonConfig(joint, (waistDistance + hipDistance) / 2.0f);
 			break;
-		case "Hip":
-			setSkeletonConfig(joint, 0.05f);
+		case "Hip": // Distance between waist and hip
+			setSkeletonConfig(joint, 0.1f);
 			break;
-		case "Waist": // Puts Waist in the middle of the height
+		case "Waist": // waist length is from shoulders (bottom of neck) to waist (right above the hip)
 			Vector3f vec = new Vector3f();
 			hmdTracker.getPosition(vec);
 			float height = vec.y;
-			if(height > 0.5f) { // Reset only if floor level is right, todo: read floor level from SteamVR if it's not 0
-				setSkeletonConfig(joint, ((height) / 2.0f) - hipDistance);
+			if(height > 0.5f) { // Reset only if floor level is right, TODO: read floor level from SteamVR if it's not 0
+				setSkeletonConfig(joint, ((height) / 2.0f) - hipDistance - neckLength);
 			}
 			break;
 		}

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
@@ -67,9 +67,9 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 	
 	public HumanSkeletonWithWaist(VRServer server, List<ComputedHumanPoseTracker> computedTrackers) {
 		List<Tracker> allTracekrs = server.getAllTrackers();
-		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.WAIST, TrackerPosition.CHEST);
-		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.CHEST, TrackerPosition.WAIST);
-		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.HIP, this.waistTracker.getBodyPosition());
+		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.WAIST, TrackerPosition.CHEST, TrackerPosition.HIP);
+		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.CHEST, TrackerPosition.WAIST, TrackerPosition.HIP);
+		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.HIP, TrackerPosition.WAIST, TrackerPosition.CHEST);
 		this.hmdTracker = server.hmdTracker;
 		this.server = server;
 		ComputedHumanPoseTracker cwt = null;
@@ -239,10 +239,6 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 			trackerWaistNode.localTransform.setRotation(qBuf);
 			hipNode.localTransform.setRotation(qBuf);
 		}
-		else if(waistTracker.getRotation(qBuf)){
-			waistNode.localTransform.setRotation(qBuf);
-			trackerWaistNode.localTransform.setRotation(qBuf);
-		}
 	}
 	
 	protected void updateComputedTrackers() {
@@ -271,7 +267,8 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 		this.chestTracker.getRotation(referenceRotation);
 		
 		this.waistTracker.resetFull(referenceRotation);
-
+		this.waistTracker.getRotation(referenceRotation);
+		
 		this.hipTracker.resetFull(referenceRotation);
 	}
 	
@@ -287,6 +284,7 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 		this.chestTracker.getRotation(referenceRotation);
 		
 		this.waistTracker.resetYaw(referenceRotation);
+		this.waistTracker.getRotation(referenceRotation);
 
 		this.hipTracker.resetYaw(referenceRotation);
 	}

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
@@ -41,15 +41,15 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 	protected final TransformNode trackerWaistNode = new TransformNode("Waist-Tracker", false);
 	protected final TransformNode hipNode = new TransformNode("Hip", false);
 	
-	protected float chestDistance = 0.42f;
+	protected float chestDistance = 0.32f;
 	/**
 	 * Distance from eyes to waist
 	 */
-	protected float waistDistance = 0.85f;
+	protected float waistDistance = 0.64f;
 	/**
 	 * Distance from waist to hip
 	 */
-	protected float hipDistance = 0f;
+	protected float hipDistance = 0.05f;
 	/**
 	 * Distance from eyes to waist, defines reported
 	 * tracker position, if you want to move resulting
@@ -124,9 +124,9 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 			resetSkeletonConfig("Head");
 			resetSkeletonConfig("Neck");
 			resetSkeletonConfig("Virtual waist");
+			resetSkeletonConfig("Hip");
 			resetSkeletonConfig("Waist");
 			resetSkeletonConfig("Chest");
-			resetSkeletonConfig("Hip");
 			break;
 		case "Head":
 			setSkeletonConfig(joint, HEAD_SHIFT_DEFAULT);
@@ -138,17 +138,17 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 			setSkeletonConfig(joint, 0.0f);
 			break;
 		case "Chest":
-			setSkeletonConfig(joint, waistDistance / 2.0f);
+			setSkeletonConfig(joint, (waistDistance / 2.0f) - hipDistance);
 			break;
 		case "Hip":
-			setSkeletonConfig(joint, 0.0f);
+			setSkeletonConfig(joint, 0.05f);
 			break;
 		case "Waist": // Puts Waist in the middle of the height
 			Vector3f vec = new Vector3f();
 			hmdTracker.getPosition(vec);
 			float height = vec.y;
 			if(height > 0.5f) { // Reset only if floor level is right, todo: read floor level from SteamVR if it's not 0
-				setSkeletonConfig(joint, (height) / 2.0f);
+				setSkeletonConfig(joint, ((height) / 2.0f) - hipDistance);
 			}
 			break;
 		}

--- a/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
+++ b/src/main/java/io/eiren/vr/processor/HumanSkeletonWithWaist.java
@@ -69,7 +69,7 @@ public class HumanSkeletonWithWaist extends HumanSkeleton {
 		List<Tracker> allTracekrs = server.getAllTrackers();
 		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.WAIST, TrackerPosition.CHEST);
 		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.CHEST, TrackerPosition.WAIST);
-		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.HIP, TrackerPosition.WAIST);
+		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(allTracekrs, TrackerPosition.HIP, this.waistTracker.getBodyPosition());
 		this.hmdTracker = server.hmdTracker;
 		this.server = server;
 		ComputedHumanPoseTracker cwt = null;

--- a/src/main/java/io/eiren/vr/trackers/TrackerPosition.java
+++ b/src/main/java/io/eiren/vr/trackers/TrackerPosition.java
@@ -10,6 +10,7 @@ public enum TrackerPosition {
 	HMD("HMD", TrackerRole.HMD),
 	CHEST("body:chest", TrackerRole.CHEST),
 	WAIST("body:waist", TrackerRole.WAIST),
+	HIP("body:hip", null),
 	LEFT_LEG("body:left_leg", TrackerRole.LEFT_KNEE),
 	RIGHT_LEG("body:right_leg", TrackerRole.RIGHT_KNEE),
 	LEFT_ANKLE("body:left_ankle", null),

--- a/src/main/java/io/eiren/vr/trackers/TrackerUtils.java
+++ b/src/main/java/io/eiren/vr/trackers/TrackerUtils.java
@@ -32,11 +32,14 @@ public class TrackerUtils {
 		return findTrackerForBodyPosition(allTrackers, altPosition);
 	}
 
-	public static <T extends Tracker> T findTrackerForBodyPosition(T[] allTrackers, TrackerPosition position, TrackerPosition altPosition) {
+	public static <T extends Tracker> T findTrackerForBodyPosition(T[] allTrackers, TrackerPosition position, TrackerPosition altPosition, TrackerPosition secondAltPosition) {
 		T t = findTrackerForBodyPosition(allTrackers, position);
 		if(t != null)
 			return t;
-		return findTrackerForBodyPosition(allTrackers, altPosition);
+		t = findTrackerForBodyPosition(allTrackers, altPosition);
+		if(t != null)
+			return t;
+		return findTrackerForBodyPosition(allTrackers, secondAltPosition);
 	}
 
 	public static Tracker findTrackerForBodyPositionOrEmpty(List<? extends Tracker> allTrackers, TrackerPosition position, TrackerPosition altPosition, TrackerPosition secondAltPosition) {

--- a/src/main/java/io/eiren/vr/trackers/TrackerUtils.java
+++ b/src/main/java/io/eiren/vr/trackers/TrackerUtils.java
@@ -39,11 +39,14 @@ public class TrackerUtils {
 		return findTrackerForBodyPosition(allTrackers, altPosition);
 	}
 
-	public static Tracker findTrackerForBodyPositionOrEmpty(List<? extends Tracker> allTrackers, TrackerPosition position, TrackerPosition altPosition) {
+	public static Tracker findTrackerForBodyPositionOrEmpty(List<? extends Tracker> allTrackers, TrackerPosition position, TrackerPosition altPosition, TrackerPosition secondAltPosition) {
 		Tracker t = findTrackerForBodyPosition(allTrackers, position);
 		if(t != null)
 			return t;
 		t = findTrackerForBodyPosition(allTrackers, altPosition);
+		if(t != null)
+			return t;
+		t = findTrackerForBodyPosition(allTrackers, secondAltPosition);
 		if(t != null)
 			return t;
 		return new ComputedTracker(Tracker.getNextLocalTrackerId(), "Empty tracker", false, false);


### PR DESCRIPTION
- Added a third bone in the spine.
Head > Neck > Chest > Waist > Hip (+ Virtual waist tracker from Hip) > Lower body
- Autobone support
- Can use any order of tracker (waist + hip, chest + hip, hip alone (why), or chest + waist + hip).
- Also changed initial values and made the reset better by including the neck length in the waist length calculation.