### PR TITLE
Keybindings: Catch even more errors, and manually check that operating system is Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,5 +75,5 @@ shadowJar {
 	archiveVersion.set('')
 }
 application {
-	mainClassName = 'io.eiren.vr.Main'
+	mainClassName = 'dev.slimevr.Main'
 }

--- a/src/main/java/dev/slimevr/gui/Keybinding.java
+++ b/src/main/java/dev/slimevr/gui/Keybinding.java
@@ -17,7 +17,7 @@ public class Keybinding implements HotkeyListener {
 	public Keybinding(VRServer server) {
 		this.server = server;
 		
-		if (OperatingSystem.getCurrentPlatform() == OperatingSystem.WINDOWS) {
+		if (OperatingSystem.getCurrentPlatform() != OperatingSystem.WINDOWS) {
 			LogManager.log.info("[Keybinding] Currently only supported on Windows. Keybindings will be disabled.");
 			return;
 		}

--- a/src/main/java/dev/slimevr/gui/Keybinding.java
+++ b/src/main/java/dev/slimevr/gui/Keybinding.java
@@ -1,12 +1,10 @@
 package dev.slimevr.gui;
 
-import java.util.Locale;
-
 import com.melloware.jintellitype.HotkeyListener;
 import com.melloware.jintellitype.JIntellitype;
-import com.melloware.jintellitype.JIntellitypeException;
 
 import dev.slimevr.VRServer;
+import io.eiren.util.OperatingSystem;
 import io.eiren.util.ann.AWTThread;
 import io.eiren.util.logging.LogManager;
 
@@ -19,14 +17,8 @@ public class Keybinding implements HotkeyListener {
 	public Keybinding(VRServer server) {
 		this.server = server;
 		
-		try {
-			String osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-			if(!osName.contains("windows")) {
-				LogManager.log.info("[Keybinding] Currently only supported on Windows. Keybindings will be disabled.");
-				return;
-			}
-		} catch (SecurityException e) {
-			LogManager.log.info("[Keybinding] Can't check operating system name. Keybindings will be disabled.");
+		if (OperatingSystem.getCurrentPlatform() == OperatingSystem.WINDOWS) {
+			LogManager.log.info("[Keybinding] Currently only supported on Windows. Keybindings will be disabled.");
 			return;
 		}
 		
@@ -50,7 +42,7 @@ public class Keybinding implements HotkeyListener {
 				JIntellitype.getInstance().registerHotKey(QUICK_RESET, quickResetBinding);
 				LogManager.log.info("[Keybinding] Bound quick reset to " + quickResetBinding);
 			}
-		} catch(JIntellitypeException | ExceptionInInitializerError | UnsatisfiedLinkError e) {
+		} catch(Throwable e) {
 			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
 		}
 	}

--- a/src/main/java/dev/slimevr/gui/Keybinding.java
+++ b/src/main/java/dev/slimevr/gui/Keybinding.java
@@ -1,11 +1,12 @@
 package dev.slimevr.gui;
 
+import java.util.Locale;
+
+import com.melloware.jintellitype.HotkeyListener;
 import com.melloware.jintellitype.JIntellitype;
 import com.melloware.jintellitype.JIntellitypeException;
 
 import dev.slimevr.VRServer;
-
-import com.melloware.jintellitype.HotkeyListener;
 import io.eiren.util.ann.AWTThread;
 import io.eiren.util.logging.LogManager;
 
@@ -17,6 +18,17 @@ public class Keybinding implements HotkeyListener {
 	@AWTThread
 	public Keybinding(VRServer server) {
 		this.server = server;
+		
+		try {
+			String osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+			if(!osName.contains("windows")) {
+				LogManager.log.info("[Keybinding] Currently only supported on Windows. Keybindings will be disabled.");
+				return;
+			}
+		} catch (SecurityException e) {
+			LogManager.log.info("[Keybinding] Can't check operating system name. Keybindings will be disabled.");
+			return;
+		}
 		
 		try {
 			if(JIntellitype.getInstance() instanceof JIntellitype) {
@@ -38,9 +50,7 @@ public class Keybinding implements HotkeyListener {
 				JIntellitype.getInstance().registerHotKey(QUICK_RESET, quickResetBinding);
 				LogManager.log.info("[Keybinding] Bound quick reset to " + quickResetBinding);
 			}
-		} catch(JIntellitypeException je) {
-			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
-		} catch(ExceptionInInitializerError e) {
+		} catch(JIntellitypeException | ExceptionInInitializerError | UnsatisfiedLinkError e) {
 			LogManager.log.info("[Keybinding] JIntellitype initialization failed. Keybindings will be disabled. Try restarting your computer.");
 		}
 	}


### PR DESCRIPTION
More errors from discord about JIntelliType. This is getting ridiculous.

Manually checks that the operating system is windows.

Also checks for UnsatisfiedLinkError. Can't test in ARM windows myself, but this will hopefully help against that too.

I can't get it to compile myself without editing build.gradle, but I can remove that change if needed.