### PR TITLE
Add RSSI to trackers

### DIFF
--- a/src/main/java/dev/slimevr/gui/TrackersList.java
+++ b/src/main/java/dev/slimevr/gui/TrackersList.java
@@ -143,6 +143,7 @@ public class TrackersList extends EJBoxNoStretch {
 		JLabel adj;
 		JLabel adjYaw;
 		JLabel correction;
+		JLabel signalStrength;
 		
 		@AWTThread
 		public TrackerPanel(Tracker t) {
@@ -216,6 +217,7 @@ public class TrackersList extends EJBoxNoStretch {
 			add(new JLabel("TPS"), c(3, row, 2, GridBagConstraints.FIRST_LINE_START));
 			if(realTracker instanceof IMUTracker) {
 				add(new JLabel("Ping"), c(2, row, 2, GridBagConstraints.FIRST_LINE_START));
+				add(new JLabel("RSSI"), c(4, row, 2, GridBagConstraints.FIRST_LINE_START));
 			}
 			row++;
 			if(t.hasRotation())
@@ -224,6 +226,7 @@ public class TrackersList extends EJBoxNoStretch {
 				add(position = new JLabel("0 0 0"), c(1, row, 2, GridBagConstraints.FIRST_LINE_START));
 			if(realTracker instanceof IMUTracker) {
 				add(ping = new JLabel(""), c(2, row, 2, GridBagConstraints.FIRST_LINE_START));
+				add(signalStrength = new JLabel(""), c(4, row, 2, GridBagConstraints.FIRST_LINE_START));
 			}
 			if(realTracker instanceof TrackerWithTPS) {
 				add(tps = new JLabel("0"), c(3, row, 2, GridBagConstraints.FIRST_LINE_START));
@@ -313,6 +316,17 @@ public class TrackersList extends EJBoxNoStretch {
 			if(realTracker instanceof IMUTracker) {
 				if(ping != null)
 					ping.setText(String.valueOf(((IMUTracker) realTracker).ping));
+				if (signalStrength != null) {
+					int signal = ((IMUTracker) realTracker).signalStrength;
+					if (signal == -1) {
+						signalStrength.setText("N/A");
+					} else {
+						// -40 dBm is excellent, -95 dBm is very poor
+						int percentage = (signal - -95) * (100 - 0) / (-40 - -95) + 0;
+						percentage = Math.max(Math.min(percentage, 100), 0);
+						signalStrength.setText(String.valueOf(percentage) + "% " + "(" + String.valueOf(signal) + " dBm" + ")");
+					}
+				}
 			}
 			realTracker.getRotation(q);
 			q.toAngles(angles);

--- a/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -35,6 +35,7 @@ public class IMUTracker implements Tracker, TrackerWithTPS, TrackerWithBattery {
 	
 	protected BufferedTimer timer = new BufferedTimer(1f);
 	public int ping = -1;
+	public int signalStrength = -1;
 	
 	public StringBuilder serialBuffer = new StringBuilder();
 	long lastSerialUpdate = 0;

--- a/src/main/java/dev/slimevr/vr/trackers/TrackersUDPServer.java
+++ b/src/main/java/dev/slimevr/vr/trackers/TrackersUDPServer.java
@@ -373,6 +373,19 @@ public class TrackersUDPServer extends Thread {
 						socket.send(new DatagramPacket(rcvBuffer, bb.position(), connection.address));
 						System.out.println("[TrackerServer] Sensor info for " + connection.sensors.get(0).getName() + "/" + sensorId + ": " + sensorStatus);
 						break;
+					case 19:
+						if(connection == null)
+							break;
+						if(connection.isOwoTrack)
+							break;
+						bb.getLong();
+						sensorId = bb.get() & 0xFF;
+						tracker = connection.sensors.get(sensorId);
+						if(tracker == null)
+							break;
+						int signalStrength = bb.get();
+						tracker.signalStrength = signalStrength;
+						break;
 					default:
 						System.out.println("[TrackerServer] Unknown data received: " + packetId + " from " + recieve.getSocketAddress());
 						break;


### PR DESCRIPTION
Adds RSSI reported by trackers. Shows `N/A` if tracker is not reporting this data, and shows signal strength in percentage and dBm. The range is: -40 dBm = 100%, -95 dBm = 0%.
![image](https://user-images.githubusercontent.com/6103913/147888666-401eaa54-b1cc-4cc8-bbd1-18e19d0fb2bb.png)

Related issue: https://github.com/SlimeVR/SlimeVR-Tracker-ESP/issues/44