### PR TITLE
Ignore everything in .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build
 
 /bin/
 
+# User-specific stuff
+.idea/*
+
 # Syncthing ignore file
 .stignore
 


### PR DESCRIPTION
Idea creates lots of project files, this makes it so contributors don't have to deal with making sure they don't commit a idea related file to the Repository.