### PR TITLE
waist tracker will default to hip before chest

### DIFF
--- a/src/main/java/dev/slimevr/vr/processor/skeleton/SimpleSkeleton.java
+++ b/src/main/java/dev/slimevr/vr/processor/skeleton/SimpleSkeleton.java
@@ -182,7 +182,7 @@ public class SimpleSkeleton extends HumanSkeleton implements SkeletonConfigCallb
 		}
 		
 		this.chestTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(trackers, TrackerPosition.CHEST, TrackerPosition.WAIST, TrackerPosition.HIP);
-		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(trackers, TrackerPosition.WAIST, TrackerPosition.CHEST, TrackerPosition.HIP);
+		this.waistTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(trackers, TrackerPosition.WAIST, TrackerPosition.HIP, TrackerPosition.CHEST);
 		this.hipTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(trackers, TrackerPosition.HIP, TrackerPosition.WAIST, TrackerPosition.CHEST);
 		
 		this.leftLegTracker = TrackerUtils.findTrackerForBodyPositionOrEmpty(trackers, TrackerPosition.LEFT_LEG, TrackerPosition.LEFT_ANKLE, null);


### PR DESCRIPTION
If user has chest + waist but uses chest + hip in the server, chest would be chest+waist length and waist would be hip length.

This can be fixed by a better explanation of “waist vs hip” in the new GUI, or just defaulting waist to hip instead of chest when no waist tracker is found.