### PR TITLE
Switch feeder app from old protocol to new protocol.

### DIFF
--- a/src/main/java/dev/slimevr/VRServer.java
+++ b/src/main/java/dev/slimevr/VRServer.java
@@ -71,9 +71,10 @@ public class VRServer extends Thread {
 			bridges.add(driverBridge);
 			//*/
 			// Create named pipe bridge for SteamVR input
-			WindowsSteamVRPipeInputBridge steamVRInput = new WindowsSteamVRPipeInputBridge(this);
-			tasks.add(() -> steamVRInput.startBridge());
-			bridges.add(steamVRInput);
+			// TODO: how do we want to handle HMD input from the feeder app?
+			WindowsNamedPipeBridge feederBridge = new WindowsNamedPipeBridge(null, "steamvr_feeder", "SteamVR Feeder Bridge", "\\\\.\\pipe\\SlimeVRInput", new FastList<ShareableTracker>());
+			tasks.add(() -> feederBridge.startBridge());
+			bridges.add(feederBridge);
 			//*/
 			WindowsNamedPipeBridge driverBridge = new WindowsNamedPipeBridge(hmdTracker, "steamvr", "SteamVR Driver Bridge", "\\\\.\\pipe\\SlimeVRDriver", shareTrackers);
 			tasks.add(() -> driverBridge.startBridge());


### PR DESCRIPTION
I should have done this awhile ago. >_>

I'm not quite sure what's going on, but using this protocol, the role IDs don't seem to be used. I am sending the IDs used in TrackerRole.