### PR TITLE
Change FORWARD to FRONT for tracker mounting

### DIFF
--- a/src/main/java/dev/slimevr/vr/trackers/TrackerMountingRotation.java
+++ b/src/main/java/dev/slimevr/vr/trackers/TrackerMountingRotation.java
@@ -5,7 +5,7 @@ import com.jme3.math.Quaternion;
 
 public enum TrackerMountingRotation {
 	
-	FORWARD(180),
+	FRONT(180),
 	LEFT(90),
 	BACK(0),
 	RIGHT(-90);


### PR DESCRIPTION
Front fits better with the other options, and should cause less confusion about what the drop-down items mean.