### PR TITLE
Add full reset command to WebSocket bridge

### DIFF
--- a/src/main/java/dev/slimevr/bridge/WebSocketVRBridge.java
+++ b/src/main/java/dev/slimevr/bridge/WebSocketVRBridge.java
@@ -160,7 +160,10 @@ public class WebSocketVRBridge extends WebSocketServer implements Bridge {
 		case "calibrate":
 			Main.vrServer.resetTrackersYaw();
 			break;
-		}
+		case "full_calibrate":
+			Main.vrServer.resetTrackers();	
+			break;
+ 		}
 	}
 
 	@Override


### PR DESCRIPTION
Players should be able to do a full reset from within the headset without going through the GUI first.
This is required for the headless standalone server on the Quest.

There is no delay before initiating the reset like in the main GUI because this is the responsibility of the app calling for the reset
