### PR TITLE
Computed trackers should use their tracker id as their num

### DIFF
--- a/src/main/java/dev/slimevr/poserecorder/PoseFrameTracker.java
+++ b/src/main/java/dev/slimevr/poserecorder/PoseFrameTracker.java
@@ -247,7 +247,7 @@ public class PoseFrameTracker implements Tracker, Iterable<TrackerFrame> {
 
 	@Override
 	public int getTrackerNum() {
-		return -1;
+		return this.getTrackerId();
 	}
 
 	@Override

--- a/src/main/java/dev/slimevr/poserecorder/TrackerFrame.java
+++ b/src/main/java/dev/slimevr/poserecorder/TrackerFrame.java
@@ -178,7 +178,7 @@ public final class TrackerFrame implements Tracker {
 
 	@Override
 	public int getTrackerNum() {
-		return -1;
+		return this.getTrackerId();
 	}
 
 	@Override

--- a/src/main/java/dev/slimevr/vr/trackers/ComputedTracker.java
+++ b/src/main/java/dev/slimevr/vr/trackers/ComputedTracker.java
@@ -135,7 +135,7 @@ public class ComputedTracker implements Tracker, TrackerWithTPS {
 
 	@Override
 	public int getTrackerNum() {
-		return -1;
+		return this.getTrackerId();
 	}
 
 	@Override


### PR DESCRIPTION
This brings the behavior in line with the protocol