### PR TITLE
Computed trackers use TrackerRole to determine TrackerPosition, if null

### DIFF
--- a/src/main/java/dev/slimevr/vr/processor/ComputedHumanPoseTracker.java
+++ b/src/main/java/dev/slimevr/vr/processor/ComputedHumanPoseTracker.java
@@ -5,6 +5,7 @@ import dev.slimevr.vr.trackers.ShareableTracker;
 import dev.slimevr.vr.trackers.TrackerRole;
 import dev.slimevr.vr.trackers.TrackerWithTPS;
 import dev.slimevr.vr.trackers.udp.Device;
+import dev.slimevr.vr.trackers.TrackerPosition;
 import io.eiren.util.BufferedTimer;
 
 public class ComputedHumanPoseTracker extends ComputedTracker implements TrackerWithTPS, ShareableTracker {
@@ -17,6 +18,7 @@ public class ComputedHumanPoseTracker extends ComputedTracker implements Tracker
 		super(trackerId, "human://" + skeletonPosition.name(), true, true);
 		this.skeletonPosition = skeletonPosition;
 		this.trackerRole = role;
+		this.bodyPosition = TrackerPosition.getByRole(role);
 	}
 
 	@Override


### PR DESCRIPTION
This will be important in the overlay. I think we need a larger, separate effort to shift to using `TrackerPosition` instead of `TrackerRole` in most of the codebase and treat `TrackerRole` as a steamvr-specific thing, but we can do that later