### PR TITLE
Use gradle git dependencies instead of submodules for slimevr-java-commons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "slime-java-commons"]
-	path = slime-java-commons
-	url = https://github.com/Eirenliel/slime-java-commons.git
 [submodule "solarxr-protocol"]
 	path = solarxr-protocol
 	url = https://github.com/SlimeVR/SolarXR-Protocol.git

--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,13 @@ allprojects {
 		// Use jcenter for resolving dependencies.
 		// You can declare any Maven/Ivy/file repository here.
 		mavenCentral()
+
+		// Lets us depend on git repos directly
+		maven { url 'https://jitpack.io' }
 	}
 }
 
 dependencies {
-	implementation project(':slime-java-commons')
 	implementation project(":solarxr-protocol")
 
 	implementation group: 'com.google.flatbuffers', name: 'flatbuffers-java', version: '2.0.3'
@@ -58,8 +60,9 @@ dependencies {
 	implementation 'com.illposed.osc:javaosc-core:0.8'
 	implementation 'com.fazecast:jSerialComm:2.9.0'
 	implementation 'com.google.protobuf:protobuf-java:3.19.4'
-	implementation "org.java-websocket:Java-WebSocket:1.5.2"
+	implementation 'org.java-websocket:Java-WebSocket:1.5.2'
 	implementation 'com.melloware:jintellitype:1.4.0'
+	implementation 'com.github.TheButlah:slime-java-commons:0858c7d10795574177efd3461c0f1f20fcec7d54'
 
 	// Use JUnit test framework
 	testImplementation platform('org.junit:junit-bom:5.8.2')

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,8 +8,6 @@
  */
 
 rootProject.name = 'SlimeVR Server'
-include ':slime-java-commons'
-
 
 include ':solarxr-protocol'
 project(':solarxr-protocol').projectDir = new File('solarxr-protocol/protocol/java')


### PR DESCRIPTION
Draft PR until https://github.com/Eirenliel/slime-java-commons/pull/5 is merged and I update to use the upstream instead of the fork.

There are two problems right now with the use of git submodules in the codebase:
* Git submodules are generally hard to work with, especially for inexperienced devs - we have had numerous cases where people didn't know how to do it or forgor to update their submodules
* At least VSCode shows errors for `slimevr-java-commons` because it has a `.settings` file. I didn't want to have to edit `slimevr-java-commons` just to make an unrelated repo happy in its IDE

Conceptually, there is no need for submodules because gradle is capable of fetching dependencies from places like maven, and even git repos directly. So I did the research and got it working in this PR and the linked one.

The changes in the linked PR are necessary because the dependency must be able to be published to a local maven repository in order for that to then be uploaded to jitpack.io. Using jitpack.io this way is a free public service btw and doesn't require anything of us to use.