### PR TITLE
Handling exception thrown when closing WiFiWindow

### DIFF
--- a/src/main/java/dev/slimevr/gui/WiFiWindow.java
+++ b/src/main/java/dev/slimevr/gui/WiFiWindow.java
@@ -139,7 +139,7 @@ public class WiFiWindow extends JFrame implements SerialListener {
 	@Override
 	@AWTThread
 	public void onSerialDisconnected() {
-		log.append("[SERVER] Serial port disconnected");
+		log.append("[SERVER] Serial port disconnected\n");
 	}
 
 	@Override

--- a/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -57,11 +57,15 @@ public class SerialHandler implements SerialPortMessageListener {
 	}
 
 	public void closeSerial() {
-		if (trackerPort != null)
-			trackerPort.closePort();
-		this.listeners.forEach(SerialListener::onSerialDisconnected);
-		System.out.println("Port closed okay");
-		trackerPort = null;
+		try {
+			if (trackerPort != null)
+				trackerPort.closePort();
+			this.listeners.forEach(SerialListener::onSerialDisconnected);
+			System.out.println("Port closed okay");
+			trackerPort = null;
+		} catch (Exception e) {
+			System.out.println("Error closing port: " + e.getMessage());
+		}
 	}
 
 	public void setWifi(String ssid, String passwd) {


### PR DESCRIPTION
Fixed an issue where nothing would happen when esp was removed and pressed close