### PR TITLE
Fixing skeleton stuff

### DIFF
--- a/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
+++ b/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
@@ -8,7 +8,7 @@ public enum SkeletonConfigToggle {
 
 	EXTENDED_SPINE_MODEL("Extended spine model", "extendedSpine", true),
 	EXTENDED_PELVIS_MODEL("Extended pelvis model", "extendedPelvis", true),
-	EXTENDED_KNEE_MODEL("Extended knee model", "extendedKnees", true),
+	EXTENDED_KNEE_MODEL("Extended knee model", "extendedKnee", true),
 	FORCE_ARMS_FROM_HMD("Force arms from HMD", "forceArmsFromHMD", false),;
 
 	public static final SkeletonConfigToggle[] values = values();

--- a/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
+++ b/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
@@ -6,12 +6,13 @@ import java.util.Map;
 
 public enum SkeletonConfigToggle {
 
-	EXTENDED_SPINE_MODEL("Extended spine model", "spine", true),
-	EXTENDED_PELVIS_MODEL("Extended pelvis model", "pelvis", true),
-	EXTENDED_KNEE_MODEL("Extended knee model", "knee", true),;
+	EXTENDED_SPINE_MODEL("Extended spine model", "extendedSpine", true),
+	EXTENDED_PELVIS_MODEL("Extended pelvis model", "extendedPelvis", true),
+	EXTENDED_KNEE_MODEL("Extended knee model", "extendedKnees", true),
+	FORCE_ARMS_FROM_HMD("Force arms from HMD", "forceArmsFromHMD", false),;
 
 	public static final SkeletonConfigToggle[] values = values();
-	private static final String CONFIG_PREFIX = "body.extendedModel.";
+	private static final String CONFIG_PREFIX = "body.skeletonToggles.";
 	private static final Map<String, SkeletonConfigToggle> byStringVal = new HashMap<>();
 
 	static {

--- a/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
+++ b/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigToggle.java
@@ -12,7 +12,7 @@ public enum SkeletonConfigToggle {
 	FORCE_ARMS_FROM_HMD("Force arms from HMD", "forceArmsFromHMD", false),;
 
 	public static final SkeletonConfigToggle[] values = values();
-	private static final String CONFIG_PREFIX = "body.skeletonToggles.";
+	private static final String CONFIG_PREFIX = "skeleton.toggles.";
 	private static final Map<String, SkeletonConfigToggle> byStringVal = new HashMap<>();
 
 	static {


### PR DESCRIPTION
- Added `forceArmsFromHMD `to `SkeletonConfigToggle`.
- Changed `SkeletonConfigToggle`'s config prefix from "body.extendedModel." to "skeleton.toggles", as I want to separate FK settings from body proportions. *(yes this breaks backwards compatibility, but the only way to change the values is manually in vrconfig.yml and I doubt anyone would :p)*
- Make shoulders independent from the upper and lower arms in `UpdateLocalTransforms`, and fix them not moving properly when the user has no arm tracker. This is for easier debugging.
- Bring back the bones @TheButlah deleted, but don't send them if `sendAllBones == false` (which it is hardcoded to be currently)
- Properly don't send certain bones when only using a subset of trackers. I tested in butlah's overlay and it works! This allows, for example, to only see the spine overlays when only using spine trackers and no legs.