### PR TITLE
Place tracker at origin when disabled

### DIFF
--- a/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
+++ b/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
@@ -245,9 +245,23 @@ public abstract class ProtobufBridge<T extends VRTracker> implements Bridge {
 	@VRServerThread
 	@Override
 	public void removeSharedTracker(ShareableTracker tracker) {
+		// Remove shared tracker
 		sharedTrackers.remove(tracker);
+
+		// Place tracker at the uncalibrated universe's origin
+		// TODO: place tracker at the origin of standing universe, as this is
+		// what VRChat expects
+		Position.Builder builder = Position.newBuilder().setTrackerId(tracker.getTrackerId());
+		builder.setX(0);
+		builder.setY(0);
+		builder.setZ(0);
+		builder.setQx(0);
+		builder.setQy(0);
+		builder.setQz(0);
+		builder.setQw(1);
+		sendMessage(ProtobufMessage.newBuilder().setPosition(builder).build());
+
 		// No message can be sent to the remote side, protocol doesn't support
-		// tracker
-		// removal (yet)
+		// tracker removal yet. TODO: mark tracker as disabled on driver
 	}
 }

--- a/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
+++ b/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
@@ -262,6 +262,6 @@ public abstract class ProtobufBridge<T extends VRTracker> implements Bridge {
 		sendMessage(ProtobufMessage.newBuilder().setPosition(builder).build());
 
 		// No message can be sent to the remote side, protocol doesn't support
-		// tracker removal yet. TODO: mark tracker as disabled on driver
+		// tracker removal yet. TODO: mark tracker as disconnected via driver
 	}
 }


### PR DESCRIPTION
While VRChat says  
` - Calibration now ignores trackers located precisely at coordinates (0,0,0) to prevent binding to some trackers that will appear there in SteamVR when powered on but not tracking`,
they are talking about the (0, 0, 0) for the standing universe. We don't have a way to mess with the standing universe just yet, so this is all I can do. This still makes debugging way easier, as we don't have floating static trackers once we disabled them. (also still helps to avoid calibrating in VRChat with disabled trackers)
Related issue: https://github.com/SlimeVR/SlimeVR-Server/issues/115