### PR TITLE
Set disconnected TrackerStatus

### DIFF
--- a/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
+++ b/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
@@ -248,20 +248,11 @@ public abstract class ProtobufBridge<T extends VRTracker> implements Bridge {
 		// Remove shared tracker
 		sharedTrackers.remove(tracker);
 
-		// Place tracker at the uncalibrated universe's origin
-		// TODO: place tracker at the origin of standing universe, as this is
-		// what VRChat expects
-		Position.Builder builder = Position.newBuilder().setTrackerId(tracker.getTrackerId());
-		builder.setX(0);
-		builder.setY(0);
-		builder.setZ(0);
-		builder.setQx(0);
-		builder.setQy(0);
-		builder.setQz(0);
-		builder.setQw(1);
-		sendMessage(ProtobufMessage.newBuilder().setPosition(builder).build());
-
-		// No message can be sent to the remote side, protocol doesn't support
-		// tracker removal yet. TODO: mark tracker as disconnected via driver
+		// Set the tracker's status as disconnected
+		TrackerStatus.Builder statusBuilder = TrackerStatus
+			.newBuilder()
+			.setTrackerId(tracker.getTrackerId());
+		statusBuilder.setStatus(TrackerStatus.Status.DISCONNECTED);
+		sendMessage(ProtobufMessage.newBuilder().setTrackerStatus(statusBuilder).build());
 	}
 }


### PR DESCRIPTION
Along with https://github.com/SlimeVR/SlimeVR-OpenVR-Driver/pull/23, this marks the trackers as disconnected and basically removes them (same behaviour as turning off a Vive tracker). That means putting the tracker at (0, 0, 0) is no longer needed.

Closes https://github.com/SlimeVR/SlimeVR-Server/issues/115

It appears that recreating the tracker automatically sets its status as OK, so we only need to disable it, not to re-enable it (it does it automatically).