### PR TITLE
Fix NPE on config converter. 

### DIFF
--- a/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -59,6 +59,7 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 				if (skeletonNode == null) {
 					skeletonNode = nodeFactory.objectNode();
 				}
+
 				ObjectNode offsetsNode = nodeFactory.objectNode();
 				while (bodyIter.hasNext()) {
 					Map.Entry<String, JsonNode> node = bodyIter.next();

--- a/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -70,6 +70,7 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 						offsetsNode.set(node.getKey(), node.getValue());
 					}
 				}
+
 				// Fix calibration wolf typos
 				offsetsNode.set("shouldersWidth", bodyNode.get("shoulersWidth"));
 				offsetsNode.set("shouldersDistance", bodyNode.get("shoulersDistance"));

--- a/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -1,6 +1,7 @@
 package dev.slimevr.config;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jonpeterson.jackson.module.versioning.VersionedModelConverter;
@@ -31,14 +32,17 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 			}
 
 			// Change trackers list to map
-			var trackersIter = modelData.withArray("trackers").iterator();
-			ObjectNode trackersNode = nodeFactory.objectNode();
-			while (trackersIter.hasNext()) {
-				JsonNode node = trackersIter.next();
-				JsonNode resultNode = TrackerConfig.toV2(node, nodeFactory);
-				trackersNode.set(node.get("name").asText(), resultNode);
+			ArrayNode oldTrackersNode = modelData.withArray("trackers");
+			if (oldTrackersNode != null) {
+				var trackersIter = oldTrackersNode.iterator();
+				ObjectNode trackersNode = nodeFactory.objectNode();
+				while (trackersIter.hasNext()) {
+					JsonNode node = trackersIter.next();
+					JsonNode resultNode = TrackerConfig.toV2(node, nodeFactory);
+					trackersNode.set(node.get("name").asText(), resultNode);
+				}
+				modelData.set("trackers", trackersNode);
 			}
-			modelData.set("trackers", trackersNode);
 
 			// Rename bridge to bridges
 			ObjectNode bridgeNode = (ObjectNode) modelData.get("bridge");
@@ -49,29 +53,31 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 
 			// Move body to skeleton (and merge it to current skeleton)
 			ObjectNode bodyNode = (ObjectNode) modelData.get("body");
-			var bodyIter = bodyNode.fields();
-			ObjectNode skeletonNode = (ObjectNode) modelData.get("skeleton");
-			if (skeletonNode == null) {
-				skeletonNode = nodeFactory.objectNode();
-			}
-			ObjectNode offsetsNode = nodeFactory.objectNode();
-			while (bodyIter.hasNext()) {
-				Map.Entry<String, JsonNode> node = bodyIter.next();
-				// Filter only number values because other types would be stuff
-				// that didn't get migrated correctly before
-				if (node.getValue().isNumber()) {
-					offsetsNode.set(node.getKey(), node.getValue());
+			if (bodyNode != null) {
+				var bodyIter = bodyNode.fields();
+				ObjectNode skeletonNode = (ObjectNode) modelData.get("skeleton");
+				if (skeletonNode == null) {
+					skeletonNode = nodeFactory.objectNode();
 				}
+				ObjectNode offsetsNode = nodeFactory.objectNode();
+				while (bodyIter.hasNext()) {
+					Map.Entry<String, JsonNode> node = bodyIter.next();
+					// Filter only number values because other types would be
+					// stuff
+					// that didn't get migrated correctly before
+					if (node.getValue().isNumber()) {
+						offsetsNode.set(node.getKey(), node.getValue());
+					}
+				}
+				// Fix calibration wolf typos
+				offsetsNode.set("shouldersWidth", bodyNode.get("shoulersWidth"));
+				offsetsNode.set("shouldersDistance", bodyNode.get("shoulersDistance"));
+				offsetsNode.remove("shoulersWidth");
+				offsetsNode.remove("shoulersDistance");
+				skeletonNode.set("offsets", offsetsNode);
+				modelData.set("skeleton", skeletonNode);
+				modelData.remove("body");
 			}
-			// Fix calibration wolf typos
-			offsetsNode.set("shouldersWidth", bodyNode.get("shoulersWidth"));
-			offsetsNode.set("shouldersDistance", bodyNode.get("shoulersDistance"));
-			offsetsNode.remove("shoulersWidth");
-			offsetsNode.remove("shoulersDistance");
-
-			skeletonNode.set("offsets", offsetsNode);
-			modelData.set("skeleton", skeletonNode);
-			modelData.remove("body");
 		}
 
 		return modelData;


### PR DESCRIPTION
Add a null check to only convert if a Body node is present.
This fix adresses Eiren error sent on discord.

The server was not starting with this config
[vrconfig.txt](https://github.com/SlimeVR/SlimeVR-Server/files/9340341/vrconfig.txt)

and producing that error
```
2022-08-13 17:14:45 [SEVERE] java.lang.NullPointerException
2022-08-13 17:14:45 [SEVERE] 	at dev.slimevr.config.CurrentVRConfigConverter.convert(CurrentVRConfigConverter.java:52)
2022-08-13 17:14:45 [SEVERE] 	at com.github.jonpeterson.jackson.module.versioning.VersionedModelDeserializer.deserialize(VersionedModelDeserializer.java:93)
2022-08-13 17:14:45 [SEVERE] 	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
2022-08-13 17:14:45 [SEVERE] 	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4674)
2022-08-13 17:14:45 [SEVERE] 	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3666)
2022-08-13 17:14:45 [SEVERE] 	at dev.slimevr.config.ConfigManager.loadConfig(ConfigManager.java:39)
2022-08-13 17:14:45 [SEVERE] 	at dev.slimevr.VRServer.<init>(VRServer.java:61)
2022-08-13 17:14:45 [SEVERE] 	at dev.slimevr.VRServer.<init>(VRServer.java:54)
2022-08-13 17:14:45 [SEVERE] 	at dev.slimevr.Main.main(Main.java:95)
```