### PR TITLE
Add a recurring AutoBone recording for user debug info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ vrconfig.yml
 
 # BVH
 BVH Recordings
-Recordings
+
+# AutoBone
+AutoBone Recordings
+Load AutoBone Recordings
 
 # Logs
 *.log.*

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vrconfig.yml
 BVH Recordings
 
 # AutoBone
+Recordings
 AutoBone Recordings
 Load AutoBone Recordings
 

--- a/src/main/java/dev/slimevr/autobone/AutoBone.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBone.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 public class AutoBone {
 
-	private static final File saveDir = new File("Recordings");
-	private static final File loadDir = new File("LoadRecordings");
+	private static final File saveDir = new File("AutoBone Recordings");
+	private static final File loadDir = new File("Load AutoBone Recordings");
 	// This is filled by reloadConfigValues()
 	public final EnumMap<BoneType, Float> offsets = new EnumMap<BoneType, Float>(
 		BoneType.class
@@ -770,28 +770,22 @@ public class AutoBone {
 		return configInfo.toString();
 	}
 
-	public void saveRecording(PoseFrames frames) {
+	public void saveRecording(PoseFrames frames, File recordingFile) {
 		if (saveDir.isDirectory() || saveDir.mkdirs()) {
-			File saveRecording;
-			int recordingIndex = 1;
-			do {
-				saveRecording = new File(saveDir, "ABRecording" + recordingIndex++ + ".pfr");
-			} while (saveRecording.exists());
-
 			LogManager
-				.info("[AutoBone] Exporting frames to \"" + saveRecording.getPath() + "\"...");
-			if (PoseFrameIO.writeToFile(saveRecording, frames)) {
+				.info("[AutoBone] Exporting frames to \"" + recordingFile.getPath() + "\"...");
+			if (PoseFrameIO.writeToFile(recordingFile, frames)) {
 				LogManager
 					.info(
 						"[AutoBone] Done exporting! Recording can be found at \""
-							+ saveRecording.getPath()
+							+ recordingFile.getPath()
 							+ "\"."
 					);
 			} else {
 				LogManager
 					.severe(
 						"[AutoBone] Failed to export the recording to \""
-							+ saveRecording.getPath()
+							+ recordingFile.getPath()
 							+ "\"."
 					);
 			}
@@ -803,6 +797,20 @@ public class AutoBone {
 						+ "\"."
 				);
 		}
+	}
+
+	public void saveRecording(PoseFrames frames, String recordingFileName) {
+		saveRecording(frames, new File(saveDir, recordingFileName));
+	}
+
+	public void saveRecording(PoseFrames frames) {
+		File recordingFile;
+		int recordingIndex = 1;
+		do {
+			recordingFile = new File(saveDir, "ABRecording" + recordingIndex++ + ".pfr");
+		} while (recordingFile.exists());
+
+		saveRecording(frames, recordingFile);
 	}
 
 	public List<Pair<String, PoseFrames>> loadRecordings() {

--- a/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
@@ -6,6 +6,8 @@ import dev.slimevr.autobone.errors.AutoBoneException;
 import dev.slimevr.poserecorder.PoseFrameTracker;
 import dev.slimevr.poserecorder.PoseFrames;
 import dev.slimevr.poserecorder.PoseRecorder;
+import dev.slimevr.poserecorder.TrackerFrame;
+import dev.slimevr.poserecorder.TrackerFrameData;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfig;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigOffsets;
 import io.eiren.util.StringUtils;

--- a/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
@@ -161,8 +161,15 @@ public class AutoBoneHandler {
 				PoseFrames frames = framesFuture.get();
 				LogManager.info("[AutoBone] Done recording!");
 
+				// Save a recurring recording for users to send as debug info
+				announceProcessStatus(AutoBoneProcessType.RECORD, "Saving recording...");
+				autoBone.saveRecording(frames, "LastABRecording.pfr");
+
 				if (this.autoBone.getConfig().saveRecordings) {
-					announceProcessStatus(AutoBoneProcessType.RECORD, "Saving recording...");
+					announceProcessStatus(
+						AutoBoneProcessType.RECORD,
+						"Saving recording (from config option)..."
+					);
 					autoBone.saveRecording(frames);
 				}
 

--- a/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
@@ -8,7 +8,6 @@ import dev.slimevr.poserecorder.PoseFrames;
 import dev.slimevr.poserecorder.PoseRecorder;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfig;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigOffsets;
-import dev.slimevr.vr.trackers.TrackerPosition;
 import io.eiren.util.StringUtils;
 import io.eiren.util.collections.FastList;
 import io.eiren.util.logging.LogManager;
@@ -326,16 +325,19 @@ public class AutoBoneHandler {
 					if (tracker == null)
 						continue;
 
-					TrackerPosition position = tracker
-						.getBodyPosition();
-					if (position == null)
+					TrackerFrame frame = tracker.safeGetFrame(0);
+					if (frame == null || !frame.hasData(TrackerFrameData.DESIGNATION))
 						continue;
 
 					if (trackerInfo.length() > 0) {
 						trackerInfo.append(", ");
 					}
 
-					trackerInfo.append(position.designation);
+					trackerInfo.append(frame.designation.designation);
+
+					if (frame.hasData(TrackerFrameData.POSITION)) {
+						trackerInfo.append(" (P)");
+					}
 				}
 
 				LogManager

--- a/src/main/java/dev/slimevr/autobone/errors/PositionError.java
+++ b/src/main/java/dev/slimevr/autobone/errors/PositionError.java
@@ -43,6 +43,7 @@ public class PositionError implements IAutoBoneError {
 			if (
 				trackerFrame == null
 					|| !trackerFrame.hasData(TrackerFrameData.POSITION)
+					|| !trackerFrame.hasData(TrackerFrameData.DESIGNATION)
 					|| trackerFrame.designation.trackerRole.isEmpty()
 			) {
 				continue;

--- a/src/main/java/dev/slimevr/autobone/errors/PositionOffsetError.java
+++ b/src/main/java/dev/slimevr/autobone/errors/PositionOffsetError.java
@@ -41,6 +41,7 @@ public class PositionOffsetError implements IAutoBoneError {
 			if (
 				trackerFrame1 == null
 					|| !trackerFrame1.hasData(TrackerFrameData.POSITION)
+					|| !trackerFrame1.hasData(TrackerFrameData.DESIGNATION)
 					|| trackerFrame1.designation.trackerRole.isEmpty()
 			) {
 				continue;
@@ -50,6 +51,7 @@ public class PositionOffsetError implements IAutoBoneError {
 			if (
 				trackerFrame2 == null
 					|| !trackerFrame2.hasData(TrackerFrameData.POSITION)
+					|| !trackerFrame2.hasData(TrackerFrameData.DESIGNATION)
 					|| trackerFrame2.designation.trackerRole.isEmpty()
 			) {
 				continue;


### PR DESCRIPTION
- Renames `Recordings` folder to `AutoBone Recordings` to describe what it is better
- Adds a recurring AutoBone recording (`AutoBone Recordings/LastABRecording.pfr`), this can be sent as debug info for AutoBone issues
- Fixes a NullPointerException with positional error calculation in AutoBone