### PR TITLE
Autobone cleanup, logging improvements, and restoring functionality

### DIFF
--- a/src/main/java/dev/slimevr/autobone/AutoBone.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBone.java
@@ -698,16 +698,22 @@ public class AutoBone {
 			}
 
 			// Calculate average error over the epoch
-			LogManager
-				.info(
-					"[AutoBone] Epoch "
-						+ (epoch + 1)
-						+ " average error: "
-						+ errorStats.getMean()
-						+ " (SD "
-						+ errorStats.getStandardDeviation()
-						+ ")"
-				);
+			if (
+				epoch <= 0
+					|| epoch >= (config.numEpochs - 1)
+					|| (epoch + 1) % config.printEveryNumEpochs == 0
+			) {
+				LogManager
+					.info(
+						"[AutoBone] Epoch "
+							+ (epoch + 1)
+							+ " average error: "
+							+ errorStats.getMean()
+							+ " (SD "
+							+ errorStats.getStandardDeviation()
+							+ ")"
+					);
+			}
 
 			applyConfig(legacyConfigs);
 			if (epochCallback != null) {

--- a/src/main/java/dev/slimevr/autobone/AutoBone.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBone.java
@@ -114,13 +114,54 @@ public class AutoBone {
 		return loadDir;
 	}
 
+	public float computeBoneOffset(BoneType bone, SkeletonConfig skeletonConfig) {
+		switch (bone) {
+			case HEAD:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.HEAD);
+			case NECK:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.NECK);
+			case CHEST:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.CHEST);
+			case WAIST:
+				return -skeletonConfig.getOffset(SkeletonConfigOffsets.CHEST)
+					+ skeletonConfig.getOffset(SkeletonConfigOffsets.TORSO)
+					- skeletonConfig.getOffset(SkeletonConfigOffsets.WAIST);
+			case HIP:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.WAIST);
+			case LEFT_HIP:
+			case RIGHT_HIP:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.HIPS_WIDTH) / 2f;
+			case LEFT_UPPER_LEG:
+			case RIGHT_UPPER_LEG:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.LEGS_LENGTH)
+					- skeletonConfig.getOffset(SkeletonConfigOffsets.KNEE_HEIGHT);
+			case LEFT_LOWER_LEG:
+			case RIGHT_LOWER_LEG:
+				return skeletonConfig.getOffset(SkeletonConfigOffsets.KNEE_HEIGHT);
+		}
+
+		return -1f;
+	}
+
 	public void reloadConfigValues() {
 		reloadConfigValues(null);
 	}
 
 	public void reloadConfigValues(List<PoseFrameTracker> trackers) {
-		for (BoneType offset : adjustOffsets) {
-			offsets.put(offset, 0.4f);
+		// Remove all previous values
+		offsets.clear();
+
+		// Get current or default skeleton configs
+		Skeleton skeleton = getSkeleton();
+		SkeletonConfig skeletonConfig = skeleton != null
+			? skeleton.getSkeletonConfig()
+			: new SkeletonConfig(false);
+
+		for (BoneType bone : adjustOffsets) {
+			float offset = computeBoneOffset(bone, skeletonConfig);
+			if (offset > 0f) {
+				offsets.put(bone, offset);
+			}
 		}
 	}
 

--- a/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
+++ b/src/main/java/dev/slimevr/autobone/AutoBoneHandler.java
@@ -11,7 +11,6 @@ import dev.slimevr.poserecorder.TrackerFrameData;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfig;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigOffsets;
 import io.eiren.util.StringUtils;
-import io.eiren.util.collections.FastList;
 import io.eiren.util.logging.LogManager;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -314,7 +313,7 @@ public class AutoBoneHandler {
 
 			announceProcessStatus(AutoBoneProcessType.PROCESS, "Processing recording(s)...");
 			LogManager.info("[AutoBone] Processing frames...");
-			FastList<Float> heightPercentError = new FastList<Float>(frameRecordings.size());
+			StatsCalculator errorStats = new StatsCalculator();
 			SkeletonConfig skeletonConfigBuffer = new SkeletonConfig(false);
 			for (Pair<String, PoseFrames> recording : frameRecordings) {
 				LogManager
@@ -352,7 +351,7 @@ public class AutoBoneHandler {
 					);
 
 				AutoBoneResults autoBoneResults = processFrames(recording.getValue());
-				heightPercentError.add(autoBoneResults.getHeightDifference());
+				errorStats.addValue(autoBoneResults.getHeightDifference());
 				LogManager.info("[AutoBone] Done processing!");
 
 				// #region Stats/Values
@@ -396,29 +395,14 @@ public class AutoBoneHandler {
 				LogManager.info("[AutoBone] Length values: " + autoBone.getLengthsString());
 			}
 
-			if (!heightPercentError.isEmpty()) {
-				float mean = 0f;
-				for (float val : heightPercentError) {
-					mean += val;
-				}
-				mean /= heightPercentError.size();
-
-				float std = 0f;
-				for (float val : heightPercentError) {
-					float stdVal = val - mean;
-					std += stdVal * stdVal;
-				}
-				std = (float) Math.sqrt(std / heightPercentError.size());
-
-				LogManager
-					.info(
-						"[AutoBone] Average height error: "
-							+ StringUtils.prettyNumber(mean, 6)
-							+ " (SD "
-							+ StringUtils.prettyNumber(std, 6)
-							+ ")"
-					);
-			}
+			LogManager
+				.info(
+					"[AutoBone] Average height error: "
+						+ StringUtils.prettyNumber(errorStats.getMean(), 6)
+						+ " (SD "
+						+ StringUtils.prettyNumber(errorStats.getStandardDeviation(), 6)
+						+ ")"
+				);
 			// #endregion
 
 			listeners.forEach(listener -> {

--- a/src/main/java/dev/slimevr/autobone/StatsCalculator.java
+++ b/src/main/java/dev/slimevr/autobone/StatsCalculator.java
@@ -1,0 +1,51 @@
+package dev.slimevr.autobone;
+
+import com.jme3.math.FastMath;
+
+
+/// This is a stat calculator based on Welford's online algorithm
+/// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+public class StatsCalculator {
+
+	private int count = 0;
+	private float mean = 0f;
+	private float M2 = 0f;
+
+	public void reset() {
+		count = 0;
+		mean = 0f;
+		M2 = 0f;
+	}
+
+	public void addValue(float newValue) {
+		count += 1;
+		float delta = newValue - mean;
+		mean += delta / count;
+		float delta2 = newValue - mean;
+		M2 += delta * delta2;
+	}
+
+	public float getMean() {
+		return mean;
+	}
+
+	public float getVariance() {
+		if (count < 1) {
+			return Float.NaN;
+		}
+
+		return M2 / count;
+	}
+
+	public float getSampleVariance() {
+		if (count < 2) {
+			return Float.NaN;
+		}
+
+		return M2 / (count - 1);
+	}
+
+	public float getStandardDeviation() {
+		return FastMath.sqrt(getVariance());
+	}
+}

--- a/src/main/java/dev/slimevr/config/AutoBoneConfig.java
+++ b/src/main/java/dev/slimevr/config/AutoBoneConfig.java
@@ -8,6 +8,8 @@ public class AutoBoneConfig {
 
 	public int numEpochs = 100;
 
+	public int printEveryNumEpochs = 25;
+
 	public float initialAdjustRate = 10f;
 	public float adjustRateMultiplier = 0.995f;
 

--- a/src/main/java/dev/slimevr/config/AutoBoneConfig.java
+++ b/src/main/java/dev/slimevr/config/AutoBoneConfig.java
@@ -2,11 +2,15 @@ package dev.slimevr.config;
 
 public class AutoBoneConfig {
 
+	public int cursorIncrement = 2;
 	public int minDataDistance = 1;
 	public int maxDataDistance = 1;
+
 	public int numEpochs = 100;
+
 	public float initialAdjustRate = 10f;
 	public float adjustRateMultiplier = 0.995f;
+
 	public float slideErrorFactor = 0.0f;
 	public float offsetSlideErrorFactor = 1.0f;
 	public float footHeightOffsetErrorFactor = 0.0f;
@@ -14,11 +18,14 @@ public class AutoBoneConfig {
 	public float heightErrorFactor = 0.0f;
 	public float positionErrorFactor = 0.0f;
 	public float positionOffsetErrorFactor = 0.0f;
+
 	public boolean calcInitError = false;
 	public float targetHeight = -1;
 
-	public int sampleCount = 1000;
+	public boolean randomizeFrameOrder = true;
+	public boolean scaleEachStep = true;
 
+	public int sampleCount = 1000;
 	public long sampleRateMs = 20;
 
 	public boolean saveRecordings = false;

--- a/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
+++ b/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
@@ -206,7 +206,7 @@ public class AutoBoneWindow extends JFrame implements AutoBoneListener {
 						epoch.epoch,
 						epoch.totalEpochs,
 						(epoch.epoch / (double) epoch.totalEpochs) * 100.0,
-						epoch.epochError
+						epoch.epochError.getMean()
 					)
 			);
 		lengthsLabel.setText(server.getAutoBoneHandler().getLengthsString());

--- a/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
+++ b/src/main/java/dev/slimevr/gui/AutoBoneWindow.java
@@ -202,11 +202,12 @@ public class AutoBoneWindow extends JFrame implements AutoBoneListener {
 			.setText(
 				String
 					.format(
-						"PROCESS: Epoch %d/%d (%.2f%%) Error: %.4f",
+						"PROCESS: Epoch %d/%d (%.2f%%) Error: %.4f (SD %.4f)",
 						epoch.epoch,
 						epoch.totalEpochs,
 						(epoch.epoch / (double) epoch.totalEpochs) * 100.0,
-						epoch.epochError.getMean()
+						epoch.epochError.getMean(),
+						epoch.epochError.getStandardDeviation()
 					)
 			);
 		lengthsLabel.setText(server.getAutoBoneHandler().getLengthsString());

--- a/src/main/java/dev/slimevr/protocol/RPCHandler.java
+++ b/src/main/java/dev/slimevr/protocol/RPCHandler.java
@@ -643,7 +643,7 @@ public class RPCHandler extends ProtocolHandler<RpcMessageHeader>
 							fbb,
 							epoch.epoch,
 							epoch.totalEpochs,
-							epoch.epochError,
+							epoch.epochError.getMean(),
 							skeletonPartsOffset
 						);
 					int outbound = this


### PR DESCRIPTION
- Uses the current skeleton proportions instead of 40 cm default
- Made the logging much cleaner, now displaying standard deviation
- Removed up unused code
- Added a utility for computing mean and variance using [Welford's online algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm)