### PR TITLE
fix comments and remove deprecated method

### DIFF
--- a/src/main/java/com/jme3/math/Matrix3f.java
+++ b/src/main/java/com/jme3/math/Matrix3f.java
@@ -595,7 +595,7 @@ public final class Matrix3f implements Cloneable, java.io.Serializable {
 	 * 3x3 two dimenion array.
 	 * 
 	 * @param matrix the new values of the matrix.
-	 * @throws javax.management.JMException if the array is not of size 9.
+	 * @throws IllegalArgumentException if the array is not of size 9.
 	 * @return this
 	 */
 	public Matrix3f set(float[][] matrix) {

--- a/src/main/java/com/jme3/math/Matrix3f.java
+++ b/src/main/java/com/jme3/math/Matrix3f.java
@@ -595,7 +595,7 @@ public final class Matrix3f implements Cloneable, java.io.Serializable {
 	 * 3x3 two dimenion array.
 	 * 
 	 * @param matrix the new values of the matrix.
-	 * @throws JmeException if the array is not of size 9.
+	 * @throws javax.management.JMException if the array is not of size 9.
 	 * @return this
 	 */
 	public Matrix3f set(float[][] matrix) {

--- a/src/main/java/com/jme3/math/Matrix4f.java
+++ b/src/main/java/com/jme3/math/Matrix4f.java
@@ -534,7 +534,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * <code>set</code> sets the values of this matrix from an array of values.
 	 * 
 	 * @param matrix the matrix to set the value to.
-	 * @throws javax.management.JMException if the array is not of size 16.
+	 * @throws IllegalArgumentException if the array is not of size 16.
 	 */
 	public void set(float[][] matrix) {
 		if (matrix.length != 4 || matrix[0].length != 4) {
@@ -1774,7 +1774,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * <code>setTranslation</code> will set the matrix's translation values.
 	 * 
 	 * @param translation the new values for the translation.
-	 * @throws javax.management.JMException if translation is not size 3.
+	 * @throws IllegalArgumentException if translation is not size 3.
 	 */
 	public void setTranslation(float[] translation) {
 		if (translation.length != 3) {
@@ -1816,7 +1816,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation values.
 	 * 
 	 * @param translation the new values for the inverse translation.
-	 * @throws javax.management.JMException if translation is not size 3.
+	 * @throws IllegalArgumentException if translation is not size 3.
 	 */
 	public void setInverseTranslation(float[] translation) {
 		if (translation.length != 3) {
@@ -1882,7 +1882,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * Euler angles that are in radians.
 	 * 
 	 * @param angles the Euler angles in radians.
-	 * @throws javax.management.JMException if angles is not size 3.
+	 * @throws IllegalArgumentException if angles is not size 3.
 	 */
 	public void setInverseRotationRadians(float[] angles) {
 		if (angles.length != 3) {
@@ -1918,7 +1918,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * Euler angles that are in degrees.
 	 * 
 	 * @param angles the Euler angles in degrees.
-	 * @throws javax.management.JMException if angles is not size 3.
+	 * @throws IllegalArgumentException if angles is not size 3.
 	 */
 	public void setInverseRotationDegrees(float[] angles) {
 		if (angles.length != 3) {
@@ -1939,8 +1939,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param vec the Vector3f data to be translated.
-	 * @throws javax.management.JMException if the size of the Vector3f is not
-	 * 3.
+	 * @throws IllegalArgumentException if the size of the Vector3f is not 3.
 	 */
 	public void inverseTranslateVect(float[] vec) {
 		if (vec.length != 3) {
@@ -1960,8 +1959,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param data the Vector3f to be translated.
-	 * @throws javax.management.JMException if the size of the Vector3f is not
-	 * 3.
+	 * @throws IllegalArgumentException if the size of the Vector3f is not 3.
 	 */
 	public void inverseTranslateVect(Vector3f data) {
 		data.x -= m03;
@@ -1975,8 +1973,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param data the Vector3f to be translated.
-	 * @throws javax.management.JMException if the size of the Vector3f is not
-	 * 3.
+	 * @throws IllegalArgumentException if the size of the Vector3f is not 3.
 	 */
 	public void translateVect(Vector3f data) {
 		data.x += m03;

--- a/src/main/java/com/jme3/math/Matrix4f.java
+++ b/src/main/java/com/jme3/math/Matrix4f.java
@@ -534,7 +534,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * <code>set</code> sets the values of this matrix from an array of values.
 	 * 
 	 * @param matrix the matrix to set the value to.
-	 * @throws JmeException if the array is not of size 16.
+	 * @throws javax.management.JMException if the array is not of size 16.
 	 */
 	public void set(float[][] matrix) {
 		if (matrix.length != 4 || matrix[0].length != 4) {
@@ -1749,7 +1749,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * Retreives the scale vector from the matrix and stores it into a given
 	 * vector.
 	 * 
-	 * @param the vector where the scale will be stored
+	 * @param vector where the scale will be stored
 	 */
 	public void toScaleVector(Vector3f vector) {
 		float scaleX = (float) Math.sqrt(m00 * m00 + m10 * m10 + m20 * m20);
@@ -1774,7 +1774,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * <code>setTranslation</code> will set the matrix's translation values.
 	 * 
 	 * @param translation the new values for the translation.
-	 * @throws JmeException if translation is not size 3.
+	 * @throws javax.management.JMException if translation is not size 3.
 	 */
 	public void setTranslation(float[] translation) {
 		if (translation.length != 3) {
@@ -1816,7 +1816,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation values.
 	 * 
 	 * @param translation the new values for the inverse translation.
-	 * @throws JmeException if translation is not size 3.
+	 * @throws javax.management.JMException if translation is not size 3.
 	 */
 	public void setInverseTranslation(float[] translation) {
 		if (translation.length != 3) {
@@ -1882,7 +1882,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * Euler angles that are in radians.
 	 * 
 	 * @param angles the Euler angles in radians.
-	 * @throws JmeException if angles is not size 3.
+	 * @throws javax.management.JMException if angles is not size 3.
 	 */
 	public void setInverseRotationRadians(float[] angles) {
 		if (angles.length != 3) {
@@ -1918,7 +1918,7 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * Euler angles that are in degrees.
 	 * 
 	 * @param angles the Euler angles in degrees.
-	 * @throws JmeException if angles is not size 3.
+	 * @throws javax.management.JMException if angles is not size 3.
 	 */
 	public void setInverseRotationDegrees(float[] angles) {
 		if (angles.length != 3) {
@@ -1939,7 +1939,8 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param vec the Vector3f data to be translated.
-	 * @throws JmeException if the size of the Vector3f is not 3.
+	 * @throws javax.management.JMException if the size of the Vector3f is not
+	 * 3.
 	 */
 	public void inverseTranslateVect(float[] vec) {
 		if (vec.length != 3) {
@@ -1959,7 +1960,8 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param data the Vector3f to be translated.
-	 * @throws JmeException if the size of the Vector3f is not 3.
+	 * @throws javax.management.JMException if the size of the Vector3f is not
+	 * 3.
 	 */
 	public void inverseTranslateVect(Vector3f data) {
 		data.x -= m03;
@@ -1973,7 +1975,8 @@ public final class Matrix4f implements Cloneable, java.io.Serializable {
 	 * translation part of this matrix.
 	 * 
 	 * @param data the Vector3f to be translated.
-	 * @throws JmeException if the size of the Vector3f is not 3.
+	 * @throws javax.management.JMException if the size of the Vector3f is not
+	 * 3.
 	 */
 	public void translateVect(Vector3f data) {
 		data.x += m03;

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -31,12 +31,12 @@
  */
 package com.jme3.math;
 
+import io.eiren.math.FloatMath;
+
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.logging.Logger;
-
-import io.eiren.math.FloatMath;
 
 
 /**
@@ -751,9 +751,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	 * specified by an angle and a normalized axis of rotation.
 	 *
 	 * @param angle the angle to rotate (in radians).
-	 * @param x
-	 * @param y
-	 * @param z the axis of rotation (already normalized).
+	 * @param ax
+	 * @param ay
+	 * @param az the axis of rotation (already normalized).
 	 */
 	public Quaternion fromAngleNormalAxis(float angle, float ax, float ay, float az) {
 		if (ax == 0 && ay == 0 && az == 0) {
@@ -854,13 +854,6 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		// else this == q1, no need to do anything.
 
 		return this;
-	}
-
-	/**
-	 * @deprecated Direct call to {@link #slerpLocal()}.
-	 */
-	public Quaternion slerp(Quaternion q2, float t) {
-		return this.slerpLocal(q2, t);
 	}
 
 	/**


### PR DESCRIPTION
The Quaternion slerp method was throwing a (harmless) error in the terminal. It's completely unused and deprecated so I removed it.
Fixed comments too that showed in red in IDEA.

note: this is for https://github.com/SlimeVR/SlimeVR-Server/tree/remove-slime-commons , NOT main.