### PR TITLE
fix trackers not loading none/null

### DIFF
--- a/src/main/java/dev/slimevr/vr/trackers/ComputedTracker.java
+++ b/src/main/java/dev/slimevr/vr/trackers/ComputedTracker.java
@@ -5,6 +5,8 @@ import com.jme3.math.Vector3f;
 import dev.slimevr.config.TrackerConfig;
 import dev.slimevr.vr.Device;
 
+import java.util.Optional;
+
 
 public class ComputedTracker implements Tracker, TrackerWithTPS {
 
@@ -50,9 +52,13 @@ public class ComputedTracker implements Tracker, TrackerWithTPS {
 		// not be
 		// allowed if editing is not allowed
 		if (userEditable()) {
-			TrackerPosition
-				.getByDesignation(config.getDesignation())
-				.ifPresent(trackerPosition -> bodyPosition = trackerPosition);
+			Optional<TrackerPosition> trackerPosition = TrackerPosition
+				.getByDesignation(config.getDesignation());
+			if (trackerPosition.isEmpty()) {
+				bodyPosition = null;
+			} else {
+				bodyPosition = trackerPosition.get();
+			}
 		}
 	}
 

--- a/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -11,6 +11,8 @@ import dev.slimevr.vr.trackers.udp.TrackersUDPServer;
 import dev.slimevr.vr.trackers.udp.UDPDevice;
 import io.eiren.util.BufferedTimer;
 
+import java.util.Optional;
+
 
 public class IMUTracker
 	implements Tracker, TrackerWithTPS, TrackerWithBattery, TrackerWithWireless {
@@ -91,9 +93,13 @@ public class IMUTracker
 			} else {
 				rotAdjust.loadIdentity();
 			}
-			TrackerPosition
-				.getByDesignation(config.getDesignation())
-				.ifPresent(trackerPosition -> bodyPosition = trackerPosition);
+			Optional<TrackerPosition> trackerPosition = TrackerPosition
+				.getByDesignation(config.getDesignation());
+			if (trackerPosition.isEmpty()) {
+				bodyPosition = null;
+			} else {
+				bodyPosition = trackerPosition.get();
+			}
 
 			FiltersConfig filtersConfig = this.vrserver
 				.getConfigManager()


### PR DESCRIPTION
Fixes an issue with where trackers where the config value when being NONE/null would not override the value given by the feeder app.