### PR TITLE
Fix vrconfig version converter crashing converting zoom

### DIFF
--- a/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -2,6 +2,7 @@ package dev.slimevr.config;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jonpeterson.jackson.module.versioning.VersionedModelConverter;
@@ -25,7 +26,7 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 		if (version < 2) {
 			// Move zoom to the window config
 			ObjectNode windowNode = (ObjectNode) modelData.get("window");
-			ObjectNode zoomNode = (ObjectNode) modelData.get("zoom");
+			DoubleNode zoomNode = (DoubleNode) modelData.get("zoom");
 			if (windowNode != null && zoomNode != null) {
 				windowNode.set("zoom", zoomNode);
 				modelData.remove("zoom");


### PR DESCRIPTION
As seen many times on Discord, some users could not convert their old configs and others were just fine.
![image](https://user-images.githubusercontent.com/20461725/190546584-68bff045-a416-40d2-9ba6-a75870a853e8.png)
This is because those few users changed the zoom of the (old) GUI.

*may be a little late to have this fix, but I believe some people still haven't updated to 0.2.1, so it'll be useful for people that happen to skip that version...*