### PR TITLE
Create a mapping for remote sensor id to internal.

### DIFF
--- a/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
+++ b/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
@@ -224,7 +224,7 @@ public class TrackersUDPServer extends Thread {
 					+ " status: "
 					+ sensorStatus
 			);
-		IMUTracker imu = connection.getTracker(trackerId);
+		IMUTracker imu = connection.setupTrackerByRemoteId(trackerId);
 		if (imu == null) {
 			imu = new IMUTracker(
 				connection,
@@ -386,7 +386,7 @@ public class TrackersUDPServer extends Thread {
 				UDPPacket1Rotation rotationPacket = (UDPPacket1Rotation) packet;
 				buf.set(rotationPacket.rotation);
 				offset.mult(buf, buf);
-				tracker = connection.getTracker(rotationPacket.getSensorId());
+				tracker = connection.getTrackerByRemoteId(rotationPacket.getSensorId());
 				if (tracker == null)
 					break;
 				tracker.rotQuaternion.set(buf);
@@ -396,7 +396,7 @@ public class TrackersUDPServer extends Thread {
 				if (connection == null)
 					break;
 				UDPPacket17RotationData rotationData = (UDPPacket17RotationData) packet;
-				tracker = connection.getTracker(rotationData.getSensorId());
+				tracker = connection.getTrackerByRemoteId(rotationData.getSensorId());
 				if (tracker == null)
 					break;
 				buf.set(rotationData.rotation);
@@ -419,7 +419,7 @@ public class TrackersUDPServer extends Thread {
 				if (connection == null)
 					break;
 				UDPPacket18MagnetometerAccuracy magAccuracy = (UDPPacket18MagnetometerAccuracy) packet;
-				tracker = connection.getTracker(magAccuracy.getSensorId());
+				tracker = connection.getTrackerByRemoteId(magAccuracy.getSensorId());
 				if (tracker == null)
 					break;
 				tracker.magnetometerAccuracy = magAccuracy.accuracyInfo;
@@ -430,7 +430,7 @@ public class TrackersUDPServer extends Thread {
 					break;
 
 				UDPPacket4Acceleration accelPacket = (UDPPacket4Acceleration) packet;
-				tracker = connection.getTracker(accelPacket.getSensorId());
+				tracker = connection.getTrackerByRemoteId(accelPacket.getSensorId());
 
 				if (tracker == null)
 					break;
@@ -498,7 +498,7 @@ public class TrackersUDPServer extends Thread {
 				if (connection == null)
 					break;
 				UDPPacket13Tap tap = (UDPPacket13Tap) packet;
-				tracker = connection.getTracker(tap.getSensorId());
+				tracker = connection.getTrackerByRemoteId(tap.getSensorId());
 				if (tracker == null)
 					break;
 				LogManager
@@ -520,7 +520,7 @@ public class TrackersUDPServer extends Thread {
 					);
 				if (connection == null)
 					break;
-				tracker = connection.getTracker(error.getSensorId());
+				tracker = connection.getTrackerByRemoteId(error.getSensorId());
 				if (tracker == null)
 					break;
 				tracker.setStatus(TrackerStatus.ERROR);
@@ -561,7 +561,7 @@ public class TrackersUDPServer extends Thread {
 				if (connection == null)
 					break;
 				UDPPacket20Temperature temp = (UDPPacket20Temperature) packet;
-				tracker = connection.getTracker(temp.getSensorId());
+				tracker = connection.getTrackerByRemoteId(temp.getSensorId());
 				if (tracker == null)
 					break;
 				tracker.temperature = temp.temperature;


### PR DESCRIPTION
This allows UDP setup packets to be sent out of order.
Sensor ID's are now decoupled from the internal id representation in slimevr.


The reason for adding this is that on my wifi udp packets often seem to be rearranged. I have to restart the slimevr server one or two times for it to recognize all my trackers with extensions. So if sensor 1 is sent first then it will be assigned to sensor 0 because of the way the code is currently written. But with a mapping layer it will remember the real position in the trackers list.

This will also allow programs such as slimevr wrangler to send an unique id with every joycon, making it so users don't have to constantly reassign their tracker positions.