### PR TITLE
bump version to 0.3.0

### DIFF
--- a/src/main/java/dev/slimevr/Main.java
+++ b/src/main/java/dev/slimevr/Main.java
@@ -15,7 +15,7 @@ import java.net.ServerSocket;
 
 public class Main {
 
-	public static String VERSION = "0.2.1";
+	public static String VERSION = "0.3.0";
 
 	public static VRServer vrServer;
 


### PR DESCRIPTION
Not sure how useful this is, since new GUI shows 0.3.0, and that editing release now wouldn't work (unless we can cherry-pick somehow?) since there's like 4 commits between latest release and this commit...