### PR TITLE
Fix appDir() causing GUI config to not be loaded

### DIFF
--- a/gui/src/hooks/config.ts
+++ b/gui/src/hooks/config.ts
@@ -4,7 +4,6 @@ import {
   writeFile,
   createDir,
 } from '@tauri-apps/api/fs';
-import { appDir } from '@tauri-apps/api/path';
 
 import { createContext, useContext, useState } from 'react';
 
@@ -57,8 +56,6 @@ export function useConfigProvider(): ConfigContext {
     loadConfig: async () => {
       setLoading(true);
       try {
-        const appDirPath = await appDir();
-        console.log(appDirPath);
         const json = await readTextFile('config.json', {
           dir: BaseDirectory.App,
         });


### PR DESCRIPTION
Gives output of `invalid value: 21, expected one of: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20` at startup, the result is already unused, so this just removes it to resolve the issue.