### PR TITLE
Make a dialog appear when rust app panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-dialog"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab637f328b31bd0855c43bd38a4a4455e74324d9e74e0aac6a803422f43abc6"
+dependencies = [
+ "block",
+ "cocoa",
+ "dirs-next",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+ "raw-window-handle 0.4.3",
+ "thiserror",
+ "wfd",
+ "which",
+ "winapi",
+]
+
+[[package]]
 name = "ndk"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1541,17 @@ checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
  "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
 ]
 
 [[package]]
@@ -1945,6 +1982,15 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
+dependencies = [
+ "cty",
+]
+
+[[package]]
+name = "raw-window-handle"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
@@ -2258,7 +2304,9 @@ version = "0.0.0"
 dependencies = [
  "clap-verbosity-flag",
  "log",
+ "native-dialog",
  "pretty_env_logger",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tauri",
@@ -2421,7 +2469,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "png",
- "raw-window-handle",
+ "raw-window-handle 0.5.0",
  "scopeguard",
  "serde",
  "unicode-segmentation",
@@ -2467,7 +2515,7 @@ dependencies = [
  "os_pipe",
  "percent-encoding",
  "rand 0.8.5",
- "raw-window-handle",
+ "raw-window-handle 0.5.0",
  "regex",
  "semver 1.0.14",
  "serde",
@@ -2569,7 +2617,7 @@ dependencies = [
  "http",
  "http-range",
  "rand 0.8.5",
- "raw-window-handle",
+ "raw-window-handle 0.5.0",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -2589,7 +2637,7 @@ dependencies = [
  "gtk",
  "percent-encoding",
  "rand 0.8.5",
- "raw-window-handle",
+ "raw-window-handle 0.5.0",
  "tauri-runtime",
  "tauri-utils",
  "uuid 1.2.2",
@@ -3039,6 +3087,27 @@ dependencies = [
  "windows 0.39.0",
  "windows-bindgen",
  "windows-metadata",
+]
+
+[[package]]
+name = "wfd"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e713040b67aae5bf1a0ae3e1ebba8cc29ab2b90da9aa1bff6e09031a8a41d7a8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -31,6 +31,8 @@ pretty_env_logger = "0.4"
 log = "0.4"
 clap-verbosity-flag = "1"
 tauri-plugin-window-state = "0.1.0"
+native-dialog = "0.6.3"
+rand = "0.8.5"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -2,16 +2,15 @@
 	all(not(debug_assertions), windows),
 	windows_subsystem = "windows"
 )]
-
-use clap::Parser;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
-use native_dialog::MessageDialog;
-use native_dialog::MessageType;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
 use std::env;
 use std::panic;
 use std::path::PathBuf;
+
+use clap::Parser;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use native_dialog::{MessageDialog, MessageType};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use tauri::api::clap;
 use tauri::api::process::Command;
 use tauri::Manager;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5521,9 +5521,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "22.10.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-22.10.26.tgz",
-      "integrity": "sha512-sdO3emf/BlLfOogW6KwHuXg16APR/E86jNacDXfSInPzt8SSEzxlHcqDekfM/IJ1CGC5bvDksfNufNhS8h1FRA=="
+      "version": "22.11.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-22.11.23.tgz",
+      "integrity": "sha512-aBOu8GjUWP3FaAC0t17lVFvNWYBEVIF/ia25Mx77BJJtJRbiyYmYQZjZV0bFoBvLBLYQ7ivnFO4ZIvgxhX1VKQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.7",
@@ -13727,9 +13727,9 @@
       }
     },
     "flatbuffers": {
-      "version": "22.10.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-22.10.26.tgz",
-      "integrity": "sha512-sdO3emf/BlLfOogW6KwHuXg16APR/E86jNacDXfSInPzt8SSEzxlHcqDekfM/IJ1CGC5bvDksfNufNhS8h1FRA=="
+      "version": "22.11.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-22.11.23.tgz",
+      "integrity": "sha512-aBOu8GjUWP3FaAC0t17lVFvNWYBEVIF/ia25Mx77BJJtJRbiyYmYQZjZV0bFoBvLBLYQ7ivnFO4ZIvgxhX1VKQ=="
     },
     "flatted": {
       "version": "3.2.7",


### PR DESCRIPTION
This implements a cross platform crate that shows the actual panic. Pretty helpful when not launching from terminal.
Also implements ~~random~~helpful window titles when one appears.
![crash window](https://user-images.githubusercontent.com/3698237/204071600-5bb49cdb-6e93-4f50-8a8e-d515af490b5f.png)
