### PR TITLE
Properly align yaw on quick reset for VRC OSCTrackers

### DIFF
--- a/server/src/main/java/dev/slimevr/vr/processor/HumanPoseProcessor.java
+++ b/server/src/main/java/dev/slimevr/vr/processor/HumanPoseProcessor.java
@@ -207,8 +207,10 @@ public class HumanPoseProcessor {
 
 	@VRServerThread
 	public void resetTrackersYaw() {
-		if (skeleton != null)
+		if (skeleton != null) {
 			skeleton.resetTrackersYaw();
+			server.getVRCOSCHandler().yawAlign();
+		}
 	}
 
 	@ThreadSafe


### PR DESCRIPTION
I forgor to call `VRCOSCHandler.yawAlign()` on quick reset. Only did for full reset. So quick reset doesn't work for standalone (but full reset does obviously)