### PR TITLE
dont reinstall rust in the github gui action

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -38,10 +38,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
 
-      - name: Install rust toolchain & cargo
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
It shouldn't be needed, [Github-hosted runners already include rustup with the rest of the toolchain](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software), and if somehow the version is not the one we need ``rust-toolchain.toml`` takes care of telling ``rustup`` to override the version.

The time saved by doing this would be between 20s and 1m, depending on the runner's OS