### PR TITLE
Add hands to gui steamvr checkboxes

### DIFF
--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -30,6 +30,7 @@ interface SettingsForm {
     feet: boolean;
     knees: boolean;
     elbows: boolean;
+    hands: boolean;
   };
   filtering: {
     type: number;
@@ -63,6 +64,7 @@ export function GeneralSettings() {
         elbows: false,
         knees: false,
         feet: false,
+        hands: false,
       },
       toggles: {
         extendedSpine: true,
@@ -87,6 +89,7 @@ export function GeneralSettings() {
       trackers.feet = values.trackers.feet;
       trackers.knees = values.trackers.knees;
       trackers.elbows = values.trackers.elbows;
+      trackers.hands = values.trackers.hands;
       settings.steamVrTrackers = trackers;
     }
 
@@ -225,6 +228,13 @@ export function GeneralSettings() {
               control={control}
               name="trackers.elbows"
               label="Elbows"
+            />
+            <CheckBox
+              variant="toggle"
+              outlined
+              control={control}
+              name="trackers.hands"
+              label="Hands"
             />
           </div>
         </>

--- a/server/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
+++ b/server/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
@@ -9,7 +9,10 @@ import dev.slimevr.vr.processor.skeleton.SkeletonConfig;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigToggles;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigValues;
 import dev.slimevr.vr.trackers.TrackerRole;
-import solarxr_protocol.rpc.*;
+import solarxr_protocol.rpc.FilteringSettings;
+import solarxr_protocol.rpc.OSCTrackersSetting;
+import solarxr_protocol.rpc.SteamVRTrackersSetting;
+import solarxr_protocol.rpc.VRCOSCSettings;
 import solarxr_protocol.rpc.settings.ModelRatios;
 import solarxr_protocol.rpc.settings.ModelSettings;
 import solarxr_protocol.rpc.settings.ModelToggles;
@@ -28,10 +31,14 @@ public class RPCSettingsBuilder {
 				config.getOSCTrackerRole(TrackerRole.HEAD, false),
 				config.getOSCTrackerRole(TrackerRole.CHEST, false),
 				config.getOSCTrackerRole(TrackerRole.WAIST, false),
-				config.getOSCTrackerRole(TrackerRole.LEFT_KNEE, false),
-				config.getOSCTrackerRole(TrackerRole.LEFT_FOOT, false),
-				config.getOSCTrackerRole(TrackerRole.LEFT_ELBOW, false),
+				config.getOSCTrackerRole(TrackerRole.LEFT_KNEE, false)
+					&& config.getOSCTrackerRole(TrackerRole.RIGHT_KNEE, false),
+				config.getOSCTrackerRole(TrackerRole.LEFT_FOOT, false)
+					&& config.getOSCTrackerRole(TrackerRole.RIGHT_FOOT, false),
+				config.getOSCTrackerRole(TrackerRole.LEFT_ELBOW, false)
+					&& config.getOSCTrackerRole(TrackerRole.RIGHT_ELBOW, false),
 				config.getOSCTrackerRole(TrackerRole.LEFT_HAND, false)
+					&& config.getOSCTrackerRole(TrackerRole.RIGHT_HAND, false)
 			);
 
 		int addressStringOffset = fbb.createString(config.getAddress());
@@ -78,7 +85,9 @@ public class RPCSettingsBuilder {
 					bridge.getShareSetting(TrackerRole.LEFT_KNEE)
 						&& bridge.getShareSetting(TrackerRole.RIGHT_KNEE),
 					bridge.getShareSetting(TrackerRole.LEFT_ELBOW)
-						&& bridge.getShareSetting(TrackerRole.RIGHT_ELBOW)
+						&& bridge.getShareSetting(TrackerRole.RIGHT_ELBOW),
+					bridge.getShareSetting(TrackerRole.LEFT_HAND)
+						&& bridge.getShareSetting(TrackerRole.RIGHT_HAND)
 				);
 		}
 		return steamvrTrackerSettings;
@@ -105,6 +114,7 @@ public class RPCSettingsBuilder {
 				config.getValue(SkeletonConfigValues.HIP_LEGS_AVERAGING),
 				config.getValue(SkeletonConfigValues.KNEE_TRACKER_ANKLE_AVERAGING)
 			);
-		return ModelSettings.createModelSettings(fbb, togglesOffset, ratiosOffset);
+		// TODO: legtweaks amount in protocol
+		return ModelSettings.createModelSettings(fbb, togglesOffset, ratiosOffset, 0);
 	}
 }

--- a/server/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.java
+++ b/server/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.java
@@ -12,7 +12,10 @@ import dev.slimevr.protocol.rpc.RPCHandler;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigToggles;
 import dev.slimevr.vr.processor.skeleton.SkeletonConfigValues;
 import dev.slimevr.vr.trackers.TrackerRole;
-import solarxr_protocol.rpc.*;
+import solarxr_protocol.rpc.ChangeSettingsRequest;
+import solarxr_protocol.rpc.RpcMessage;
+import solarxr_protocol.rpc.RpcMessageHeader;
+import solarxr_protocol.rpc.SettingsResponse;
 
 
 public record RPCSettingsHandler(RPCHandler rpcHandler, ProtocolAPI api) {
@@ -80,6 +83,8 @@ public record RPCSettingsHandler(RPCHandler rpcHandler, ProtocolAPI api) {
 				bridge.changeShareSettings(TrackerRole.RIGHT_KNEE, req.steamVrTrackers().knees());
 				bridge.changeShareSettings(TrackerRole.LEFT_ELBOW, req.steamVrTrackers().elbows());
 				bridge.changeShareSettings(TrackerRole.RIGHT_ELBOW, req.steamVrTrackers().elbows());
+				bridge.changeShareSettings(TrackerRole.LEFT_HAND, req.steamVrTrackers().hands());
+				bridge.changeShareSettings(TrackerRole.RIGHT_HAND, req.steamVrTrackers().hands());
 			}
 		}
 


### PR DESCRIPTION
- Add the checkbox for Hands steamvr trackers in GUI settings.
This was omitted, but was present in the old GUI.
Protocol PR: https://github.com/SlimeVR/SolarXR-Protocol/pull/79