### PR TITLE
Right align some text for body proportions

### DIFF
--- a/gui/src/components/onboarding/BodyAssignment.tsx
+++ b/gui/src/components/onboarding/BodyAssignment.tsx
@@ -51,7 +51,7 @@ export function BodyAssignment({
       <BodyInteractions
         assignedRoles={assignedRoles}
         leftControls={
-          <div className="flex flex-col justify-between h-full">
+          <div className="flex flex-col justify-between h-full text-right">
             <div className="flex flex-col gap-2">
               {advanced && (
                 <TrackerPartCard


### PR DESCRIPTION
In my opinion it looks better that the text for the right side of the body is consistent, that all of the text is aligned.

Before:
![image](https://user-images.githubusercontent.com/272571/206744024-2aee9212-1a69-4c1d-8257-861503d26856.png)

After:
![image2](https://user-images.githubusercontent.com/272571/206744048-2e26ea06-fd1e-4819-9a86-e8f0a3749fec.png)
