### PR TITLE
Rename upper/lower legs to thigh/ankle

### DIFF
--- a/gui/src/i18n/en/translation.json
+++ b/gui/src/i18n/en/translation.json
@@ -15,8 +15,8 @@
     "RIGHT_UPPER_ARM": "Right upper arm",
     "RIGHT_LOWER_ARM": "Right lower arm",
     "RIGHT_HAND": "Right hand",
-    "RIGHT_UPPER_LEG": "Right upper leg",
-    "RIGHT_LOWER_LEG": "Right lower leg",
+    "RIGHT_UPPER_LEG": "Right thigh",
+    "RIGHT_LOWER_LEG": "Right ankle",
     "RIGHT_FOOT": "Right foot",
     "CHEST": "Chest",
     "WAIST": "Waist",
@@ -25,8 +25,8 @@
     "LEFT_UPPER_ARM": "Left upper arm",
     "LEFT_LOWER_ARM": "Left lower arm",
     "LEFT_HAND": "Left hand",
-    "LEFT_UPPER_LEG": "Left upper leg",
-    "LEFT_LOWER_LEG": "Left lower leg",
+    "LEFT_UPPER_LEG": "Left thigh",
+    "LEFT_LOWER_LEG": "Left ankle",
     "LEFT_FOOT": "Left foot"
   },
   "skeleton-bone": {


### PR DESCRIPTION
I believe using upper/lower_leg is better in the code, but can be very confusing for users.
This
1. Makes it clear where a tracker should be (e.g: users should mount on ankles, not calves)
2. Makes the text less verbose and easier to understand.
3. Make translating into other languages easier without weird or long formulations (e.g: "left upper leg" = "haut de la jambe gauche"...)

Please give your thoughts if you disagree to rename these.