### PR TITLE
Sort steamvr trackers top-down in GUI

### DIFF
--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -235,13 +235,6 @@ export function GeneralSettings() {
               variant="toggle"
               outlined
               control={control}
-              name="trackers.waist"
-              label={t('settings.general.steamvr.trackers.waist')}
-            />
-            <CheckBox
-              variant="toggle"
-              outlined
-              control={control}
               name="trackers.chest"
               label={t('settings.general.steamvr.trackers.chest')}
             />
@@ -249,8 +242,8 @@ export function GeneralSettings() {
               variant="toggle"
               outlined
               control={control}
-              name="trackers.feet"
-              label={t('settings.general.steamvr.trackers.feet')}
+              name="trackers.waist"
+              label={t('settings.general.steamvr.trackers.waist')}
             />
             <CheckBox
               variant="toggle"
@@ -258,6 +251,13 @@ export function GeneralSettings() {
               control={control}
               name="trackers.knees"
               label={t('settings.general.steamvr.trackers.knees')}
+            />
+            <CheckBox
+              variant="toggle"
+              outlined
+              control={control}
+              name="trackers.feet"
+              label={t('settings.general.steamvr.trackers.feet')}
             />
             <CheckBox
               variant="toggle"


### PR DESCRIPTION
This makes more sense IMO and is how it was in the old GUI.
Current sorting makes no sense...