### PR TITLE
Fixed NPE in catch of UDP Server

### DIFF
--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
@@ -97,12 +97,16 @@ public class TrackersUDPServer extends Thread {
 	private static String packetToString(DatagramPacket packet) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("DatagramPacket{");
-		sb.append(packet.getAddress().toString());
-		sb.append(packet.getPort());
-		sb.append(',');
-		sb.append(packet.getLength());
-		sb.append(',');
-		sb.append(ArrayUtils.toString(packet.getData()));
+		if (packet == null) {
+			sb.append("null");
+		} else {
+			sb.append(packet.getAddress().toString());
+			sb.append(packet.getPort());
+			sb.append(',');
+			sb.append(packet.getLength());
+			sb.append(',');
+			sb.append(ArrayUtils.toString(packet.getData()));
+		}
 		sb.append('}');
 		return sb.toString();
 	}
@@ -443,7 +447,7 @@ public class TrackersUDPServer extends Thread {
 			case 5: // PACKET_MAG
 			case 9: // PACKET_RAW_MAGENTOMETER
 				break; // None of these packets are used by SlimeVR trackers and
-						// are deprecated, use
+			// are deprecated, use
 			// more generic PACKET_ROTATION_DATA
 			case 8: // PACKET_CONFIG
 				if (connection == null)


### PR DESCRIPTION
Stack trace that caused me to make this fix:
```
23:22:49 [INFO] [WebSocketAPI] New connection from: 127.
0.0.1                                                   
23:24:25 [SEVERE] java.lang.NullPointerException: Cannot
 invoke "java.net.DatagramPacket.getAddress()" because "
packet" is null                                         
23:24:25 [SEVERE]       at dev.slimevr.vr.trackers.udp.T
rackersUDPServer.packetToString(TrackersUDPServer.java:1
00)                                                     
23:24:25 [SEVERE]       at dev.slimevr.vr.trackers.udp.T
rackersUDPServer.run(TrackersUDPServer.java:307)        
```