### PR TITLE
Fix NPE in Unix socket

### DIFF
--- a/server/src/main/java/dev/slimevr/platform/linux/UnixSocketBridge.java
+++ b/server/src/main/java/dev/slimevr/platform/linux/UnixSocketBridge.java
@@ -198,7 +198,7 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 
 	@Override
 	public boolean isConnected() {
-		return channel.isConnected();
+		return channel != null && channel.isConnected();
 	}
 }
 


### PR DESCRIPTION
It will give an NPE when there is no driver connected and you ask the bridge if its connected