### PR TITLE
Switch rotation to orientation

### DIFF
--- a/gui/src/components/onboarding/pages/mounting/ManualMounting.tsx
+++ b/gui/src/components/onboarding/pages/mounting/ManualMounting.tsx
@@ -45,7 +45,7 @@ export function ManualMountingPage() {
       const assignreq = new AssignTrackerRequestT();
 
       assignreq.bodyPosition = td.tracker.info?.bodyPart || BodyPart.NONE;
-      assignreq.mountingRotation = QuaternionToQuatT(
+      assignreq.mountingOrientation = QuaternionToQuatT(
         Quaternion.fromEuler(0, +mountingOrientation, 0)
       );
       assignreq.trackerId = td.tracker.trackerId;

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
@@ -57,7 +57,7 @@ export function TrackersAssignPage() {
       const assignreq = new AssignTrackerRequestT();
 
       assignreq.bodyPosition = role;
-      assignreq.mountingRotation = rotation;
+      assignreq.mountingOrientation = rotation;
       assignreq.trackerId = trackerId;
       sendRPCPacket(RpcMessage.AssignTrackerRequest, assignreq);
     };

--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -59,7 +59,7 @@ export function TrackerSettingsPage() {
 
     const assignreq = new AssignTrackerRequestT();
 
-    assignreq.mountingRotation = QuaternionToQuatT(
+    assignreq.mountingOrientation = QuaternionToQuatT(
       Quaternion.fromEuler(
         0,
         0,

--- a/server/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/server/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -19,13 +19,7 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 		int version = Integer.parseInt(modelVersion);
 
 		// Configs with old versions need a migration to the latest config
-		if (version == 2) {
-			// Check for out-of-bound filtering amount
-			ObjectNode filtersNode = (ObjectNode) modelData.get("filters");
-			if (filtersNode != null && filtersNode.get("amount").floatValue() > 2f) {
-				filtersNode.set("amount", new FloatNode(0.2f));
-			}
-		} else if (version < 2) {
+		if (version < 2) {
 			// Move zoom to the window config
 			ObjectNode windowNode = (ObjectNode) modelData.get("window");
 			DoubleNode zoomNode = (DoubleNode) modelData.get("zoom");
@@ -81,6 +75,30 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 				skeletonNode.set("offsets", offsetsNode);
 				modelData.set("skeleton", skeletonNode);
 				modelData.remove("body");
+			}
+		}
+		if (version < 3) {
+			// Check for out-of-bound filtering amount
+			ObjectNode filtersNode = (ObjectNode) modelData.get("filters");
+			if (filtersNode != null && filtersNode.get("amount").floatValue() > 2f) {
+				filtersNode.set("amount", new FloatNode(0.2f));
+			}
+		}
+		if (version < 4) {
+			// Change mountingRotation to mountingOrientation
+			ObjectNode oldTrackersNode = (ObjectNode) modelData.get("trackers");
+			if (oldTrackersNode != null) {
+				var trackersIter = oldTrackersNode.iterator();
+				var fieldNamesIter = oldTrackersNode.fieldNames();
+				ObjectNode trackersNode = nodeFactory.objectNode();
+				String fieldName;
+				while (trackersIter.hasNext()) {
+					ObjectNode node = (ObjectNode) trackersIter.next();
+					fieldName = fieldNamesIter.next();
+					node.set("mountingOrientation", node.get("mountingRotation"));
+					trackersNode.set(fieldName, node);
+				}
+				modelData.set("trackers", trackersNode);
 			}
 		}
 

--- a/server/src/main/java/dev/slimevr/config/TrackerConfig.java
+++ b/server/src/main/java/dev/slimevr/config/TrackerConfig.java
@@ -15,7 +15,7 @@ public class TrackerConfig {
 
 	private Quaternion adjustment;
 
-	private Quaternion mountingRotation;
+	private Quaternion mountingOrientation;
 
 	public TrackerConfig() {
 	}
@@ -73,11 +73,11 @@ public class TrackerConfig {
 		this.adjustment = adjustment;
 	}
 
-	public Quaternion getMountingRotation() {
-		return mountingRotation;
+	public Quaternion getMountingOrientation() {
+		return mountingOrientation;
 	}
 
-	public void setMountingRotation(Quaternion mountingRotation) {
-		this.mountingRotation = mountingRotation;
+	public void setMountingOrientation(Quaternion mountingOrientation) {
+		this.mountingOrientation = mountingOrientation;
 	}
 }

--- a/server/src/main/java/dev/slimevr/config/VRConfig.java
+++ b/server/src/main/java/dev/slimevr/config/VRConfig.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 
 @JsonVersionedModel(
-	currentVersion = "3", defaultDeserializeToVersion = "3", toCurrentConverterClass = CurrentVRConfigConverter.class
+	currentVersion = "4", defaultDeserializeToVersion = "4", toCurrentConverterClass = CurrentVRConfigConverter.class
 )
 public class VRConfig {
 

--- a/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -98,8 +98,8 @@ public class DataFeedBuilder {
 		// TODO need support: TrackerInfo.addPollRate(fbb, tracker.);
 
 		if (tracker instanceof IMUTracker imuTracker) {
-			if (imuTracker.getMountingRotation() != null) {
-				Quaternion quaternion = imuTracker.getMountingRotation();
+			if (imuTracker.getMountingOrientation() != null) {
+				Quaternion quaternion = imuTracker.getMountingOrientation();
 				TrackerInfo
 					.addMountingOrientation(
 						fbb,

--- a/server/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.java
+++ b/server/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.java
@@ -191,15 +191,15 @@ public class RPCHandler extends ProtocolHandler<RpcMessageHeader>
 		TrackerPosition pos = TrackerPosition.getByBodyPart(req.bodyPosition()).orElse(null);
 		tracker.setBodyPosition(pos);
 
-		if (req.mountingRotation() != null) {
+		if (req.mountingOrientation() != null) {
 			if (tracker instanceof IMUTracker imu) {
 				imu
-					.setMountingRotation(
+					.setMountingOrientation(
 						new Quaternion(
-							req.mountingRotation().x(),
-							req.mountingRotation().y(),
-							req.mountingRotation().z(),
-							req.mountingRotation().w()
+							req.mountingOrientation().x(),
+							req.mountingOrientation().y(),
+							req.mountingOrientation().z(),
+							req.mountingOrientation().w()
 						)
 					);
 			}

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -87,7 +87,7 @@ public class IMUTracker
 	public void writeConfig(TrackerConfig config) {
 		config.setDesignation(bodyPosition == null ? null : bodyPosition.designation);
 		config
-			.setMountingRotation(
+			.setMountingOrientation(
 				mounting != null ? mounting : new Quaternion().fromAngles(0, FastMath.PI, 0)
 			);
 		config.setCustomName(customName);
@@ -100,9 +100,9 @@ public class IMUTracker
 		if (userEditable()) {
 			setCustomName(config.getCustomName());
 
-			if (config.getMountingRotation() != null) {
-				mounting = config.getMountingRotation();
-				mountAdjust.set(config.getMountingRotation());
+			if (config.getMountingOrientation() != null) {
+				mounting = config.getMountingOrientation();
+				mountAdjust.set(config.getMountingOrientation());
 			} else {
 				mountAdjust.loadIdentity();
 			}
@@ -116,11 +116,11 @@ public class IMUTracker
 		}
 	}
 
-	public Quaternion getMountingRotation() {
+	public Quaternion getMountingOrientation() {
 		return mounting;
 	}
 
-	public void setMountingRotation(Quaternion mr) {
+	public void setMountingOrientation(Quaternion mr) {
 		mounting = mr;
 		if (mounting != null) {
 			mountAdjust.set(mounting);


### PR DESCRIPTION
Both orientation and rotation were used for mounting. 
Orientation being the end result rather than the process, it makes more sense to use that rather than rotation.
This switches all uses of "mounting rotation" to "mounting orientation"

Protocol PR: https://github.com/SlimeVR/SolarXR-Protocol/pull/84