### PR TITLE
Add User Action packet. Allows for reset buttons on trackers and not just tap detection to reset.

### DIFF
--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
@@ -564,33 +564,39 @@ public class TrackersUDPServer extends Thread {
 					break;
 				tracker.temperature = temp.temperature;
 				break;
-			case UDPProtocolParser.PACKET_RESET:
+			case UDPProtocolParser.PACKET_USER_ACTION:
 				if (connection == null)
 					break;
-				UDPPacket21Reset reset = (UDPPacket21Reset) packet;
-				String name = "";
-				switch (reset.type) {
-					case UDPPacket21Reset.RESET:
-						name = "Full";
-						Main.getVrServer().resetTrackers();
-						break;
-					case UDPPacket21Reset.RESET_YAW:
-						name = "Yaw";
-						Main.getVrServer().resetTrackersYaw();
-						break;
-					case UDPPacket21Reset.RESET_MOUNTING:
-						name = "Mounting";
-						Main.getVrServer().resetTrackersMounting();
+				UDPPacket21UserAction action = (UDPPacket21UserAction) packet;
+				switch (action.type) {
+					case UDPPacket21UserAction.RESET:
+					case UDPPacket21UserAction.RESET_YAW:
+					case UDPPacket21UserAction.RESET_MOUNTING:
+						String name = "";
+						switch (action.type) {
+							case UDPPacket21UserAction.RESET:
+								name = "Full";
+								Main.getVrServer().resetTrackers();
+								break;
+							case UDPPacket21UserAction.RESET_YAW:
+								name = "Yaw";
+								Main.getVrServer().resetTrackersYaw();
+								break;
+							case UDPPacket21UserAction.RESET_MOUNTING:
+								name = "Mounting";
+								Main.getVrServer().resetTrackersMounting();
+								break;
+						}
+						LogManager
+							.info(
+								"[TrackerServer] User action from "
+									+ connection.descriptiveName
+									+ " received. "
+									+ name
+									+ " reset performed."
+							);
 						break;
 				}
-				LogManager
-					.info(
-						"[TrackerServer] Reset packet from "
-							+ connection.descriptiveName
-							+ ". "
-							+ name
-							+ " reset performed."
-					);
 				break;
 			default:
 				LogManager.warning("[TrackerServer] Skipped packet " + packet);

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
@@ -564,6 +564,34 @@ public class TrackersUDPServer extends Thread {
 					break;
 				tracker.temperature = temp.temperature;
 				break;
+			case UDPProtocolParser.PACKET_RESET:
+				if (connection == null)
+					break;
+				UDPPacket21Reset reset = (UDPPacket21Reset) packet;
+				String name = "";
+				switch (reset.type) {
+					case UDPPacket21Reset.RESET:
+						name = "Full";
+						Main.getVrServer().resetTrackers();
+						break;
+					case UDPPacket21Reset.RESET_YAW:
+						name = "Yaw";
+						Main.getVrServer().resetTrackersYaw();
+						break;
+					case UDPPacket21Reset.RESET_MOUNTING:
+						name = "Mounting";
+						Main.getVrServer().resetTrackersMounting();
+						break;
+				}
+				LogManager
+					.info(
+						"[TrackerServer] Reset packet from "
+							+ connection.descriptiveName
+							+ ". "
+							+ name
+							+ " reset performed."
+					);
+				break;
 			default:
 				LogManager.warning("[TrackerServer] Skipped packet " + packet);
 				break;

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPPacket21Reset.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPPacket21Reset.java
@@ -1,0 +1,32 @@
+package dev.slimevr.vr.trackers.udp;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+
+public class UDPPacket21Reset extends UDPPacket {
+
+	public static final int RESET = 0;
+	public static final int RESET_YAW = 1;
+	public static final int RESET_MOUNTING = 2;
+
+	public int type;
+
+	public UDPPacket21Reset() {
+	}
+
+	@Override
+	public int getPacketId() {
+		return 21;
+	}
+
+	@Override
+	public void readData(ByteBuffer buf) throws IOException {
+		type = buf.get() & 0xFF;
+	}
+
+	@Override
+	public void writeData(ByteBuffer buf) throws IOException {
+		// Never sent back in current protocol
+	}
+}

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPPacket21UserAction.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPPacket21UserAction.java
@@ -4,15 +4,15 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 
-public class UDPPacket21Reset extends UDPPacket {
+public class UDPPacket21UserAction extends UDPPacket {
 
-	public static final int RESET = 0;
-	public static final int RESET_YAW = 1;
-	public static final int RESET_MOUNTING = 2;
+	public static final int RESET = 2;
+	public static final int RESET_YAW = 3;
+	public static final int RESET_MOUNTING = 4;
 
 	public int type;
 
-	public UDPPacket21Reset() {
+	public UDPPacket21UserAction() {
 	}
 
 	@Override

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPProtocolParser.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPProtocolParser.java
@@ -30,7 +30,7 @@ public class UDPProtocolParser {
 	public static final int PACKET_MAGNETOMETER_ACCURACY = 18;
 	public static final int PACKET_SIGNAL_STRENGTH = 19;
 	public static final int PACKET_TEMPERATURE = 20;
-	public static final int PACKET_RESET = 21;
+	public static final int PACKET_USER_ACTION = 21;
 
 	public static final int PACKET_PROTOCOL_CHANGE = 200;
 
@@ -113,7 +113,7 @@ public class UDPProtocolParser {
 			case PACKET_MAGNETOMETER_ACCURACY -> new UDPPacket18MagnetometerAccuracy();
 			case PACKET_SIGNAL_STRENGTH -> new UDPPacket19SignalStrength();
 			case PACKET_TEMPERATURE -> new UDPPacket20Temperature();
-			case PACKET_RESET -> new UDPPacket21Reset();
+			case PACKET_USER_ACTION -> new UDPPacket21UserAction();
 			case PACKET_PROTOCOL_CHANGE -> new UDPPacket200ProtocolChange();
 			default -> null;
 		};

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPProtocolParser.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPProtocolParser.java
@@ -30,6 +30,7 @@ public class UDPProtocolParser {
 	public static final int PACKET_MAGNETOMETER_ACCURACY = 18;
 	public static final int PACKET_SIGNAL_STRENGTH = 19;
 	public static final int PACKET_TEMPERATURE = 20;
+	public static final int PACKET_RESET = 21;
 
 	public static final int PACKET_PROTOCOL_CHANGE = 200;
 
@@ -112,6 +113,7 @@ public class UDPProtocolParser {
 			case PACKET_MAGNETOMETER_ACCURACY -> new UDPPacket18MagnetometerAccuracy();
 			case PACKET_SIGNAL_STRENGTH -> new UDPPacket19SignalStrength();
 			case PACKET_TEMPERATURE -> new UDPPacket20Temperature();
+			case PACKET_RESET -> new UDPPacket21Reset();
 			case PACKET_PROTOCOL_CHANGE -> new UDPPacket200ProtocolChange();
 			default -> null;
 		};


### PR DESCRIPTION
This is needed to support resetting by pressing a button on a joycon, as the normal tap detection system doesn't work well on joycons.