### PR TITLE
Support arbitrary sensor id's for devices

### DIFF
--- a/server/src/main/java/dev/slimevr/platform/SteamVRBridge.java
+++ b/server/src/main/java/dev/slimevr/platform/SteamVRBridge.java
@@ -103,7 +103,7 @@ public abstract class SteamVRBridge extends ProtobufBridge<VRTracker> implements
 			device
 		);
 
-		device.getTrackers().add(tracker);
+		device.getTrackers().put(0, tracker);
 		Main.getVrServer().getDeviceManager().addDevice(device);
 		TrackerRole role = TrackerRole.getById(trackerAdded.getTrackerRole());
 		if (role != null) {

--- a/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -30,13 +30,6 @@ import java.util.List;
 public class DataFeedBuilder {
 
 	public static int createHardwareInfo(FlatBufferBuilder fbb, Device device) {
-		// Tracker firstTracker = device.getTrackers().get(0);
-		// if (firstTracker == null) {
-		// firstTracker =
-		// device.getTrackers().entrySet().iterator().next().getValue();
-		// }
-		// Tracker tracker = firstTracker.get();
-
 		int nameOffset = device.getFirmwareVersion() != null
 			? fbb.createString(device.getFirmwareVersion())
 			: 0;

--- a/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -30,7 +30,12 @@ import java.util.List;
 public class DataFeedBuilder {
 
 	public static int createHardwareInfo(FlatBufferBuilder fbb, Device device) {
-		Tracker tracker = device.getTrackers().get(0).get();
+		// Tracker firstTracker = device.getTrackers().get(0);
+		// if (firstTracker == null) {
+		// firstTracker =
+		// device.getTrackers().entrySet().iterator().next().getValue();
+		// }
+		// Tracker tracker = firstTracker.get();
 
 		int nameOffset = device.getFirmwareVersion() != null
 			? fbb.createString(device.getFirmwareVersion())
@@ -193,7 +198,7 @@ public class DataFeedBuilder {
 		device
 			.getTrackers()
 			.forEach(
-				(value) -> trackersOffsets
+				(key, value) -> trackersOffsets
 					.add(DataFeedBuilder.createTrackerData(fbb, mask.getTrackerData(), value))
 			);
 
@@ -214,8 +219,13 @@ public class DataFeedBuilder {
 		if (device.getTrackers().size() <= 0)
 			return 0;
 
-		Tracker tracker = device.getTrackers().get(0).get();
+		Tracker firstTracker = device.getTrackers().get(0);
+		if (firstTracker == null) {
+			// Not actually the "first" tracker, but do we care?
+			firstTracker = device.getTrackers().entrySet().iterator().next().getValue();
+		}
 
+		Tracker tracker = firstTracker.get();
 		if (tracker == null)
 			return 0;
 

--- a/server/src/main/java/dev/slimevr/vr/Device.java
+++ b/server/src/main/java/dev/slimevr/vr/Device.java
@@ -1,9 +1,9 @@
 package dev.slimevr.vr;
 
 import dev.slimevr.vr.trackers.Tracker;
-import io.eiren.util.collections.FastList;
 
 import java.net.InetAddress;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -16,7 +16,7 @@ public class Device {
 	private String firmwareVersion;
 	private String manufacturer;
 
-	private final FastList<Tracker> trackers = new FastList<>();
+	private final HashMap<Integer, Tracker> trackers = new HashMap<>();
 
 	public Device() {
 		this.id = nextLocalDeviceId.incrementAndGet();
@@ -58,7 +58,7 @@ public class Device {
 		return null;
 	}
 
-	public FastList<Tracker> getTrackers() {
+	public HashMap<Integer, Tracker> getTrackers() {
 		return trackers;
 	}
 }

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/TrackersUDPServer.java
@@ -237,7 +237,7 @@ public class TrackersUDPServer extends Thread {
 				Main.getVrServer()
 			);
 
-			connection.getTrackers().add(imu);
+			connection.getTrackers().put(trackerId, imu);
 			trackersConsumer.accept(imu);
 			LogManager
 				.info(
@@ -315,7 +315,7 @@ public class TrackersUDPServer extends Thread {
 							parser.write(bb, conn, new UDPPacket1Heartbeat());
 							socket.send(new DatagramPacket(rcvBuffer, bb.position(), conn.address));
 							if (conn.lastPacket + 1000 < System.currentTimeMillis()) {
-								for (Tracker value : conn.getTrackers()) {
+								for (Tracker value : conn.getTrackers().values()) {
 									IMUTracker tracker = (IMUTracker) value;
 									if (tracker.getStatus() == TrackerStatus.OK)
 										tracker.setStatus(TrackerStatus.DISCONNECTED);
@@ -326,7 +326,7 @@ public class TrackersUDPServer extends Thread {
 								}
 							} else {
 								conn.timedOut = false;
-								for (Tracker value : conn.getTrackers()) {
+								for (Tracker value : conn.getTrackers().values()) {
 									IMUTracker tracker = (IMUTracker) value;
 									if (tracker.getStatus() == TrackerStatus.DISCONNECTED)
 										tracker.setStatus(TrackerStatus.OK);
@@ -452,7 +452,7 @@ public class TrackersUDPServer extends Thread {
 					break;
 				UDPPacket10PingPong ping = (UDPPacket10PingPong) packet;
 				if (connection.lastPingPacketId == ping.pingId) {
-					for (Tracker t : connection.getTrackers()) {
+					for (Tracker t : connection.getTrackers().values()) {
 						IMUTracker imuTracker = (IMUTracker) t;
 						imuTracker
 							.setPing(
@@ -485,7 +485,7 @@ public class TrackersUDPServer extends Thread {
 
 				if (connection.getTrackers().size() > 0) {
 
-					for (Tracker value : connection.getTrackers()) {
+					for (Tracker value : connection.getTrackers().values()) {
 						IMUTracker tr = (IMUTracker) value;
 						tr.setBatteryVoltage(battery.voltage);
 						tr.setBatteryLevel(battery.level * 100);
@@ -549,7 +549,7 @@ public class TrackersUDPServer extends Thread {
 				UDPPacket19SignalStrength signalStrength = (UDPPacket19SignalStrength) packet;
 
 				if (connection.getTrackers().size() > 0) {
-					for (Tracker value : connection.getTrackers()) {
+					for (Tracker value : connection.getTrackers().values()) {
 						IMUTracker tr = (IMUTracker) value;
 						tr.setSignalStrength(signalStrength.signalStrength);
 					}

--- a/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPDevice.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/udp/UDPDevice.java
@@ -4,10 +4,10 @@ import dev.slimevr.NetworkProtocol;
 import dev.slimevr.vr.Device;
 import dev.slimevr.vr.trackers.IMUTracker;
 import dev.slimevr.vr.trackers.Tracker;
-import io.eiren.util.collections.FastList;
 
 import java.net.InetAddress;
 import java.net.SocketAddress;
+import java.util.HashMap;
 
 
 public class UDPDevice extends Device {
@@ -26,7 +26,7 @@ public class UDPDevice extends Device {
 	public NetworkProtocol protocol = null;
 	public int firmwareBuild = 0;
 	public boolean timedOut = false;
-	private final FastList<Tracker> trackers = new FastList<>();
+	private final HashMap<Integer, Tracker> trackers = new HashMap<>();
 
 	public UDPDevice(SocketAddress address, InetAddress ipAddress) {
 		this.address = address;
@@ -77,13 +77,11 @@ public class UDPDevice extends Device {
 	}
 
 	@Override
-	public FastList<Tracker> getTrackers() {
+	public HashMap<Integer, Tracker> getTrackers() {
 		return this.trackers;
 	}
 
 	public IMUTracker getTracker(int id) {
-		if (id >= 0 && id < this.getTrackers().size())
-			return (IMUTracker) this.getTrackers().get(id);
-		return null;
+		return (IMUTracker) this.getTrackers().get(id);
 	}
 }


### PR DESCRIPTION
So I wanted to check how much work it was to change the device tracker storage to use a hashmap instead of a list, enabling arbitrary sensor id's. Turns out SolarXR and the GUI already supported this. I think I have gone through the UI code regarding this and found no place where the this would break things. So the needed changes were very minimal.

The only minor concern is in DataFeedBuilder, where the first tracker is used, however, it only seems to get the hardware info like temperature, voltage etc, and these are all the same for every tracker. I'm not 100% sure on this however.

I have tested it in VR, sending normal sensor id's and arbitrary id's. Seems to work fine.

Further testing is needed though, making sure that both AutoBone and the SlimeVR Overlay still works. Would love some help testing that. :)