### PR TITLE
gui: Fix UI wrapping in settings

### DIFF
--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -437,18 +437,16 @@ export function GeneralSettings() {
             )}
           </Typography>
           <div className="flex flex-col pt-2 pb-4">
-            <Typography color="secondary">
-              {l10n
-                .getString(
-                  'settings-general-tracker_mechanics-drift_compensation-description'
-                )
-                .split('\n')
-                .map((line, i) => (
-                  <Typography color="secondary" key={i}>
-                    {line}
-                  </Typography>
-                ))}
-            </Typography>
+            {l10n
+              .getString(
+                'settings-general-tracker_mechanics-drift_compensation-description'
+              )
+              .split('\n')
+              .map((line, i) => (
+                <Typography color="secondary" key={i}>
+                  {line}
+                </Typography>
+              ))}
           </div>
           <CheckBox
             variant="toggle"

--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -758,76 +758,61 @@ export function GeneralSettings() {
           <Typography variant="main-title">
             {l10n.getString('settings-general-interface')}
           </Typography>
-          <div className="gap-4 grid">
-            <div className="grid sm:grid-cols-2">
-              <div>
-                <Typography bold>
-                  {l10n.getString('settings-general-interface-dev_mode')}
-                </Typography>
-                <div className="flex flex-col">
-                  <Typography color="secondary">
-                    {l10n.getString(
-                      'settings-general-interface-dev_mode-description'
-                    )}
-                  </Typography>
-                </div>
-                <div className="pt-2">
-                  <CheckBox
-                    variant="toggle"
-                    control={control}
-                    outlined
-                    name="interface.devmode"
-                    label={l10n.getString(
-                      'settings-general-interface-dev_mode-label'
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="grid sm:grid-cols-2">
-              <div>
-                <Typography bold>
-                  {l10n.getString(
-                    'settings-general-interface-serial_detection'
-                  )}
-                </Typography>
-                <div className="flex flex-col">
-                  <Typography color="secondary">
-                    {l10n.getString(
-                      'settings-general-interface-serial_detection-description'
-                    )}
-                  </Typography>
-                </div>
-                <div className="pt-2">
-                  <CheckBox
-                    variant="toggle"
-                    control={control}
-                    outlined
-                    name="interface.watchNewDevices"
-                    label={l10n.getString(
-                      'settings-general-interface-serial_detection-label'
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="grid sm:grid-cols-2">
-              <div>
-                <Typography bold>
-                  {l10n.getString('settings-general-interface-lang')}
-                </Typography>
-                <div className="flex flex-col">
-                  <Typography color="secondary">
-                    {l10n.getString(
-                      'settings-general-interface-lang-description'
-                    )}
-                  </Typography>
-                </div>
-                <div className="pt-2">
-                  <LangSelector />
-                </div>
-              </div>
-            </div>
+
+          <Typography bold>
+            {l10n.getString('settings-general-interface-dev_mode')}
+          </Typography>
+          <div className="flex flex-col pt-1 pb-2">
+            <Typography color="secondary">
+              {l10n.getString(
+                'settings-general-interface-dev_mode-description'
+              )}
+            </Typography>
+          </div>
+          <div className="grid sm:grid-cols-2 pb-4">
+            <CheckBox
+              variant="toggle"
+              control={control}
+              outlined
+              name="interface.devmode"
+              label={l10n.getString(
+                'settings-general-interface-dev_mode-label'
+              )}
+            />
+          </div>
+
+          <Typography bold>
+            {l10n.getString('settings-general-interface-serial_detection')}
+          </Typography>
+          <div className="flex flex-col pt-1 pb-2">
+            <Typography color="secondary">
+              {l10n.getString(
+                'settings-general-interface-serial_detection-description'
+              )}
+            </Typography>
+          </div>
+          <div className="grid sm:grid-cols-2 pb-4">
+            <CheckBox
+              variant="toggle"
+              control={control}
+              outlined
+              name="interface.watchNewDevices"
+              label={l10n.getString(
+                'settings-general-interface-serial_detection-label'
+              )}
+            />
+          </div>
+
+          <Typography bold>
+            {l10n.getString('settings-general-interface-lang')}
+          </Typography>
+          <div className="flex flex-col pt-1 pb-2">
+            <Typography color="secondary">
+              {l10n.getString('settings-general-interface-lang-description')}
+            </Typography>
+          </div>
+          <div className="grid sm:grid-cols-2 pb-4">
+            <LangSelector />
           </div>
         </>
       </SettingsPageLayout>

--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -162,7 +162,7 @@ export function TrackerSettingsPage() {
         onClose={() => setSelectRotation(false)}
         onDirectionSelected={onDirectionSelected}
       ></MountingSelectionMenu>
-      <div className="flex gap-2 md:h-full flex-wrap md:flex-row ">
+      <div className="flex gap-2 md:h-full max-md:flex-wrap md:flex-row ">
         <div className="flex flex-col w-full md:max-w-xs gap-2">
           {tracker && (
             <TrackerCard
@@ -284,31 +284,27 @@ export function TrackerSettingsPage() {
             </div>
           </div>
           {tracker?.tracker.info?.isImu && (
-            <>
-              <div className="flex flex-col gap-2 w-full mt-3">
-                <Typography variant="section-title">
-                  {l10n.getString(
-                    'tracker-settings-drift_compensation_section'
+            <div className="flex flex-col gap-2 w-full mt-3">
+              <Typography variant="section-title">
+                {l10n.getString('tracker-settings-drift_compensation_section')}
+              </Typography>
+              <Typography color="secondary">
+                {l10n.getString(
+                  'tracker-settings-drift_compensation_section-description'
+                )}
+              </Typography>
+              <div className="flex">
+                <CheckBox
+                  variant="toggle"
+                  outlined
+                  name="allowDriftCompensation"
+                  control={control}
+                  label={l10n.getString(
+                    'tracker-settings-drift_compensation_section-edit'
                   )}
-                </Typography>
-                <Typography color="secondary">
-                  {l10n.getString(
-                    'tracker-settings-drift_compensation_section-description'
-                  )}
-                </Typography>
-                <div className="flex">
-                  <CheckBox
-                    variant="toggle"
-                    outlined
-                    name="allowDriftCompensation"
-                    control={control}
-                    label={l10n.getString(
-                      'tracker-settings-drift_compensation_section-edit'
-                    )}
-                  />
-                </div>
+                />
               </div>
-            </>
+            </div>
           )}
           <div className="flex flex-col gap-2 w-full mt-3">
             <Typography variant="section-title">


### PR DESCRIPTION
- Fixes responsive table wrapping caused by text length in tracker settings (drift compensation description was too long);

![image](https://user-images.githubusercontent.com/114709761/211237200-00f7ba8c-ca51-4540-9900-94030ab344b6.png)

- Makes text and control padding in interface settings more consistent.

![image](https://user-images.githubusercontent.com/114709761/211237429-900ad828-ef33-46d9-b672-b79b3457aa49.png)

- Fixes this:

![image](https://user-images.githubusercontent.com/114709761/211299544-eca92132-b657-4c6a-9167-0aeb3e1ff9f0.png)

