### PR TITLE
Rename "wifi" to "Wi-Fi" and "SSID" to "Wi-Fi" name

### DIFF
--- a/gui/public/i18n/en-x-owo/translation.ftl
+++ b/gui/public/i18n/en-x-owo/translation.ftl
@@ -67,7 +67,7 @@ reset-quick = quick weset
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = nyu sewiaw device detected~!
-serial_detection-new_device-p1 = entaw youw wifi cwedentiaws~!
+serial_detection-new_device-p1 = entaw youw wi-fi cwedentiaws~!
 serial_detection-new_device-p2 = pwease sewect what youw want to do wit it
 serial_detection-open_wifi = cownnyect to wyfy~
 serial_detection-open_serial = awpen sewiaw console >w<
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = pawt out
     .placeholder = pawt out (defawwt: 9000)
 settings-osc-vrchat-network-address = network addwess
-settings-osc-vrchat-network-address-description = choose which addwess to send out data to vwchat (check yuw wifi settwings on yuw device)
+settings-osc-vrchat-network-address-description = choose which addwess to send out data to vwchat (check yuw wi-fi settwings on yuw device)
 settings-osc-vrchat-network-address-placeholder = vwchat ip addwess
 settings-osc-vrchat-network-trackers = trayckawws
 settings-osc-vrchat-network-trackers-description = toggle teh sending of spweciwic twackers viwa OSC
@@ -366,18 +366,18 @@ onboarding-skip = skipy setup
 onboarding-continue = continyue
 onboarding-wip = wowwk in pwowgress
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = gaww bawwk to intwoduction
-onboarding-wifi_creds = input wifi cwedentials
+onboarding-wifi_creds = input wi-fi cwedentials
 # This cares about multilines
 onboarding-wifi_creds-description =
     teh twawckaws will use these cwedentials to connect wirelessly
     pwease use teh cwedentials that yaww awe cwowently cownyected to
-onboarding-wifi_creds-skip = skipy wifi settiwyngs
+onboarding-wifi_creds-skip = skipy wi-fi settiwyngs
 onboarding-wifi_creds-submit = suwbmyt!
 onboarding-wifi_creds-ssid =
-    .label = SSID
-    .placeholder = Enter SSID
+    .label = wi-fi nawme
+    .placeholder = enter wi-fi nawme
 onboarding-wifi_creds-password =
     .label = Password
     .placeholder = Enter password
@@ -407,15 +407,15 @@ onboarding-done-description = enjoy yoaww fuww body expewwience
 onboarding-done-close = cwose the guide
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = gaww bawwk to wifi cwedentials
+onboarding-connect_tracker-back = gaww bawwk to wi-fi cwedentials
 onboarding-connect_tracker-title = connect twackaws
 onboarding-connect_tracker-description-p0 = now onto teh fun pawwt, connecting awe teh twackaws!
 onboarding-connect_tracker-description-p1 = simply connect awe that awe nawt cownyected yet, through a usb powwt.
 onboarding-connect_tracker-issue-serial = i'm having twouble connecting!
 onboarding-connect_tracker-usb = usb twacker
-onboarding-connect_tracker-connection_status-connecting = sending wifi cwedentials
-onboarding-connect_tracker-connection_status-connected = cownyected to wifi
-onboarding-connect_tracker-connection_status-error = unabwe to cownyect to wifi
+onboarding-connect_tracker-connection_status-connecting = sending wi-fi cwedentials
+onboarding-connect_tracker-connection_status-connected = cownyected to wi-fi
+onboarding-connect_tracker-connection_status-error = unabwe to cownyect to wi-fi
 onboarding-connect_tracker-connection_status-start_connecting = wooking for twackaws
 onboarding-connect_tracker-connection_status-handshake = cownyected to teh sewvew
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = i cownyected awe my twackaws
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = go bak to wifi credyentials
+onboarding-assign_trackers-back = go bak to wi-fi credyentials
 onboarding-assign_trackers-title = assign twackaws
 onboarding-assign_trackers-description = wets choyse which twackaw goes whewe. cwick on a wocation whewe yowo want to payce a twackaw
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Quick Reset
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = New serial device detected!
-serial_detection-new_device-p1 = Enter your WiFi credentials!
+serial_detection-new_device-p1 = Enter your Wi-Fi credentials!
 serial_detection-new_device-p2 = Please select what you want to do with it
-serial_detection-open_wifi = Connect to WiFi
+serial_detection-open_wifi = Connect to Wi-Fi
 serial_detection-open_serial = Open Serial Console
 serial_detection-submit = Submit!
 serial_detection-close = Close
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Port Out
     .placeholder = Port out (default: 9000)
 settings-osc-vrchat-network-address = Network address
-settings-osc-vrchat-network-address-description = Choose which address to send out data to VRChat (check your wifi settings on your device).
+settings-osc-vrchat-network-address-description = Choose which address to send out data to VRChat (check your Wi-Fi settings on your device).
 settings-osc-vrchat-network-address-placeholder = VRChat ip address
 settings-osc-vrchat-network-trackers = Trackers
 settings-osc-vrchat-network-trackers-description = Toggle the sending of specific trackers via OSC.
@@ -366,18 +366,18 @@ onboarding-skip = Skip setup
 onboarding-continue = Continue
 onboarding-wip = Work in progress
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Go Back to introduction
-onboarding-wifi_creds = Input WiFi credentials
+onboarding-wifi_creds = Input Wi-Fi credentials
 # This cares about multilines
 onboarding-wifi_creds-description =
-    The Trackers will use these credentials to connect wirelessly.
+    The Trackers will use these credentials to connect wireless.
     Please use the credentials that you are currently connected to.
-onboarding-wifi_creds-skip = Skip wifi settings
+onboarding-wifi_creds-skip = Skip Wi-Fi settings
 onboarding-wifi_creds-submit = Submit!
 onboarding-wifi_creds-ssid =
-    .label = SSID
-    .placeholder = Enter SSID
+    .label = Wi-Fi name
+    .placeholder = Enter Wi-Fi name
 onboarding-wifi_creds-password =
     .label = Password
     .placeholder = Enter password
@@ -407,15 +407,15 @@ onboarding-done-description = Enjoy your full body experience
 onboarding-done-close = Close the guide
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Go Back to WiFi credentials
+onboarding-connect_tracker-back = Go Back to Wi-Fi credentials
 onboarding-connect_tracker-title = Connect trackers
 onboarding-connect_tracker-description-p0 = Now onto the fun part, connecting all the trackers!
 onboarding-connect_tracker-description-p1 = Simply connect all that aren't connected yet, through a USB port.
 onboarding-connect_tracker-issue-serial = I'm having trouble connecting!
 onboarding-connect_tracker-usb = USB Tracker
-onboarding-connect_tracker-connection_status-connecting = Sending wifi credentials
-onboarding-connect_tracker-connection_status-connected = Connected to WiFi
-onboarding-connect_tracker-connection_status-error = Unable to connect to Wifi
+onboarding-connect_tracker-connection_status-connecting = Sending Wi-Fi credentials
+onboarding-connect_tracker-connection_status-connected = Connected to Wi-Fi
+onboarding-connect_tracker-connection_status-error = Unable to connect to Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = Looking for trackers
 onboarding-connect_tracker-connection_status-handshake = Connected to the Server
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = I connected all my trackers
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Go Back to Wifi Credentials
+onboarding-assign_trackers-back = Go Back to Wi-Fi Credentials
 onboarding-assign_trackers-title = Assign trackers
 onboarding-assign_trackers-description = Let's choose which tracker goes where. Click on a location where you want to place a tracker
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -371,7 +371,7 @@ onboarding-wifi_creds-back = Go Back to introduction
 onboarding-wifi_creds = Input Wi-Fi credentials
 # This cares about multilines
 onboarding-wifi_creds-description =
-    The Trackers will use these credentials to connect wireless.
+    The Trackers will use these credentials to connect wirelessly.
     Please use the credentials that you are currently connected to.
 onboarding-wifi_creds-skip = Skip Wi-Fi settings
 onboarding-wifi_creds-submit = Submit!

--- a/gui/public/i18n/es-419/translation.ftl
+++ b/gui/public/i18n/es-419/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Reinicio rápido
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = ¡Nuevo dispositivo serial detectado!
-serial_detection-new_device-p1 = ¡Ingresa tus credenciales del WiFi!
+serial_detection-new_device-p1 = ¡Ingresa tus credenciales del Wi-Fi!
 serial_detection-new_device-p2 = Por favor selecciona que quieres hacer con el
-serial_detection-open_wifi = Conectarse al WiFi
+serial_detection-open_wifi = Conectarse al Wi-Fi
 serial_detection-open_serial = Abrir consola serial
 serial_detection-submit = ¡Enviar!
 serial_detection-close = Cerrar
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Puerto de salida
     .placeholder = Puerto de salida (por defecto: 9000)
 settings-osc-vrchat-network-address = Dirección de red
-settings-osc-vrchat-network-address-description = Establece la dirección donde se enviarán los datos de VRChat (revisa los ajustes de WiFi de tu dispositivo que tenga el juego).
+settings-osc-vrchat-network-address-description = Establece la dirección donde se enviarán los datos de VRChat (revisa los ajustes de Wi-Fi de tu dispositivo que tenga el juego).
 settings-osc-vrchat-network-address-placeholder = Dirección IP de VRChat
 settings-osc-vrchat-network-trackers = Sensores
 settings-osc-vrchat-network-trackers-description = Habilita el envío de sensores específicos mediante OSC.
@@ -366,14 +366,14 @@ onboarding-skip = Saltar configuración
 onboarding-continue = Continuar
 onboarding-wip = Trabajo en progreso
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Volver a la introducción
-onboarding-wifi_creds = Ingresar credenciales del WiFi
+onboarding-wifi_creds = Ingresar credenciales del Wi-Fi
 # This cares about multilines
 onboarding-wifi_creds-description =
     Los sensores utilizarán estas credenciales para conectarse inalámbricamente. 
-    Por favor usa las credenciales del WiFi al cuál estás conectado actualmente.
-onboarding-wifi_creds-skip = Saltar ajustes de WiFi
+    Por favor usa las credenciales del Wi-Fi al cuál estás conectado actualmente.
+onboarding-wifi_creds-skip = Saltar ajustes de Wi-Fi
 onboarding-wifi_creds-submit = ¡Enviar!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = Disfruta moverte en la realidad virtual
 onboarding-done-close = Cerrar la guía
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Volver a las credenciales WiFi
+onboarding-connect_tracker-back = Volver a las credenciales Wi-Fi
 onboarding-connect_tracker-title = Conecta tus sensores
 onboarding-connect_tracker-description-p0 = Ahora la parte divertida, ¡Conectar todos tus sensores!
 onboarding-connect_tracker-description-p1 = Simplemente conecta todos los sensores que aún no están conectados, por medio de un puerto USB.
 onboarding-connect_tracker-issue-serial = ¡Tengo problemas conectándolos!
 onboarding-connect_tracker-usb = Sensor USB
-onboarding-connect_tracker-connection_status-connecting = Enviando credenciales WiFi
-onboarding-connect_tracker-connection_status-connected = Conectado al WiFi
-onboarding-connect_tracker-connection_status-error = Incapaz de conectar al WiFi
+onboarding-connect_tracker-connection_status-connecting = Enviando credenciales Wi-Fi
+onboarding-connect_tracker-connection_status-connected = Conectado al Wi-Fi
+onboarding-connect_tracker-connection_status-error = Incapaz de conectar al Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = Buscando sensores
 onboarding-connect_tracker-connection_status-handshake = Conectado con el servidor
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = He conectado todos mis sensores
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Volver a las credenciales WiFi
+onboarding-assign_trackers-back = Volver a las credenciales Wi-Fi
 onboarding-assign_trackers-title = Asignación de sensores
 onboarding-assign_trackers-description = Debes escoger dónde van los sensores. Has clic en la ubicación donde quieras colocar un sensor
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/et/translation.ftl
+++ b/gui/public/i18n/et/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Kiir Lähtestamine
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = Uus jadaseade tuvastatud!
-serial_detection-new_device-p1 = Sisestage enda WiFi andmed!
+serial_detection-new_device-p1 = Sisestage enda Wi-Fi andmed!
 serial_detection-new_device-p2 = Palun valige, mida te soovite sellega teha
-serial_detection-open_wifi = Ühendage WiFi-ga
+serial_detection-open_wifi = Ühendage Wi-Fi-ga
 serial_detection-open_serial = Avage Jadakonsool
 serial_detection-submit = Jätka!
 serial_detection-close = Sulge
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Võrguport välja
     .placeholder = Võrguport välja (vaikimisi: 9000)
 settings-osc-vrchat-network-address = Võrgu aadress
-settings-osc-vrchat-network-address-description = Vali, mis aadressile saata andmeid VRChat-i jaoks (kontrolli enda WiFi seadeid seadmest).
+settings-osc-vrchat-network-address-description = Vali, mis aadressile saata andmeid VRChat-i jaoks (kontrolli enda Wi-Fi seadeid seadmest).
 settings-osc-vrchat-network-address-placeholder = VRChat ip aadress
 settings-osc-vrchat-network-trackers = Jälgia
 settings-osc-vrchat-network-trackers-description = Lülita sisse/välja teatud jälgijate andmete saatmise OSC kaudu.
@@ -366,14 +366,14 @@ onboarding-skip = Jäta seadistamine vahele
 onboarding-continue = Jätka
 onboarding-wip = Töö käib
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Mine tagasi juhistele
-onboarding-wifi_creds = Sisestage enda WiFi andmed!
+onboarding-wifi_creds = Sisestage enda Wi-Fi andmed!
 # This cares about multilines
 onboarding-wifi_creds-description =
     Jälgijad kasutavad neid andmeid, et ühendada juhtmevabalt. 
-    Palun kasutage neid WiFi andmeid, millega te praegu olete ühendatud.
-onboarding-wifi_creds-skip = Jätke WiFi seaded vahele.
+    Palun kasutage neid Wi-Fi andmeid, millega te praegu olete ühendatud.
+onboarding-wifi_creds-skip = Jätke Wi-Fi seaded vahele.
 onboarding-wifi_creds-submit = Jätka!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = Nautige enda kogu keha jälgimis kogemust
 onboarding-done-close = Sulgege juhend
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Minge tagasi WiFi andmetesse
+onboarding-connect_tracker-back = Minge tagasi Wi-Fi andmetesse
 onboarding-connect_tracker-title = Ühendage jälgijad
 onboarding-connect_tracker-description-p0 = Nüüd lähme lõbusa osa juurde, ühendame kõik jälgijad-
 onboarding-connect_tracker-description-p1 = Lihtsalt ühendage kõik jälgijad, mis ei ole ühendatud läbi USB enda arvutisse.
 onboarding-connect_tracker-issue-serial = Mul on probleeme ühenduse loomisega!
 onboarding-connect_tracker-usb = USB Jälgija
-onboarding-connect_tracker-connection_status-connecting = Saadame WiFi andmeid
-onboarding-connect_tracker-connection_status-connected = Ühendatud WiFi võrguga
-onboarding-connect_tracker-connection_status-error = WiFi-ga ei saa ühendust luua!
+onboarding-connect_tracker-connection_status-connecting = Saadame Wi-Fi andmeid
+onboarding-connect_tracker-connection_status-connected = Ühendatud Wi-Fi võrguga
+onboarding-connect_tracker-connection_status-error = Wi-Fi-ga ei saa ühendust luua!
 onboarding-connect_tracker-connection_status-start_connecting = Jälgijate otsimine
 onboarding-connect_tracker-connection_status-handshake = Ühendatud serveriga
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = Olen ühendanud kõik oma jälgijad
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Minge tagasi WiFi andmetesse
+onboarding-assign_trackers-back = Minge tagasi Wi-Fi andmetesse
 onboarding-assign_trackers-title = Määrake jälgijad asukoht
 onboarding-assign_trackers-description = Valime mis jälgijad lähevad kuhu. Vajutage asukohale kuhu te tahate, et jälgija läheks.
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/fr/translation.ftl
+++ b/gui/public/i18n/fr/translation.ftl
@@ -366,7 +366,7 @@ onboarding-skip = Passer
 onboarding-continue = Continuer
 onboarding-wip = Pas encore implémenté
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Retour à l'introduction
 onboarding-wifi_creds = Saisir les identifiants Wi-Fi
 # This cares about multilines
@@ -376,11 +376,11 @@ onboarding-wifi_creds-description =
 onboarding-wifi_creds-skip = Passer la configuration Wi-Fi
 onboarding-wifi_creds-submit = Valider
 onboarding-wifi_creds-ssid =
-    .label = SSID
-    .placeholder = Enter SSID
+    .label = Nom du Wi-Fi
+    .placeholder = Nom
 onboarding-wifi_creds-password =
-    .label = Password
-    .placeholder = Enter password
+    .label = Mot de passe du Wi-Fi
+    .placeholder = Mot de passe
 
 ## Mounting setup
 onboarding-reset_tutorial-back = Retourner à l'alignement des capteurs

--- a/gui/public/i18n/it/translation.ftl
+++ b/gui/public/i18n/it/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Reset veloce
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = Nuovo dispositivo seriale rilevato!
-serial_detection-new_device-p1 = Inserisci le tue credenziali WiFi!
+serial_detection-new_device-p1 = Inserisci le tue credenziali Wi-Fi!
 serial_detection-new_device-p2 = Seleziona come utilizzare il tracker, per piacere
-serial_detection-open_wifi = Connetti al WiFi
+serial_detection-open_wifi = Connetti al Wi-Fi
 serial_detection-open_serial = Apri la Serial Console
 serial_detection-submit = Conferma!
 serial_detection-close = Chiudi
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Porta in uscita
     .placeholder = Porta in uscita (predefinito: 9000)
 settings-osc-vrchat-network-address = Indirizzo di rete
-settings-osc-vrchat-network-address-description = Scegli a quale indirizzo di rete inviare i dati di VRChat (controlla le impostazioni WiFi sul tuo dispositivo)
+settings-osc-vrchat-network-address-description = Scegli a quale indirizzo di rete inviare i dati di VRChat (controlla le impostazioni Wi-Fi sul tuo dispositivo)
 settings-osc-vrchat-network-address-placeholder = Indirizzo IP di VRChat
 settings-osc-vrchat-network-trackers = Tracker
 settings-osc-vrchat-network-trackers-description = Attiva o disattiva l'invio e la ricezione dei dati
@@ -366,14 +366,14 @@ onboarding-skip = Salta la configurazione
 onboarding-continue = Continua
 onboarding-wip = Lavori in corso
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Torna all'introduzione
-onboarding-wifi_creds = Inserisci credenziali WiFi
+onboarding-wifi_creds = Inserisci credenziali Wi-Fi
 # This cares about multilines
 onboarding-wifi_creds-description =
     I tracker utilizzeranno queste credenziali per connettersi in modalità wireless
     Si prega di utilizzare le stesse credenziali con cui si è attualmente connessi
-onboarding-wifi_creds-skip = Salta impostazioni WiFi
+onboarding-wifi_creds-skip = Salta impostazioni Wi-Fi
 onboarding-wifi_creds-submit = Conferma!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = Goditi la tua esperienza di full-body tracking
 onboarding-done-close = Chiudi la guida
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Torna alle credenziali WiFi
+onboarding-connect_tracker-back = Torna alle credenziali Wi-Fi
 onboarding-connect_tracker-title = Connetti i tracker
 onboarding-connect_tracker-description-p0 = Ora passiamo alla parte divertente, colleghiamo tutti i tracker!
 onboarding-connect_tracker-description-p1 = Collega semplicemente tutti i tracker che non sono ancora collegati tramite una porta USB.
 onboarding-connect_tracker-issue-serial = Ho problemi con la connessione!
 onboarding-connect_tracker-usb = Tracker USB
-onboarding-connect_tracker-connection_status-connecting = Invio credenziali WiFi in corso.
-onboarding-connect_tracker-connection_status-connected = Connesso al WiFi
-onboarding-connect_tracker-connection_status-error = Impossibile connettersi al WiFi
+onboarding-connect_tracker-connection_status-connecting = Invio credenziali Wi-Fi in corso.
+onboarding-connect_tracker-connection_status-connected = Connesso al Wi-Fi
+onboarding-connect_tracker-connection_status-error = Impossibile connettersi al Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = Ricerca dei tracker in corso
 onboarding-connect_tracker-connection_status-handshake = Connesso al Server
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = Ho collegato tutti i miei tracker
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Torna alle credenziali WiFi
+onboarding-assign_trackers-back = Torna alle credenziali Wi-Fi
 onboarding-assign_trackers-title = Assegna i tracker
 onboarding-assign_trackers-description = Scegliamo quale tracker va dove. Fare clic su una parte del corpo in cui si desidera assegnare un tracker
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/ja/translation.ftl
+++ b/gui/public/i18n/ja/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = クイックリセット
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = 新しいシリアルデバイスを検出しました！
-serial_detection-new_device-p1 = wifiの認証情報を入力してください！
+serial_detection-new_device-p1 = Wi-Fiの認証情報を入力してください！
 serial_detection-new_device-p2 = 何をするか選択してください
-serial_detection-open_wifi = WiFiに接続
+serial_detection-open_wifi = Wi-Fiに接続
 serial_detection-open_serial = シリアルコンソールを開く
 serial_detection-submit = 実行！
 serial_detection-close = 閉じる
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = ポートアウト
     .placeholder = ポートアウト (デフォルト: 9000)
 settings-osc-vrchat-network-address = ネットワークアドレス
-settings-osc-vrchat-network-address-description = VRChatにデータを送信するアドレスを選択してください（デバイスのwifi設定を確認してください）
+settings-osc-vrchat-network-address-description = VRChatにデータを送信するアドレスを選択してください（デバイスのWi-Fi設定を確認してください）
 settings-osc-vrchat-network-address-placeholder = VRChatのIPアドレス
 settings-osc-vrchat-network-trackers = トラッカー
 settings-osc-vrchat-network-trackers-description = データの送受信を切り替える。
@@ -366,14 +366,14 @@ onboarding-skip = 設定をスキップする
 onboarding-continue = 続ける
 onboarding-wip = 実行中
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = 戻る
-onboarding-wifi_creds = WiFiの認証情報の入力
+onboarding-wifi_creds = Wi-Fi
 # This cares about multilines
 onboarding-wifi_creds-description =
-    トラッカーはこれらの認証情報を使ってwifiに接続します。
+    トラッカーはこれらの認証情報を使ってWi-Fiに接続します。
     現在接続している認証情報を使用してください。
-onboarding-wifi_creds-skip = wifi設定をスキップする
+onboarding-wifi_creds-skip = Wi-Fi設定をスキップする
 onboarding-wifi_creds-submit = 実行！
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = フルトラをお楽しみください
 onboarding-done-close = ガイドを閉じる
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = WiFi認証に戻る
+onboarding-connect_tracker-back = Wi-Fi認証に戻る
 onboarding-connect_tracker-title = 接続中のトラッカー
 onboarding-connect_tracker-description-p0 = さあ、楽しい部分に移りましょう。すべてのトラッカーを接続します！
 onboarding-connect_tracker-description-p1 = まだ接続されていないトラッカーたちをUSBポートを通して接続するだけです。
 onboarding-connect_tracker-issue-serial = 接続に問題があります！
 onboarding-connect_tracker-usb = USBトラッカー
-onboarding-connect_tracker-connection_status-connecting = wifiの認証情報を送信中
-onboarding-connect_tracker-connection_status-connected = WiFiに接続されました
-onboarding-connect_tracker-connection_status-error = Wifiに接続できません
+onboarding-connect_tracker-connection_status-connecting = Wi-Fiの認証情報を送信中
+onboarding-connect_tracker-connection_status-connected = Wi-Fiに接続されました
+onboarding-connect_tracker-connection_status-error = Wi-Fiに接続できません
 onboarding-connect_tracker-connection_status-start_connecting = トラッカーを探しています
 onboarding-connect_tracker-connection_status-handshake = サーバーに接続されました
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = すべてのトラッカーを接続しました
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Wifi認証に戻る
+onboarding-assign_trackers-back = Wi-Fi認証に戻る
 onboarding-assign_trackers-title = トラッカーを割り当てる
 onboarding-assign_trackers-description = どのトラッカーをどこに置くか選んでみましょう。トラッカーを配置したい場所をクリックしてください。
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/ko/translation.ftl
+++ b/gui/public/i18n/ko/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = 퀵 리셋
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = 새로운 시리얼 디바이스를 찾았어요!
-serial_detection-new_device-p1 = WiFi 자격 증명을 입력해주세요!
+serial_detection-new_device-p1 = Wi-Fi 자격 증명을 입력해주세요!
 serial_detection-new_device-p2 = 원하는 작업을 선택하세요
-serial_detection-open_wifi = WiFi 연결
+serial_detection-open_wifi = Wi-Fi 연결
 serial_detection-open_serial = 시리얼 콘솔 열기
 serial_detection-submit = 저장!
 serial_detection-close = 닫기
@@ -366,14 +366,14 @@ onboarding-skip = 설정 건너뛰기
 onboarding-continue = 계속하기
 onboarding-wip = 아직 공사 중이에요
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = 처음으로 돌아가기
-onboarding-wifi_creds = WiFi 자격 증명을 입력하세요
+onboarding-wifi_creds = Wi-Fi 자격 증명을 입력하세요
 # This cares about multilines
 onboarding-wifi_creds-description =
     트래커는 이 자격 증명을 사용하여 무선으로 연결해요
     지금 연결되어 있는 자격 증명을 사용해주세요
-onboarding-wifi_creds-skip = WiFi 설정 건너뛰기
+onboarding-wifi_creds-skip = Wi-Fi 설정 건너뛰기
 onboarding-wifi_creds-submit = 저장!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = 풀바디 트래킹을 즐기세요!
 onboarding-done-close = 마법사 닫기
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = WiFi 자격 증명으로 돌아가기
+onboarding-connect_tracker-back = Wi-Fi 자격 증명으로 돌아가기
 onboarding-connect_tracker-title = 트래커 연결
 onboarding-connect_tracker-description-p0 = 이제 모든 트래커를 연결하는 재미있는 부분으로 가봐요!
 onboarding-connect_tracker-description-p1 = 그냥 모든 트래커를 USB 포트에 연결하기만 하면 돼요
 onboarding-connect_tracker-issue-serial = 연결하는 데 문제가 생겼어요!
 onboarding-connect_tracker-usb = USB 트래커
-onboarding-connect_tracker-connection_status-connecting = WiFi 자격증명 전송 중
-onboarding-connect_tracker-connection_status-connected = WiFi 연결됨
-onboarding-connect_tracker-connection_status-error = Wifi에 연결할 수 없음
+onboarding-connect_tracker-connection_status-connecting = Wi-Fi 자격증명 전송 중
+onboarding-connect_tracker-connection_status-connected = Wi-Fi 연결됨
+onboarding-connect_tracker-connection_status-error = Wi-Fi에 연결할 수 없음
 onboarding-connect_tracker-connection_status-start_connecting = 트래커 찾는 중
 onboarding-connect_tracker-connection_status-handshake = 서버에 연결됨
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = 모든 트래커를 잘 연결했어요
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = WiFi 자격 증명으로 돌아가기
+onboarding-assign_trackers-back = Wi-Fi 자격 증명으로 돌아가기
 onboarding-assign_trackers-title = 트래커 위치 지정
 onboarding-assign_trackers-description = 이제, 어떤 트래커가 어디에 있는지 선택할 시간이에요. 트래커를 배치할 위치를 클릭해보세요
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/pl/translation.ftl
+++ b/gui/public/i18n/pl/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Szybki Reset
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = Wykryto Nowe Urządzenie.
-serial_detection-new_device-p1 = Wprowadź dane WiFi!
+serial_detection-new_device-p1 = Wprowadź dane Wi-Fi!
 serial_detection-new_device-p2 = Wybierz co chcesz z nim zrobić.
-serial_detection-open_wifi = Połącz z WiFi
+serial_detection-open_wifi = Połącz z Wi-Fi
 serial_detection-open_serial = Otwórz Konsole
 serial_detection-submit = Potwierdź!
 serial_detection-close = Zamknij
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Port Out
     .placeholder = Port out (default: 9000)
 settings-osc-vrchat-network-address = Network address
-settings-osc-vrchat-network-address-description = Choose which address to send out data to VRChat (check your wifi settings on your device).
+settings-osc-vrchat-network-address-description = Choose which address to send out data to VRChat (check your Wi-Fi settings on your device).
 settings-osc-vrchat-network-address-placeholder = VRChat ip address
 settings-osc-vrchat-network-trackers = Trackers
 settings-osc-vrchat-network-trackers-description = Toggle the sending of specific trackers via OSC.
@@ -366,14 +366,14 @@ onboarding-skip = Pomiń wstępną konfiguracje
 onboarding-continue = Kontynuuj
 onboarding-wip = W trakcie prac
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Cofnij się do początku
-onboarding-wifi_creds = Wpisz dane WiFi
+onboarding-wifi_creds = Wpisz dane Wi-Fi
 # This cares about multilines
 onboarding-wifi_creds-description =
     Trackery będą używać tej sieci do łączenia się z serwerem
     proszę używać sieci do której jest się połączonym
-onboarding-wifi_creds-skip = Pomiń ustawienia WiFi
+onboarding-wifi_creds-skip = Pomiń ustawienia Wi-Fi
 onboarding-wifi_creds-submit = Potwierdź!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = Ciesz się Full-Body
 onboarding-done-close = Zamknij Poradnik
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Cofnij się do ustawień WiFi
+onboarding-connect_tracker-back = Cofnij się do ustawień Wi-Fi
 onboarding-connect_tracker-title = Połącz trackery
 onboarding-connect_tracker-description-p0 = Teraz czas na zabawe, połączenie wszystkich trackerów!
 onboarding-connect_tracker-description-p1 = Po prostu połącz wszystkie dotychczas nie połączone trackery za pomocą USB
 onboarding-connect_tracker-issue-serial = Mam problemy z połączeniem!
 onboarding-connect_tracker-usb = USB Tracker
-onboarding-connect_tracker-connection_status-connecting = Wysyłanie danych WiFi
-onboarding-connect_tracker-connection_status-connected = Połączono z WiFi
-onboarding-connect_tracker-connection_status-error = Nie można połączyć z Wifi
+onboarding-connect_tracker-connection_status-connecting = Wysyłanie danych Wi-Fi
+onboarding-connect_tracker-connection_status-connected = Połączono z Wi-Fi
+onboarding-connect_tracker-connection_status-error = Nie można połączyć z Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = Szukanie Trackerów
 onboarding-connect_tracker-connection_status-handshake = Połączono z serwerem
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = Połączyłem już wszystkie trackery
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Cofnij się do ustawień WiFi
+onboarding-assign_trackers-back = Cofnij się do ustawień Wi-Fi
 onboarding-assign_trackers-title = Przydziel Trackery
 onboarding-assign_trackers-description = Wybierzmy gdzie idzie jaki tracker. Naciśnij gdzie chcesz go przydzielić
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/pt-BR/translation.ftl
+++ b/gui/public/i18n/pt-BR/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = Reset Rápido
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = Novo dispositivo de serial detectado!
-serial_detection-new_device-p1 = Insira suas credenciais de wifi!
+serial_detection-new_device-p1 = Insira suas credenciais de Wi-Fi!
 serial_detection-new_device-p2 = Selecione o que quer fazer com ele
-serial_detection-open_wifi = Conectar ao WiFi
+serial_detection-open_wifi = Conectar ao Wi-Fi
 serial_detection-open_serial = Abrir o Console Serial
 serial_detection-submit = Enviar!
 serial_detection-close = Fechar
@@ -351,7 +351,7 @@ settings-osc-vrchat-network-port_out =
     .label = Porta de saída
     .placeholder = Porta de saída (padrão: 9000)
 settings-osc-vrchat-network-address = Endereço de rede
-settings-osc-vrchat-network-address-description = Escolha qual o endereço para enviar dados para o VRChat (verifique as suas opções de wifi no seu dispositivo)
+settings-osc-vrchat-network-address-description = Escolha qual o endereço para enviar dados para o VRChat (verifique as suas opções de Wi-Fi no seu dispositivo)
 settings-osc-vrchat-network-address-placeholder = Endereço de ip do VRChat
 settings-osc-vrchat-network-trackers = Trackers
 settings-osc-vrchat-network-trackers-description = Ligar ou desligar o envio e recepção de dados.
@@ -366,14 +366,14 @@ onboarding-skip = Pular configurações
 onboarding-continue = Continuar
 onboarding-wip = Trabalho em progresso
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Voltar para introdução
-onboarding-wifi_creds = Insira as credenciais de WiFi
+onboarding-wifi_creds = Insira as credenciais de Wi-Fi
 # This cares about multilines
 onboarding-wifi_creds-description =
     Os Trackers vão usar essas credenciais para conectar à rede sem fio
     Use as credenciais da rede em que você está atualmente conectado
-onboarding-wifi_creds-skip = Pular as configurações de WiFi
+onboarding-wifi_creds-skip = Pular as configurações de Wi-Fi
 onboarding-wifi_creds-submit = Enviar!
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -407,15 +407,15 @@ onboarding-done-description = Aproveite sua experiência com full body
 onboarding-done-close = Fechar o guia
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = Voltar para as credenciais de WiFi
+onboarding-connect_tracker-back = Voltar para as credenciais de Wi-Fi
 onboarding-connect_tracker-title = Conectar os trackers
 onboarding-connect_tracker-description-p0 = Agora para a parte divertida, conectando todos os seus trackers!
 onboarding-connect_tracker-description-p1 = Simplesmente conecte todos que ainda não estão conectados, via porta USB.
 onboarding-connect_tracker-issue-serial = Estou tendo problemas para conectar!
 onboarding-connect_tracker-usb = Tracker USB
-onboarding-connect_tracker-connection_status-connecting = Enviando credenciais de wifi
-onboarding-connect_tracker-connection_status-connected = Conectado ao WiFi
-onboarding-connect_tracker-connection_status-error = Não é possível conectar ao WiFi
+onboarding-connect_tracker-connection_status-connecting = Enviando credenciais de Wi-Fi
+onboarding-connect_tracker-connection_status-connected = Conectado ao Wi-Fi
+onboarding-connect_tracker-connection_status-error = Não é possível conectar ao Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = Procurando por trackers
 onboarding-connect_tracker-connection_status-handshake = Conectado ao servidor
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -431,7 +431,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = Eu conectei todos os meus trackers
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = Voltar para as credenciais de WiFi
+onboarding-assign_trackers-back = Voltar para as credenciais de Wi-Fi
 onboarding-assign_trackers-title = Atribuir trackers
 onboarding-assign_trackers-description = Vamos escolher onde cada tracker vai. Clique no local onde você quer colocar o tracker
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals

--- a/gui/public/i18n/vi/translation.ftl
+++ b/gui/public/i18n/vi/translation.ftl
@@ -366,7 +366,7 @@ onboarding-skip = Bỏ qua cài đặt
 onboarding-continue = Tiếp tục
 onboarding-wip = Đang làm dở (vui lòng quay lại sau update)
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = Quay lại đoạn giới thiệuthiệu
 onboarding-wifi_creds = Bỏ thông tin Wi-Fi ở đây
 # This cares about multilines

--- a/gui/public/i18n/zh-Hans/translation.ftl
+++ b/gui/public/i18n/zh-Hans/translation.ftl
@@ -67,9 +67,9 @@ reset-quick = 快速重置
 
 ## Serial detection stuff
 serial_detection-new_device-p0 = 检测到了新的串口设备!
-serial_detection-new_device-p1 = 输入你的 WiFi 凭据!
+serial_detection-new_device-p1 = 输入你的 Wi-Fi 凭据!
 serial_detection-new_device-p2 = 请选择你想对它做什么
-serial_detection-open_wifi = 连接到 WiFi
+serial_detection-open_wifi = 连接到 Wi-Fi
 serial_detection-open_serial = 打开串口控制台
 serial_detection-submit = 提交!
 serial_detection-close = 关闭
@@ -350,7 +350,7 @@ settings-osc-vrchat-network-port_out =
     .label = 输出端口
     .placeholder = 输出端口（默认 9000）
 settings-osc-vrchat-network-address = 网络地址
-settings-osc-vrchat-network-address-description = 选择将数据发送到 VRChat 的地址（检查设备上的 WiFi 设置）
+settings-osc-vrchat-network-address-description = 选择将数据发送到 VRChat 的地址（检查设备上的 Wi-Fi 设置）
 settings-osc-vrchat-network-address-placeholder = VRChat IP 地址
 settings-osc-vrchat-network-trackers = 追踪器
 settings-osc-vrchat-network-trackers-description = 切换数据的发送和接收
@@ -365,14 +365,14 @@ onboarding-skip = 跳过设置
 onboarding-continue = 继续
 onboarding-wip = 仍在开发中
 
-## WiFi setup
+## Wi-Fi setup
 onboarding-wifi_creds-back = 返回简介
-onboarding-wifi_creds = 输入 WiFi 凭据
+onboarding-wifi_creds = 输入 Wi-Fi 凭据
 # This cares about multilines
 onboarding-wifi_creds-description =
-    追踪器将使用这些凭据连接到 WiFi
-    请使用当前连接到 WiFi 的凭据
-onboarding-wifi_creds-skip = 跳过 WiFi 设置
+    追踪器将使用这些凭据连接到 Wi-Fi
+    请使用当前连接到 Wi-Fi 的凭据
+onboarding-wifi_creds-skip = 跳过 Wi-Fi 设置
 onboarding-wifi_creds-submit = 提交！
 onboarding-wifi_creds-ssid =
     .label = SSID
@@ -406,15 +406,15 @@ onboarding-done-description = 享受你的全身追踪体验吧
 onboarding-done-close = 关闭向导
 
 ## Tracker connection setup
-onboarding-connect_tracker-back = 返回到 WiFi 凭据设置
+onboarding-connect_tracker-back = 返回到 Wi-Fi 凭据设置
 onboarding-connect_tracker-title = 连接追踪器
 onboarding-connect_tracker-description-p0 = 来到了我第二喜欢的环节，连接所有的追踪器！
 onboarding-connect_tracker-description-p1 = 只需通过 USB 连接所有尚未连接的设备即可。
 onboarding-connect_tracker-issue-serial = QAQ 我在连接时遇到问题！
 onboarding-connect_tracker-usb = USB 追踪器
-onboarding-connect_tracker-connection_status-connecting = 正在发送 WiFi 凭据
-onboarding-connect_tracker-connection_status-connected = WiFi 已连接
-onboarding-connect_tracker-connection_status-error = 无法连接到 WiFi
+onboarding-connect_tracker-connection_status-connecting = 正在发送 Wi-Fi 凭据
+onboarding-connect_tracker-connection_status-connected = Wi-Fi 已连接
+onboarding-connect_tracker-connection_status-error = 无法连接到 Wi-Fi
 onboarding-connect_tracker-connection_status-start_connecting = 寻找追踪器
 onboarding-connect_tracker-connection_status-handshake = 已连接到服务器
 # $amount (Number) - Amount of trackers connected (this is a number, but you can use CLDR plural rules for your language)
@@ -429,7 +429,7 @@ onboarding-connect_tracker-connected_trackers = { $amount ->
 onboarding-connect_tracker-next = 所有的追踪器都连接好了
 
 ## Tracker assignment setup
-onboarding-assign_trackers-back = 返回 WiFi 凭据设置
+onboarding-assign_trackers-back = 返回 Wi-Fi 凭据设置
 onboarding-assign_trackers-title = 分配追踪器
 onboarding-assign_trackers-description = 让我们选择哪个追踪器在哪里。单击要放置追踪器的部位
 # Look at translation of onboarding-connect_tracker-connected_trackers on how to use plurals


### PR DESCRIPTION
- Wi-Fi is the official spelling, see https://english.stackexchange.com/questions/41180/how-do-you-spell-wifi-wi-fi-wifi
- SSID is causing a lot of confusion amongst users who don't know what it means. Wi-Fi name is easier to understand.