### PR TITLE
Bring back elbow offset

### DIFF
--- a/gui/public/i18n/en-x-owo/translation.ftl
+++ b/gui/public/i18n/en-x-owo/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = uppew awm wength
 skeleton_bone-LOWER_ARM = fowewawm disyance
 skeleton_bone-CONTROLLER_Y = cyontwowla disance y
 skeleton_bone-CONTROLLER_Z = cyontwowla disance z
+skeleton_bone-ELBOW_OFFSET = ewbow awfsewt
 
 ## Tracker reset buttons
 reset-reset_all = weset aww pwopowtions~

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Upper Arm Length
 skeleton_bone-LOWER_ARM = Lower Arm Length
 skeleton_bone-CONTROLLER_Y = Controller Distance Y
 skeleton_bone-CONTROLLER_Z = Controller Distance Z
+skeleton_bone-ELBOW_OFFSET = Elbow Offset
 
 ## Tracker reset buttons
 reset-reset_all = Reset all proportions

--- a/gui/public/i18n/es-419/translation.ftl
+++ b/gui/public/i18n/es-419/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Largo del brazo superior
 skeleton_bone-LOWER_ARM = Distancia del antebrazo
 skeleton_bone-CONTROLLER_Y = Distancia Y del mando
 skeleton_bone-CONTROLLER_Z = Distancia Z del mando
+skeleton_bone-ELBOW_OFFSET = Desplazamiento del codo
 
 ## Tracker reset buttons
 reset-reset_all = Reiniciar todas las proporciones

--- a/gui/public/i18n/et/translation.ftl
+++ b/gui/public/i18n/et/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Õlavarre Pikkus
 skeleton_bone-LOWER_ARM = Käsivarre Kaugus
 skeleton_bone-CONTROLLER_Y = Kontrolleri Kaugus Y
 skeleton_bone-CONTROLLER_Z = Kontrolleri Kaugus Z
+skeleton_bone-ELBOW_OFFSET = Küünarnuki Nihe
 
 ## Tracker reset buttons
 reset-reset_all = Lähtesta kõik proportsioonid

--- a/gui/public/i18n/fr/translation.ftl
+++ b/gui/public/i18n/fr/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Longueur des bras supérieurs
 skeleton_bone-LOWER_ARM = Longueur des avant-bras
 skeleton_bone-CONTROLLER_Y = Distance Y des contrôleurs
 skeleton_bone-CONTROLLER_Z = Distance Z des contrôleurs
+skeleton_bone-ELBOW_OFFSET = Écart des coudes
 
 ## Tracker reset buttons
 reset-reset_all = Réinitialiser toutes les proportions

--- a/gui/public/i18n/it/translation.ftl
+++ b/gui/public/i18n/it/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Lunghezza Braccia
 skeleton_bone-LOWER_ARM = Distanza Avambracci
 skeleton_bone-CONTROLLER_Y = Distanza Y Controller
 skeleton_bone-CONTROLLER_Z = Distanza Z Controller
+skeleton_bone-ELBOW_OFFSET = Correzione Gomito
 
 ## Tracker reset buttons
 reset-reset_all = Ripristina tutte le proporzioni

--- a/gui/public/i18n/ja/translation.ftl
+++ b/gui/public/i18n/ja/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = 上腕長さ
 skeleton_bone-LOWER_ARM = 前腕長さ
 skeleton_bone-CONTROLLER_Y = コントローラ距離 Y
 skeleton_bone-CONTROLLER_Z = コントローラ距離 Z
+skeleton_bone-ELBOW_OFFSET = 肘オフセット
 
 ## Tracker reset buttons
 reset-reset_all = すべてのプロポーションをリセット

--- a/gui/public/i18n/ko/translation.ftl
+++ b/gui/public/i18n/ko/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = 위팔 거리
 skeleton_bone-LOWER_ARM = 전완 길이
 skeleton_bone-CONTROLLER_Y = 컨트롤러 Y축 거리
 skeleton_bone-CONTROLLER_Z = 컨트롤러 Z축 거리
+skeleton_bone-ELBOW_OFFSET = 팔꿈치 오프셋
 
 ## Tracker reset buttons
 reset-reset_all = 모든 신체 비율 리셋

--- a/gui/public/i18n/pl/translation.ftl
+++ b/gui/public/i18n/pl/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Długość Bicepsa
 skeleton_bone-LOWER_ARM = Długość PrzedRamienia
 skeleton_bone-CONTROLLER_Z = Controller Distance Z
 skeleton_bone-CONTROLLER_Y = Controller Distance Y
+skeleton_bone-ELBOW_OFFSET = Offset Łokcia
 
 ## Tracker reset buttons
 reset-reset_all = Zresetuj wszystkie wymiary

--- a/gui/public/i18n/pt-BR/translation.ftl
+++ b/gui/public/i18n/pt-BR/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Tamanho do Braço Superior
 skeleton_bone-LOWER_ARM = Distância do Antebraço
 skeleton_bone-CONTROLLER_Y = Distância do Controle Y
 skeleton_bone-CONTROLLER_Z = Distância do Controle Z
+skeleton_bone-ELBOW_OFFSET = Compensação do Cotovelo
 
 ## Tracker reset buttons
 reset-reset_all = Redefinir todas as proporções

--- a/gui/public/i18n/vi/translation.ftl
+++ b/gui/public/i18n/vi/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = Chiều dài tay trên
 skeleton_bone-LOWER_ARM = khoảng cách cánh tay
 skeleton_bone-CONTROLLER_Y = Khoảng cách tay cầm Y
 skeleton_bone-CONTROLLER_Z = Khoảng cách tay cầm Z
+skeleton_bone-ELBOW_OFFSET = Lệch đo khuỷu tay
 
 ## Tracker reset buttons
 reset-reset_all = Reset tất cả bộ phận

--- a/gui/public/i18n/zh-Hans/translation.ftl
+++ b/gui/public/i18n/zh-Hans/translation.ftl
@@ -58,6 +58,7 @@ skeleton_bone-UPPER_ARM = 上臂长度
 skeleton_bone-LOWER_ARM = 前臂距离
 skeleton_bone-CONTROLLER_Y = 控制器距离 Y
 skeleton_bone-CONTROLLER_Z = 控制器距离 Z
+skeleton_bone-ELBOW_OFFSET = 肘部偏移
 
 ## Tracker reset buttons
 reset-reset_all = 重置所有比例

--- a/server/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfig.java
+++ b/server/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfig.java
@@ -329,6 +329,12 @@ public class SkeletonConfig {
 				getOffset(SkeletonConfigOffsets.CONTROLLER_Y),
 				getOffset(SkeletonConfigOffsets.CONTROLLER_Z)
 			);
+			case LEFT_ELBOW_TRACKER, RIGHT_ELBOW_TRACKER -> setNodeOffset(
+				nodeOffset,
+				0,
+				getOffset(SkeletonConfigOffsets.ELBOW_OFFSET),
+				0
+			);
 		}
 	}
 

--- a/server/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigOffsets.java
+++ b/server/src/main/java/dev/slimevr/vr/processor/skeleton/SkeletonConfigOffsets.java
@@ -123,6 +123,12 @@ public enum SkeletonConfigOffsets {
 		0.13f,
 		new BoneType[] { BoneType.LEFT_CONTROLLER, BoneType.RIGHT_CONTROLLER,
 			BoneType.LEFT_HAND, BoneType.RIGHT_HAND }
+	),
+	ELBOW_OFFSET(
+		20,
+		"elbowOffset",
+		0.0f,
+		new BoneType[] { BoneType.LEFT_ELBOW_TRACKER, BoneType.RIGHT_ELBOW_TRACKER }
 	),;
 
 	public static final SkeletonConfigOffsets[] values = values();


### PR DESCRIPTION
I remove the elbow offset in https://github.com/SlimeVR/SlimeVR-Server/pull/443, but I forgot it was actually used for better shoulder tracking from controllers, and now, to compensate for VRChat's calibration mapping the elbows to the chest.

~~Needs https://github.com/SlimeVR/SolarXR-Protocol/pull/87~~ merged