### PR TITLE
Use `cache-apt-pkgs-action` for apt instead

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -36,9 +36,13 @@ jobs:
 
       - if: matrix.os == 'ubuntu-20.04'
         name: Set up Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+          # Increment to invalidate the cache
+          version: 1.0
+          # Enables a workaround to attempt to run pre and post install scripts
+          execute_install_scripts: true
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -43,6 +43,8 @@ jobs:
           version: 1.0
           # Enables a workaround to attempt to run pre and post install scripts
           execute_install_scripts: true
+          # Disables uploading logs as a build artifact
+          debug: false
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -80,9 +80,13 @@ jobs:
           path: server/build/libs/
 
       - name: Set up Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf libfuse2
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf libfuse2
+          # Increment to invalidate the cache
+          version: 1.0
+          # Enables a workaround to attempt to run pre and post install scripts
+          execute_install_scripts: true
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -87,6 +87,8 @@ jobs:
           version: 1.0
           # Enables a workaround to attempt to run pre and post install scripts
           execute_install_scripts: true
+          # Disables uploading logs as a build artifact
+          debug: false
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Replaces `apt`/`apt-get` calls with https://github.com/marketplace/actions/cache-apt-packages

This is attempting to workaround build errors with the current workflow files by using Ubuntu repos directly and caching the packages instead of re-downloading every time. This should hopefully save some time on workflows.

As an alternative, this fix can be considered, but may slow down the workflow significantly: https://github.com/adafruit/ci-arduino/commit/e0fdb88014c2b8f369358d6f0e6d5aabfcf35131