### PR TITLE
Improve config reliability

### DIFF
--- a/server/src/main/java/dev/slimevr/config/ConfigManager.java
+++ b/server/src/main/java/dev/slimevr/config/ConfigManager.java
@@ -9,8 +9,10 @@ import com.jme3.math.Quaternion;
 import dev.slimevr.config.serializers.QuaternionDeserializer;
 import dev.slimevr.config.serializers.QuaternionSerializer;
 import io.eiren.util.ann.ThreadSafe;
+import io.eiren.util.logging.LogManager;
 
 import java.io.*;
+import java.nio.file.*;
 
 
 public class ConfigManager {
@@ -40,6 +42,9 @@ public class ConfigManager {
 		} catch (FileNotFoundException e) {
 			// Config file didn't exist, is not an error
 		} catch (IOException e) {
+			// Make a backup of the erroneous config
+			backupConfig();
+			// Re-throw the exception
 			throw new RuntimeException(e);
 		}
 
@@ -48,14 +53,79 @@ public class ConfigManager {
 		}
 	}
 
-	@ThreadSafe
-	public synchronized void saveConfig() {
-		File cfgFile = new File(configPath);
+	public void atomicMove(Path from, Path to) throws IOException {
+		try {
+			// Atomic move to overwrite
+			Files.move(from, to, StandardCopyOption.ATOMIC_MOVE);
+		} catch (AtomicMoveNotSupportedException | FileAlreadyExistsException e) {
+			// Atomic move not supported or does not replace, try just replacing
+			Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	public void backupConfig() {
+		Path cfgFile = Path.of(configPath);
+		Path tmpBakCfgFile = Path.of(configPath + ".bak.tmp");
+		Path bakCfgFile = Path.of(configPath + ".bak");
 
 		try {
-			om.writeValue(cfgFile, this.vrConfig);
+			Files
+				.copy(
+					cfgFile,
+					tmpBakCfgFile,
+					StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.COPY_ATTRIBUTES
+				);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LogManager
+				.severe(
+					"Unable to make backup copy of config from \""
+						+ cfgFile
+						+ "\" to \""
+						+ tmpBakCfgFile
+						+ "\"",
+					e
+				);
+			return; // Abort write
+		}
+
+		try {
+			atomicMove(tmpBakCfgFile, bakCfgFile);
+		} catch (IOException e) {
+			LogManager
+				.severe(
+					"Unable to move backup config from \""
+						+ tmpBakCfgFile
+						+ "\" to \""
+						+ bakCfgFile
+						+ "\"",
+					e
+				);
+		}
+	}
+
+	@ThreadSafe
+	public synchronized void saveConfig() {
+		Path tmpCfgFile = Path.of(configPath + ".tmp");
+		Path cfgFile = Path.of(configPath);
+
+		// Serialize config
+		try {
+			om.writeValue(tmpCfgFile.toFile(), this.vrConfig);
+		} catch (IOException e) {
+			LogManager.severe("Unable to write serialized config to \"" + tmpCfgFile + "\"", e);
+			return; // Abort write
+		}
+
+		// Overwrite old config
+		try {
+			atomicMove(tmpCfgFile, cfgFile);
+		} catch (IOException e) {
+			LogManager
+				.severe(
+					"Unable to move new config from \"" + tmpCfgFile + "\" to \"" + cfgFile + "\"",
+					e
+				);
 		}
 	}
 

--- a/server/src/main/java/dev/slimevr/config/VRConfig.java
+++ b/server/src/main/java/dev/slimevr/config/VRConfig.java
@@ -146,7 +146,7 @@ public class VRConfig {
 		tracker.writeConfig(tc);
 	}
 
-	public BridgeConfig getBrige(String bridgeKey) {
+	public BridgeConfig getBridge(String bridgeKey) {
 		BridgeConfig config = bridges.get(bridgeKey);
 		if (config == null) {
 			config = new BridgeConfig();

--- a/server/src/main/java/dev/slimevr/platform/SteamVRBridge.java
+++ b/server/src/main/java/dev/slimevr/platform/SteamVRBridge.java
@@ -32,7 +32,7 @@ public abstract class SteamVRBridge extends ProtobufBridge<VRTracker> implements
 		this.bridgeSettingsKey = bridgeSettingsKey;
 		this.runnerThread = new Thread(this, threadName);
 		this.shareableTrackers = shareableTrackers;
-		this.config = server.getConfigManager().getVrConfig().getBrige(bridgeSettingsKey);
+		this.config = server.getConfigManager().getVrConfig().getBridge(bridgeSettingsKey);
 	}
 
 	@Override


### PR DESCRIPTION
Based on notes from my message at https://discord.com/channels/817184208525983775/948579740225261598/1054723637673996350

Should be able to write the atomically and handle errors better without losing data, also makes a backup of the config when load fails:
- For writing, writes to `vrconfig.yml.tmp` then atomically moves to `vrconfig.yml`
- For loading errors, copies to `vrconfig.yml.bak.tmp` then atomically moves to `vrconfig.yml.bak`