### PR TITLE
Improve reset code and make it so VRTrackers can reset

### DIFF
--- a/server/src/main/java/com/jme3/math/Quaternion.java
+++ b/server/src/main/java/com/jme3/math/Quaternion.java
@@ -1494,9 +1494,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	/**
 	 * <code>inverse</code> returns the inverse of this quaternion as a new
 	 * quaternion. If this quaternion does not have an inverse (if its normal is
-	 * 0 or less), then null is returned.
+	 * 0 or less), then this quaternion is returned.
 	 *
-	 * @return the inverse of this quaternion or null if the inverse does not
+	 * @return the inverse of this quaternion or itself if the inverse does not
 	 * exist.
 	 */
 	public Quaternion inverse() {
@@ -1512,9 +1512,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	/**
 	 * <code>inverse</code> returns the inverse of this quaternion. If this
 	 * quaternion does not have an inverse (if its normal is 0 or less), then
-	 * null is returned.
+	 * this quaternion is returned.
 	 *
-	 * @return the inverse of this quaternion or null if the inverse does not
+	 * @return the inverse of this quaternion or itself if the inverse does not
 	 * exist.
 	 */
 	public Quaternion inverse(Quaternion store) {
@@ -1523,8 +1523,8 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 			float invNorm = 1.0f / norm;
 			return store.set(-x * invNorm, -y * invNorm, -z * invNorm, w * invNorm);
 		}
-		// return an invalid result to flag the error
-		return null;
+		// return itself since it has no inverse
+		return this;
 	}
 
 	/**

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -458,7 +458,7 @@ public class IMUTracker
 	private void fixGyroscope(Quaternion sensorRotation) {
 		sensorRotation = sensorRotation.clone();
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
-		gyroFix.set(sensorRotation.inverse());
+		gyroFix.set(sensorRotation).inverseLocal();
 	}
 
 	private void fixAttachment(Quaternion sensorRotation) {

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -509,7 +509,7 @@ public class IMUTracker
 
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
 
-		yawFix.set(sensorRotation).inverseLocal().multLocal(reference);
+		yawFix.set(sensorRotation.inverseLocal().multLocal(reference));
 	}
 
 	private void calibrateMag() {

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -407,6 +407,7 @@ public class IMUTracker
 		fixAttachment(getMountedAdjustedRotation());
 		makeIdentityAdjustmentQuatsFull();
 		fixYaw(getMountedAdjustedRotation(), reference);
+		calibrateMag();
 		calculateDrift(rot);
 	}
 

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -253,7 +253,7 @@ public class IMUTracker
 	 * Calculates reference-adjusted rotation (with full/quick reset) including
 	 * the mounting orientation (front, back, left, right) and mounting reset
 	 * adjustment. Also taking drift compensation into account.
-	 * 
+	 *
 	 * @param store Where to store the calculation result.
 	 */
 	@Override
@@ -406,8 +406,7 @@ public class IMUTracker
 		fixGyroscope(getMountedAdjustedRotation());
 		fixAttachment(getMountedAdjustedRotation());
 		makeIdentityAdjustmentQuatsFull();
-		fixYaw(reference);
-		calibrateMag();
+		fixYaw(getMountedAdjustedRotation(), reference);
 		calculateDrift(rot);
 	}
 
@@ -421,7 +420,7 @@ public class IMUTracker
 	@Override
 	public void resetYaw(Quaternion reference) {
 		Quaternion rot = getAdjustedRawRotation();
-		fixYaw(reference);
+		fixYaw(getMountedAdjustedRotation(), reference);
 		makeIdentityAdjustmentQuatsYaw();
 		calibrateMag();
 		calculateDrift(rot);
@@ -432,7 +431,7 @@ public class IMUTracker
 	 * mounting-reset-adjusted by applying quaternions produced after
 	 * {@link #resetFull(Quaternion)}, {@link #resetYaw(Quaternion)} and
 	 * {@link #resetMounting(boolean)}.
-	 * 
+	 *
 	 * @param store Raw or filtered rotation to mutate.
 	 */
 	protected void adjustToReference(Quaternion store) {
@@ -456,13 +455,15 @@ public class IMUTracker
 	}
 
 	private void fixGyroscope(Quaternion sensorRotation) {
+		sensorRotation = sensorRotation.clone();
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
-		gyroFix.set(sensorRotation).inverseLocal();
+		gyroFix.set(sensorRotation.inverse());
 	}
 
 	private void fixAttachment(Quaternion sensorRotation) {
+		sensorRotation = sensorRotation.clone();
 		gyroFix.mult(sensorRotation, sensorRotation);
-		attachmentFix.set(sensorRotation).inverseLocal();
+		attachmentFix.set(sensorRotation.inverse());
 	}
 
 	@Override
@@ -490,24 +491,24 @@ public class IMUTracker
 		mountRotFix.set(buffer);
 
 		// Get the difference from the last adjustment
-		buffer.multLocal(lastRotAdjust.inverseLocal());
+		buffer.multLocal(lastRotAdjust.inverse());
 		// Apply the yaw rotation difference to the yaw fix quaternion
-		yawFix.multLocal(buffer.inverseLocal());
+		yawFix.multLocal(buffer.inverse());
 	}
 
-	private void fixYaw(Quaternion reference) {
+	private void fixYaw(Quaternion sensorRotation, Quaternion reference) {
 		// Use only yaw HMD rotation
-		Quaternion targetRotation = reference.clone();
-		targetRotation.fromAngles(0, targetRotation.getYaw(), 0);
+		reference = reference.clone();
+		reference.fromAngles(0, reference.getYaw(), 0);
 
-		Quaternion sensorRotation = getMountedAdjustedRotation();
+		sensorRotation = sensorRotation.clone();
 		gyroFix.mult(sensorRotation, sensorRotation);
 		sensorRotation.multLocal(attachmentFix);
 		sensorRotation.multLocal(mountRotFix);
 
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
 
-		yawFix.set(sensorRotation).inverseLocal().multLocal(targetRotation);
+		yawFix.set(sensorRotation.inverse().mult(reference));
 	}
 
 	private void calibrateMag() {
@@ -515,7 +516,7 @@ public class IMUTracker
 			magnetometerCalibrated = true;
 			// During calibration set correction to match magnetometer readings
 			// TODO : Correct only yaw
-			correction.set(rotQuaternion).inverseLocal().multLocal(rotMagQuaternion);
+			correction.set(rotQuaternion.inverse().mult(rotMagQuaternion));
 		}
 	}
 
@@ -523,7 +524,7 @@ public class IMUTracker
 	 * Calculates drift since last reset and store the data related to it in
 	 * driftQuat, timeAtLastReset and timeForLastReset
 	 */
-	synchronized private void calculateDrift(Quaternion beforeQuat) {
+	private void calculateDrift(Quaternion beforeQuat) {
 		if (compensateDrift && allowDriftCompensation) {
 			Quaternion rotQuat = getAdjustedRawRotation();
 

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -464,7 +464,7 @@ public class IMUTracker
 	private void fixAttachment(Quaternion sensorRotation) {
 		sensorRotation = sensorRotation.clone();
 		gyroFix.mult(sensorRotation, sensorRotation);
-		attachmentFix.set(sensorRotation.inverse());
+		attachmentFix.set(sensorRotation.inverseLocal());
 	}
 
 	@Override
@@ -492,9 +492,9 @@ public class IMUTracker
 		mountRotFix.set(buffer);
 
 		// Get the difference from the last adjustment
-		buffer.multLocal(lastRotAdjust.inverse());
+		buffer.multLocal(lastRotAdjust.inverseLocal());
 		// Apply the yaw rotation difference to the yaw fix quaternion
-		yawFix.multLocal(buffer.inverse());
+		yawFix.multLocal(buffer.inverseLocal());
 	}
 
 	private void fixYaw(Quaternion sensorRotation, Quaternion reference) {
@@ -509,7 +509,7 @@ public class IMUTracker
 
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
 
-		yawFix.set(sensorRotation.inverse().mult(reference));
+		yawFix.set(sensorRotation).inverseLocal().multLocal(reference);
 	}
 
 	private void calibrateMag() {
@@ -517,7 +517,7 @@ public class IMUTracker
 			magnetometerCalibrated = true;
 			// During calibration set correction to match magnetometer readings
 			// TODO : Correct only yaw
-			correction.set(rotQuaternion.inverse().mult(rotMagQuaternion));
+			correction.set(rotQuaternion).inverseLocal().multLocal(rotMagQuaternion);
 		}
 	}
 

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -458,7 +458,7 @@ public class IMUTracker
 	private void fixGyroscope(Quaternion sensorRotation) {
 		sensorRotation = sensorRotation.clone();
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
-		gyroFix.set(sensorRotation).inverseLocal();
+		gyroFix.set(sensorRotation.inverseLocal());
 	}
 
 	private void fixAttachment(Quaternion sensorRotation) {

--- a/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/IMUTracker.java
@@ -281,6 +281,16 @@ public class IMUTracker
 
 	private Quaternion getMountedAdjustedRotation() {
 		Quaternion rot = new Quaternion(rotQuaternion);
+		// correction.mult(store, store); // Correction is not used now to
+		// prevent accidental errors while debugging other things
+		rot.multLocal(mountAdjust);
+		return rot;
+	}
+
+	private Quaternion getMountedAdjustedDriftRotation() {
+		Quaternion rot = new Quaternion(rotQuaternion);
+		// correction.mult(store, store); // Correction is not used now to
+		// prevent accidental errors while debugging other things
 		rot.multLocal(mountAdjust);
 		if ((compensateDrift && allowDriftCompensation) && totalDriftTime > 0) {
 			rot
@@ -398,7 +408,7 @@ public class IMUTracker
 	@Override
 	public void resetMounting(boolean reverseYaw) {
 		// Get the current calibrated rotation
-		Quaternion buffer = getMountedAdjustedRotation();
+		Quaternion buffer = getMountedAdjustedDriftRotation();
 		gyroFix.mult(buffer, buffer);
 		buffer.multLocal(attachmentFix);
 
@@ -450,10 +460,10 @@ public class IMUTracker
 	}
 
 	/**
-	 * Calculates 1 since last reset and store the data related to it in
+	 * Calculates drift since last reset and store the data related to it in
 	 * driftQuat, timeAtLastReset and timeForLastReset
 	 */
-	synchronized public void calculateDrift(Quaternion beforeQuat) {
+	synchronized private void calculateDrift(Quaternion beforeQuat) {
 		if (compensateDrift && allowDriftCompensation) {
 			Quaternion rotQuat = getAdjustedRawRotation();
 
@@ -471,11 +481,10 @@ public class IMUTracker
 				// Add new drift quaternion
 				driftQuats
 					.add(
-						new Quaternion()
-							.fromAngles(
-								0f,
-								rotQuat.mult(beforeQuat.inverse()).getYaw(),
-								0f
+						rotQuat
+							.fromAngles(0, rotQuat.getYaw(), 0)
+							.mult(
+								beforeQuat.fromAngles(0, beforeQuat.getYaw(), 0).inverse()
 							)
 					);
 
@@ -512,23 +521,25 @@ public class IMUTracker
 				averagedDriftQuat.fromAveragedQuaternions(driftQuats, driftWeights);
 
 				// Save tracker rotation and current time
-				rotationSinceReset.set(rotQuat.mult(beforeQuat.inverse()));
+				rotationSinceReset.set(driftQuats.getLatest());
 				timeAtLastReset = System.currentTimeMillis();
 			} else if (
 				System.currentTimeMillis() - timeAtLastReset < DRIFT_COOLDOWN_MS
 					&& driftQuats.size() > 0
 			) {
 				// Replace latest drift quaternion
-				rotationSinceReset.multLocal(beforeQuat.mult(rotQuat.inverse()));
+				rotationSinceReset
+					.multLocal(
+						rotQuat
+							.fromAngles(0, rotQuat.getYaw(), 0)
+							.mult(
+								beforeQuat.fromAngles(0, beforeQuat.getYaw(), 0).inverse()
+							)
+					);
 				driftQuats
 					.set(
 						driftQuats.size() - 1,
-						new Quaternion()
-							.fromAngles(
-								0f,
-								rotationSinceReset.inverse().getYaw(),
-								0f
-							)
+						rotationSinceReset
 					);
 
 				// Add drift time to total

--- a/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
@@ -36,6 +36,8 @@ public class VRTracker extends ComputedTracker {
 		return true;
 	}
 
+	// TODO Reduce code duplication from IMUTracker.java
+	// Refactor all tracker classes into one?
 	protected void adjustInternal(Quaternion store) {
 		store.multLocal(attachmentFix);
 		store.multLocal(mountFix);

--- a/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
@@ -56,10 +56,8 @@ public class VRTracker extends ComputedTracker {
 	}
 
 	private void fixAttachment(Quaternion sensorRotation, Quaternion reference) {
-		reference = reference.clone();
 		mountFix.fromAngles(0, reference.getYaw(), 0);
 
-		sensorRotation = sensorRotation.clone();
 		attachmentFix.set(sensorRotation.inverse());
 	}
 
@@ -74,7 +72,7 @@ public class VRTracker extends ComputedTracker {
 
 		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
 
-		yawFix.set(sensorRotation.inverse().mult(reference));
+		yawFix.set(sensorRotation).inverseLocal().multLocal(reference);
 	}
 
 	@Override

--- a/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
+++ b/server/src/main/java/dev/slimevr/vr/trackers/VRTracker.java
@@ -1,5 +1,6 @@
 package dev.slimevr.vr.trackers;
 
+import com.jme3.math.Quaternion;
 import dev.slimevr.vr.Device;
 import io.eiren.util.BufferedTimer;
 
@@ -7,6 +8,9 @@ import io.eiren.util.BufferedTimer;
 public class VRTracker extends ComputedTracker {
 
 	protected BufferedTimer timer = new BufferedTimer(1f);
+	public final Quaternion mountFix = new Quaternion();
+	public final Quaternion attachmentFix = new Quaternion();
+	public final Quaternion yawFix = new Quaternion();
 
 	public VRTracker(
 		int id,
@@ -21,6 +25,54 @@ public class VRTracker extends ComputedTracker {
 
 	public VRTracker(int id, String name, boolean hasRotation, boolean hasPosition) {
 		super(id, name, name, hasRotation, hasPosition, null);
+	}
+
+	@Override
+	public boolean getRotation(Quaternion store) {
+		store.set(rotation);
+		// Don't adjust if tracker is HMD/Head (use raw rotation)
+		if (super.getBodyPosition() != TrackerPosition.HMD)
+			adjustInternal(store);
+		return true;
+	}
+
+	protected void adjustInternal(Quaternion store) {
+		store.multLocal(attachmentFix);
+		store.multLocal(mountFix);
+		yawFix.mult(store, store);
+	}
+
+	@Override
+	public void resetFull(Quaternion reference) {
+		fixAttachment(rotation, reference);
+		fixYaw(rotation, reference);
+	}
+
+	@Override
+	public void resetYaw(Quaternion reference) {
+		fixYaw(rotation, reference);
+	}
+
+	private void fixAttachment(Quaternion sensorRotation, Quaternion reference) {
+		reference = reference.clone();
+		mountFix.fromAngles(0, reference.getYaw(), 0);
+
+		sensorRotation = sensorRotation.clone();
+		attachmentFix.set(sensorRotation.inverse());
+	}
+
+	private void fixYaw(Quaternion sensorRotation, Quaternion reference) {
+		// Use only yaw HMD rotation
+		reference = reference.clone();
+		reference.fromAngles(0, reference.getYaw(), 0);
+
+		sensorRotation = sensorRotation.clone();
+		sensorRotation.multLocal(attachmentFix);
+		sensorRotation.multLocal(mountFix);
+
+		sensorRotation.fromAngles(0, sensorRotation.getYaw(), 0);
+
+		yawFix.set(sensorRotation.inverse().mult(reference));
 	}
 
 	@Override


### PR DESCRIPTION
- Improves some reset code and make sure none of the fix___ methods are modifying the tracker's rotation (which they were, and it caused trackers to jump for a frame sometimes when resetting)
- Make it so VRTrackers (Vive trackers) can align to HMD when resetting and quick resetting. First step in supporting Vive trackers... this will already make them more usable!