### PR TITLE
Better JVM detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c401e795850edb4e9fdde5940f856364f0fbab573e8dea58f6ee5f85fcf471d"
+checksum = "8da90bd2a722461267a2c5d20b2c6de76dba087348e60484fd6c3fbb48b766d6"
 dependencies = [
  "const_format",
  "git2",
@@ -2609,10 +2609,12 @@ dependencies = [
 name = "slimevr"
 version = "0.0.0"
 dependencies = [
+ "cfg-if",
  "cfg_aliases",
  "clap",
  "clap-verbosity-flag",
  "const_format",
+ "glob",
  "log",
  "open",
  "pretty_env_logger",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -11,9 +11,6 @@ rust-version = "1.65"
 default-run = "slimevr"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[profile.release]
-lto = true
-codegen-units = 1
 
 [features]
 # by default Tauri runs in production mode

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -11,6 +11,9 @@ rust-version = "1.65"
 default-run = "slimevr"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+lto = true
+codegen-units = 1
 
 [features]
 # by default Tauri runs in production mode
@@ -23,7 +26,7 @@ custom-protocol = ["tauri/custom-protocol"]
 [build-dependencies]
 tauri-build = { version = "1.2", features = [] }
 cfg_aliases = "0.1"
-shadow-rs = "0.19"
+shadow-rs = "0.20"
 
 [dependencies]
 serde_json = "1"
@@ -36,10 +39,12 @@ clap-verbosity-flag = "2"
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/tauri-plugin-window-state", rev = "refs/pull/52/head" }
 rand = "0.8.5"
 tempfile = "3"
-which = "4.3.0"
+which = "4.3"
+glob = "0.3"
 open = "3"
-shadow-rs = { version = "0.19", default-features = false }
+shadow-rs = { version = "0.20", default-features = false }
 const_format = "0.2.30"
+cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ glob = "0.3"
 open = "3"
 shadow-rs = { version = "0.20", default-features = false }
 const_format = "0.2.30"
-cfg-if = "1.0.0"
+cfg-if = "1"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "1"

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -63,7 +63,7 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 		}
 	}
 
-	// This is only for AppImage
+	// AppImage passes the path in `APPDIR` env var.
 	if let Some(appimage) = env::var_os("APPDIR") {
 		let path = PathBuf::from(appimage);
 		if is_valid_path(&path) {

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -63,9 +63,9 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 		env::var_os("APPDIR").map(|x| PathBuf::from(x)),
 		env::current_dir().ok(),
 		Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
-		Some(PathBuf::from("/usr/share/slimevr/")),
 		// For flatpak container
 		Some(PathBuf::from("/app/share/slimevr/")),
+		Some(PathBuf::from("/usr/share/slimevr/")),
 	];
 	paths
 		.into_iter()

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -64,6 +64,8 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 		env::current_dir().ok(),
 		Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
 		Some(PathBuf::from("/usr/share/slimevr/")),
+		// For flatpak container
+		Some(PathBuf::from("/app/share/slimevr/")),
 	];
 	paths
 		.into_iter()

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -65,7 +65,10 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 		Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
 		Some(PathBuf::from("/usr/share/slimevr/")),
 	];
-	paths.iter().filter_map(|x| *x).find(|x| is_valid_path(x))
+	paths
+		.into_iter()
+		.filter_map(|x| x)
+		.find(|x: &PathBuf| is_valid_path(x))
 }
 
 fn spawn_java(java: &OsStr, java_version: &OsStr) -> std::io::Result<Child> {

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -15,7 +15,6 @@ use shadow_rs::shadow;
 use tauri::api::process::Command;
 use tauri::Manager;
 use tempfile::Builder;
-use which::which_all;
 
 #[cfg(windows)]
 /// For Commands on Windows so they dont create terminals
@@ -64,6 +63,14 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 		}
 	}
 
+	// This is only for AppImage
+	if let Some(appimage) = env::var_os("APPDIR") {
+		let path = PathBuf::from(appimage);
+		if is_valid_path(&path) {
+			return Some(path);
+		}
+	}
+
 	let path = env::current_dir().unwrap();
 	if is_valid_path(&path) {
 		return Some(path);
@@ -77,14 +84,6 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 	let path = PathBuf::from("/usr/share/slimevr/");
 	if is_valid_path(&path) {
 		return Some(path);
-	}
-
-	// This is only for AppImage
-	if let Some(appimage) = env::var_os("APPDIR") {
-		let path = PathBuf::from(appimage);
-		if is_valid_path(&path) {
-			return Some(path);
-		}
 	}
 
 	None
@@ -306,7 +305,23 @@ fn valid_java_paths() -> Vec<(OsString, i32)> {
 
 	// Otherwise check if anything else is a supported version
 	let mut childs = vec![];
-	for java in which_all(JAVA_BIN).unwrap() {
+	cfg_if::cfg_if! {
+		if #[cfg(target_os = "macos")] {
+			// TODO: Actually use macOS paths
+			let libs = which::which_all(JAVA_BIN);
+		} else if #[cfg(unix)] {
+			// Linux JVMs are saved on /usr/lib/jvm from what I found out,
+			// there is usually a default dir and a default-runtime dir also which are linked
+			// to the current default runtime and the current default JDK (I think it's JDK)
+			let libs = glob::glob(concatcp!("/usr/lib/jvm/*/bin/", JAVA_BIN))
+				.unwrap()
+				.filter_map(|res| res.ok());
+		} else {
+			let libs = which::which_all(JAVA_BIN);
+		}
+	}
+
+	for java in libs {
 		let res = spawn_java(java.as_os_str(), java_version.as_os_str());
 
 		match res {

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -68,7 +68,7 @@ fn get_launch_path(cli: Cli) -> Option<PathBuf> {
 	paths
 		.into_iter()
 		.filter_map(|x| x)
-		.find(|x: &PathBuf| is_valid_path(x))
+		.find(|x| is_valid_path(x))
 }
 
 fn spawn_java(java: &OsStr, java_version: &OsStr) -> std::io::Result<Child> {

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::panic;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Stdio};
 
 use clap::Parser;
@@ -52,7 +52,7 @@ struct Cli {
 	verbose: clap_verbosity_flag::Verbosity,
 }
 
-fn is_valid_path(path: &PathBuf) -> bool {
+fn is_valid_path(path: &Path) -> bool {
 	path.join("slimevr.jar").exists()
 }
 

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -298,9 +298,9 @@ fn valid_java_paths() -> Vec<(OsString, i32)> {
 		.expect("Couldn't execute the main Java binary")
 		.code()
 	{
-		// if main_child >= MINIMUM_JAVA_VERSION {
-		// 	return vec![(main_java, main_child)];
-		// }
+		if main_child >= MINIMUM_JAVA_VERSION {
+			return vec![(main_java, main_child)];
+		}
 	}
 
 	// Otherwise check if anything else is a supported version

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -298,9 +298,9 @@ fn valid_java_paths() -> Vec<(OsString, i32)> {
 		.expect("Couldn't execute the main Java binary")
 		.code()
 	{
-		if main_child >= MINIMUM_JAVA_VERSION {
-			return vec![(main_java, main_child)];
-		}
+		// if main_child >= MINIMUM_JAVA_VERSION {
+		// 	return vec![(main_java, main_child)];
+		// }
 	}
 
 	// Otherwise check if anything else is a supported version
@@ -308,7 +308,7 @@ fn valid_java_paths() -> Vec<(OsString, i32)> {
 	cfg_if::cfg_if! {
 		if #[cfg(target_os = "macos")] {
 			// TODO: Actually use macOS paths
-			let libs = which::which_all(JAVA_BIN);
+			let libs = which::which_all(JAVA_BIN).unwrap();
 		} else if #[cfg(unix)] {
 			// Linux JVMs are saved on /usr/lib/jvm from what I found out,
 			// there is usually a default dir and a default-runtime dir also which are linked
@@ -317,7 +317,7 @@ fn valid_java_paths() -> Vec<(OsString, i32)> {
 				.unwrap()
 				.filter_map(|res| res.ok());
 		} else {
-			let libs = which::which_all(JAVA_BIN);
+			let libs = which::which_all(JAVA_BIN).unwrap();
 		}
 	}
 


### PR DESCRIPTION
Added conditionals depending on OS, now Linux does it's own JVM detection based on ``/usr/lib/jvm``.
Also left a macOS one because it makes the ``#[cfg()]`` a lot cleaner and I just need to actually test it (I know where macOS saves them but I still want to test it).
I prioritized the ``APPDIR`` env just in case, because if we are using AppImage, we should trust the jar we have instead of a relative dir one.
I also kind of crept in some optimizations on the release build for less bin size... :eyes:
