### PR TITLE
Maintain compatibility with Java 19

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.ByteArrayOutputStream
 
 plugins {
-	kotlin("jvm") version "1.7.21"
+	kotlin("jvm") version "1.8.0"
 	application
 	id("com.github.johnrengelman.shadow") version "7.1.2"
 	id("com.diffplug.spotless") version "6.12.0"


### PR DESCRIPTION
Changed the version of some packages to maintain compatibility with Java 19.
For backwards compatibility, I did not change the target Java version but I hope to update it sometime..!

Would it be okay to merge this?
(If not, is this an auto-managed part?)