### PR TITLE
Add a way to override current locale

### DIFF
--- a/gui/src/i18n/config.tsx
+++ b/gui/src/i18n/config.tsx
@@ -83,7 +83,7 @@ export const langs = [
 // AppConfig path: https://docs.rs/tauri/1.2.4/tauri/api/path/fn.config_dir.html
 // We doing this only once, don't want an override check to be done on runtime,
 // only on launch :P
-const overrideLangExists = await exists(OVERRIDE_FILENAME, {
+const overrideLangExists = exists(OVERRIDE_FILENAME, {
   dir: BaseDirectory.AppConfig,
 });
 
@@ -136,7 +136,7 @@ export function AppLocalizationProvider(props: AppLocalizationProviderProps) {
     );
     setCurrentLocales([currentLocale]);
 
-    const currentLocaleFile: [string, string] = overrideLangExists
+    const currentLocaleFile: [string, string] = (await overrideLangExists)
       ? [
           // TODO: Fix, actually detect the locale being used somehow...
           'en-US',

--- a/gui/src/i18n/config.tsx
+++ b/gui/src/i18n/config.tsx
@@ -9,7 +9,6 @@ import {
   createContext,
   useContext,
 } from 'react';
-import { ConfigContext, ConfigContextC } from '../hooks/config';
 import { exists, readTextFile, BaseDirectory } from '@tauri-apps/api/fs';
 
 
@@ -138,8 +137,7 @@ export function AppLocalizationProvider(props: AppLocalizationProviderProps) {
 
     const currentLocaleFile: [string, string] = (await overrideLangExists)
       ? [
-          // TODO: Fix, actually detect the locale being used somehow...
-          'en-US',
+          currentLocale,
           await readTextFile(OVERRIDE_FILENAME, {
             dir: BaseDirectory.AppConfig,
           }),


### PR DESCRIPTION
Current behavior is simple, if [config dir](https://docs.rs/tauri/1.2.4/tauri/api/path/fn.config_dir.html) contains a file called ``override.ftl``, it will be used instead of the selected locale in the language menu. It's loaded as the current type of locale which means number formatting, plural rules and etc won't work correctly...

The main usage for this is for testing locales without having to compile the GUI.