### PR TITLE
fix: websocket fail to bind to address due to time_wait

### DIFF
--- a/server/src/main/java/dev/slimevr/websocketapi/WebsocketAPI.java
+++ b/server/src/main/java/dev/slimevr/websocketapi/WebsocketAPI.java
@@ -28,6 +28,7 @@ public class WebsocketAPI extends WebSocketServer implements ProtocolAPIServer {
 		this.protocolAPI = protocolAPI;
 
 		this.protocolAPI.registerAPIServer(this);
+		setReuseAddr(true);
 	}
 
 	@Override


### PR DESCRIPTION
Related to: #515 

setReuseAddr(true) is the Setter for soReuseAddr Enable/disable SO_REUSEADDR for the socket

SO_REUSEADDR allows the server to bind to an address which is in a TIME_WAIT state

https://www.javadoc.io/doc/org.java-websocket/Java-WebSocket/1.3.5/org/java_websocket/server/WebSocketServer.html