### PR TITLE
docs: include java version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ cd SlimeVR-Server
 
 Now you can open the codebase in your favorite IDE or text editor.
 
+### Installing Java
+The codebase is required to build with Java version 11 or higher.
+
+```bash
+# Check java version
+java --version
+```
+
+
 ### Building the code
 The code is built with `gradle`, a cli tool that manages java projects and their
 dependencies. You can build the code with `./gradlew build` and run it with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd SlimeVR-Server
 Now you can open the codebase in your favorite IDE or text editor.
 
 ### Installing Java
-The codebase is required to build with Java version 11 or higher.
+The codebase is required to build with Java version 17 or higher.
 
 ```bash
 # Check java version


### PR DESCRIPTION
When I follow the CONTRIBUTING.md, I encounter a build error because of the old version of JDK

An error like below. 

```bash
Unrecognized option: --add-exports
```

Therefore, I suggest adding a Java version inside  CONTRIBUTING.md to make sure the guideline works as expected