### PR TITLE
Make IMU trackers start at # 1

### DIFF
--- a/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
@@ -735,7 +735,8 @@ public class IMUTracker
 
 	@Override
 	public String getDisplayName() {
-		return "IMU Tracker #" + getTrackerId();
+		return "IMU Tracker #"
+			+ (getTrackerId() - vrserver.humanPoseManager.getShareableTracker().size());
 	}
 
 	@Override


### PR DESCRIPTION
just subtract shareable trackers amount from IMU trackers' name. I am aware this isn't a good solution (or a "solution" at all), but it'll prevent further user confusion until we rewrite trackers and have a good solution for trackers default display name.