### PR TITLE
gui: Fix text wrapping in TrackerTable

### DIFF
--- a/gui/src/components/tracker/TrackerStatus.tsx
+++ b/gui/src/components/tracker/TrackerStatus.tsx
@@ -33,7 +33,9 @@ export function TrackerStatus({ status }: { status: number }) {
       <div className="flex flex-col justify-center">
         <div className={classNames('w-2 h-2 rounded-full', statusClass)}></div>
       </div>
-      <Typography color="secondary">{l10n.getString(statusLabel)}</Typography>
+      <Typography color="secondary" whitespace="whitespace-nowrap">
+        {l10n.getString(statusLabel)}
+      </Typography>
     </div>
   );
 }

--- a/gui/src/components/tracker/TrackerWifi.tsx
+++ b/gui/src/components/tracker/TrackerWifi.tsx
@@ -15,15 +15,19 @@ export function TrackerWifi({
   textColor?: string;
 }) {
   return (
-    <div className="flex gap-2 whitespace-nowrap">
+    <div className="flex gap-2">
       <div className="flex flex-col justify-around">
         <WifiIcon value={rssi} disabled={disabled} />
       </div>
       {!disabled && (
         <div className="w-12">
-          <Typography color={textColor}>{ping} ms</Typography>
+          <Typography color={textColor} whitespace="whitespace-nowrap">
+            {ping} ms
+          </Typography>
           {rssiShowNumeric && (
-            <Typography color={textColor}>{rssi} dBm</Typography>
+            <Typography color={textColor} whitespace="whitespace-nowrap">
+              {rssi} dBm
+            </Typography>
           )}
         </div>
       )}

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -62,8 +62,10 @@ export function TrackerNameCell({ tracker }: { tracker: TrackerDataT }) {
       <div className="flex flex-col justify-center items-center fill-background-10">
         <FootIcon></FootIcon>
       </div>
-      <div className="flex flex-col flex-grow whitespace-nowrap">
-        <Typography bold>{name}</Typography>
+      <div className="flex flex-col flex-grow">
+        <Typography bold whitespace="whitespace-nowrap">
+          {name}
+        </Typography>
         <TrackerStatus status={tracker.status}></TrackerStatus>
       </div>
     </div>
@@ -89,10 +91,8 @@ export function TrackerRotCell({
     : useRawRotationEulerDegrees();
 
   return (
-    <Typography color={color}>
-      <span className="whitespace-nowrap">
-        {formatVector3(rot, precise ? 2 : 0)}
-      </span>
+    <Typography color={color} whitespace="whitespace-nowrap">
+      {formatVector3(rot, precise ? 2 : 0)}
     </Typography>
   );
 }
@@ -336,10 +336,8 @@ export function TrackersTable({
         labelClassName: 'w-36',
         row: ({ tracker }) =>
           tracker.linearAcceleration && (
-            <Typography color={fontColor}>
-              <span className="whitespace-nowrap">
-                {formatVector3(tracker.linearAcceleration, 1)}
-              </span>
+            <Typography color={fontColor} whitespace="whitespace-nowrap">
+              {formatVector3(tracker.linearAcceleration, 1)}
             </Typography>
           ),
       })}
@@ -350,10 +348,8 @@ export function TrackersTable({
         labelClassName: 'w-36',
         row: ({ tracker }) =>
           tracker.position && (
-            <Typography color={fontColor}>
-              <span className="whitespace-nowrap">
-                {formatVector3(tracker.position, 2)}
-              </span>
+            <Typography color={fontColor} whitespace="whitespace-nowrap">
+              {formatVector3(tracker.position, 2)}
             </Typography>
           ),
       })}
@@ -362,7 +358,7 @@ export function TrackersTable({
         id: DisplayColumn.URL,
         label: l10n.getString('tracker-table-column-url'),
         row: ({ device }) => (
-          <Typography color={fontColor}>
+          <Typography color={fontColor} whitespace="whitespace-nowrap">
             udp://
             {IPv4.fromNumber(
               device?.hardwareInfo?.ipAddress?.addr || 0


### PR DESCRIPTION
Fixes rows shifting in TrackerTable, caused by Typography text wrapping change in #516:

![image](https://user-images.githubusercontent.com/114709761/218263280-3c078529-e3ed-4c07-ac83-264c929675b6.png)
