### PR TITLE
gui: Fix undefined in temperature column

### DIFF
--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -321,11 +321,10 @@ export function TrackersTable({
         id: DisplayColumn.TEMPERATURE,
         label: l10n.getString('tracker-table-column-temperature'),
         row: ({ tracker }) =>
-          tracker?.temp && tracker?.temp?.temp != 0 && (
-            <Typography color={fontColor}>
-              <span className="whitespace-nowrap">
-                {`${tracker.temp.temp.toFixed(2)}`}
-              </span>
+          tracker?.temp &&
+          tracker?.temp?.temp != 0 && (
+            <Typography color={fontColor} whitespace="whitespace-nowrap">
+              {`${tracker.temp.temp.toFixed(2)}`}
             </Typography>
           ),
       })}

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -183,7 +183,7 @@ export function TrackersTable({
   const moreInfo = config?.devSettings?.moreInfo;
 
   const hasTemperature = !!filteredSortedTrackers.find(
-    ({ tracker }) => Number(tracker?.temp?.temp) != 0
+    ({ tracker }) => tracker?.temp && tracker?.temp?.temp != 0
   );
   displayColumns[DisplayColumn.TEMPERATURE] = hasTemperature || false;
   displayColumns[DisplayColumn.POSITION] = moreInfo || false;
@@ -321,10 +321,10 @@ export function TrackersTable({
         id: DisplayColumn.TEMPERATURE,
         label: l10n.getString('tracker-table-column-temperature'),
         row: ({ tracker }) =>
-          tracker.temp?.temp != 0 && (
+          tracker?.temp && tracker?.temp?.temp != 0 && (
             <Typography color={fontColor}>
               <span className="whitespace-nowrap">
-                {`${tracker.temp?.temp.toFixed(2)}`}
+                {`${tracker.temp.temp.toFixed(2)}`}
               </span>
             </Typography>
           ),


### PR DESCRIPTION
Fixes temperature column displaying `undefined` for non-IMU trackers, as in this case the wrapped temperature value is sent as null:

![image](https://user-images.githubusercontent.com/114709761/217802618-8db36182-d614-41ad-9140-09a3d3ae25dc.png)
