### PR TITLE
gui: Display raw rotation if no ref/ident-adjusted

### DIFF
--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -84,9 +84,9 @@ export function TrackerRotCell({
   const { useRawRotationEulerDegrees, useRefAdjRotationEulerDegrees } =
     useTracker(tracker);
 
-  const rot = referenceAdjusted
-    ? useRefAdjRotationEulerDegrees()
-    : useRawRotationEulerDegrees();
+  const rotationRaw = useRawRotationEulerDegrees();
+  const rotationRef = useRefAdjRotationEulerDegrees() || rotationRaw;
+  const rot = referenceAdjusted ? rotationRef : rotationRaw;
 
   return (
     <Typography color={color}>

--- a/gui/src/components/widgets/IMUVisualizerWidget.tsx
+++ b/gui/src/components/widgets/IMUVisualizerWidget.tsx
@@ -129,10 +129,16 @@ function SceneRenderer({ x, y, z, w }: QuatObject) {
 export function IMUVisualizerWidget({ tracker }: { tracker: TrackerDataT }) {
   const { l10n } = useLocalization();
   const [enabled, setEnabled] = useState(false);
-  const quat = tracker?.rotationIdentityAdjusted || new THREE.Quaternion();
 
   const { useRawRotationEulerDegrees, useIdentAdjRotationEulerDegrees } =
     useTracker(tracker);
+
+  const rotationRaw = useRawRotationEulerDegrees();
+  const rotationIdent = useIdentAdjRotationEulerDegrees() || rotationRaw;
+  const quat =
+    tracker?.rotationIdentityAdjusted ||
+    tracker?.rotation ||
+    new THREE.Quaternion();
 
   return (
     <div className="bg-background-70 flex flex-col p-3 rounded-lg gap-2">
@@ -144,18 +150,14 @@ export function IMUVisualizerWidget({ tracker }: { tracker: TrackerDataT }) {
         <Typography color="secondary">
           {l10n.getString('widget-imu_visualizer-rotation_raw')}
         </Typography>
-        <Typography>
-          {formatVector3(useRawRotationEulerDegrees(), 2)}
-        </Typography>
+        <Typography>{formatVector3(rotationRaw, 2)}</Typography>
       </div>
 
       <div className="flex justify-between">
         <Typography color="secondary">
           {l10n.getString('widget-imu_visualizer-rotation_preview')}
         </Typography>
-        <Typography>
-          {formatVector3(useIdentAdjRotationEulerDegrees(), 2)}
-        </Typography>
+        <Typography>{formatVector3(rotationIdent, 2)}</Typography>
       </div>
 
       {!enabled && (

--- a/gui/src/hooks/tracker.ts
+++ b/gui/src/hooks/tracker.ts
@@ -51,12 +51,16 @@ export function useTracker(tracker: TrackerDataT) {
       useMemo(() => QuaternionToEulerDegrees(tracker?.rotation), [tracker.rotation]),
     useRefAdjRotationEulerDegrees: () =>
       useMemo(
-        () => QuaternionToEulerDegrees(tracker?.rotationReferenceAdjusted),
+        () =>
+          tracker?.rotationReferenceAdjusted &&
+          QuaternionToEulerDegrees(tracker?.rotationReferenceAdjusted),
         [tracker.rotationReferenceAdjusted]
       ),
     useIdentAdjRotationEulerDegrees: () =>
       useMemo(
-        () => QuaternionToEulerDegrees(tracker?.rotationIdentityAdjusted),
+        () =>
+          tracker?.rotationIdentityAdjusted &&
+          QuaternionToEulerDegrees(tracker?.rotationIdentityAdjusted),
         [tracker.rotationIdentityAdjusted]
       ),
     useVelocity: () => {


### PR DESCRIPTION
In developer mode, when displaying computed rotation, display raw rotation instead of defaulting to `(0, 0, 0)` if reference/identity-adjusted quaternions are not sent:

![image](https://user-images.githubusercontent.com/114709761/217804019-d9a4fdfb-a703-429a-846a-a4370b9d675d.png)

Same applies to the IMU visualizer:

![image](https://user-images.githubusercontent.com/114709761/217805461-627fb2aa-2d57-4a08-8797-758da15f3dbd.png)
