### PR TITLE
WiFi provisioning and serial fixes

### DIFF
--- a/gui/src/components/settings/pages/Serial.tsx
+++ b/gui/src/components/settings/pages/Serial.tsx
@@ -93,9 +93,7 @@ export function Serial() {
     (data: SerialUpdateResponseT) => {
       if (data.closed) {
         setSerialOpen(false);
-      }
-
-      if (!data.closed) {
+      } else {
         setSerialOpen(true);
       }
 
@@ -127,9 +125,12 @@ export function Serial() {
 
   useEffect(() => {
     const id = setInterval(() => {
-      if (!isSerialOpen) openSerial(port);
-      else clearInterval(id);
-    }, 1000);
+      if (!isSerialOpen) {
+        openSerial(port);
+      } else {
+        clearInterval(id);
+      }
+    }, 3000);
 
     return () => {
       clearInterval(id);

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -92,6 +92,8 @@ public class ProvisioningHandler implements SerialListener {
 		if (System.currentTimeMillis() - this.lastStatusChange > 10000) {
 			if (this.provisioningStatus == ProvisioningStatus.NONE)
 				this.initSerial(this.preferredPort);
+			else if (this.provisioningStatus == ProvisioningStatus.SERIAL_INIT)
+				initSerial(this.preferredPort);
 			else if (this.provisioningStatus == ProvisioningStatus.PROVISIONING)
 				this.tryProvisioning();
 			else if (this.provisioningStatus == ProvisioningStatus.LOOKING_FOR_SERVER)

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -61,10 +61,13 @@ public class ProvisioningHandler implements SerialListener {
 		this.provisioningStatus = ProvisioningStatus.SERIAL_INIT;
 
 		try {
+			boolean openResult;
 			if (port != null)
-				vrServer.getSerialHandler().openSerial(port, false);
+				openResult = vrServer.getSerialHandler().openSerial(port, false);
 			else
-				vrServer.getSerialHandler().openSerial(null, true);
+				openResult = vrServer.getSerialHandler().openSerial(null, true);
+			if(!openResult)
+				LogManager.info("Serial port wasn't open...");
 		} catch (Exception e) {
 			LogManager.severe("Unable to open serial port", e);
 		} catch (Throwable e) {

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -71,7 +71,8 @@ public class ProvisioningHandler implements SerialListener {
 		} catch (Exception e) {
 			LogManager.severe("[SerialHandler] Unable to open serial port", e);
 		} catch (Throwable e) {
-			LogManager.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
+			LogManager
+				.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
 		}
 
 	}

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -67,9 +67,9 @@ public class ProvisioningHandler implements SerialListener {
 			else
 				openResult = vrServer.getSerialHandler().openSerial(null, true);
 			if (!openResult)
-				LogManager.info("Serial port wasn't open...");
+				LogManager.info("[SerialHandler] Serial port wasn't open...");
 		} catch (Exception e) {
-			LogManager.severe("Unable to open serial port", e);
+			LogManager.severe("[SerialHandler] Unable to open serial port", e);
 		} catch (Throwable e) {
 			LogManager.severe("Using serial ports is not supported on this platform", e);
 		}

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -71,7 +71,7 @@ public class ProvisioningHandler implements SerialListener {
 		} catch (Exception e) {
 			LogManager.severe("[SerialHandler] Unable to open serial port", e);
 		} catch (Throwable e) {
-			LogManager.severe("Using serial ports is not supported on this platform", e);
+			LogManager.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
 		}
 
 	}

--- a/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/ProvisioningHandler.java
@@ -61,12 +61,12 @@ public class ProvisioningHandler implements SerialListener {
 		this.provisioningStatus = ProvisioningStatus.SERIAL_INIT;
 
 		try {
-			boolean openResult;
+			boolean openResult = false;
 			if (port != null)
 				openResult = vrServer.getSerialHandler().openSerial(port, false);
 			else
 				openResult = vrServer.getSerialHandler().openSerial(null, true);
-			if(!openResult)
+			if (!openResult)
 				LogManager.info("Serial port wasn't open...");
 		} catch (Exception e) {
 			LogManager.severe("Unable to open serial port", e);

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -90,7 +90,10 @@ public class SerialHandler implements SerialPortMessageListener {
 			return false;
 		}
 		if (this.isConnected()) {
-			if (currentPort != null && newPort != currentPort) {
+			if (
+				!newPort.getPortLocation().equals(currentPort.getPortLocation())
+					|| !newPort.getDescriptivePortName().equals(currentPort.getDescriptivePortName())
+			) {
 				LogManager
 					.info(
 						"Closing current serial port "
@@ -193,6 +196,7 @@ public class SerialHandler implements SerialPortMessageListener {
 	}
 
 	public void addLog(String str) {
+		LogManager.info("[Serial] " + str);
 		this.listeners.forEach(listener -> listener.onSerialLog(str));
 	}
 

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -106,7 +106,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			} else {
 				LogManager.info("Reusing already open port");
 				this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
-				return;
+				return true;
 			}
 		}
 		currentPort = newPort;

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -121,16 +121,16 @@ public class SerialHandler implements SerialPortMessageListener {
 			if (currentPort != null)
 				currentPort.closePort();
 			this.listeners.forEach(SerialListener::onSerialDisconnected);
-			LogManager.
-				info(
+			LogManager
+				.info(
 					"Port "
 						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null")
 						+ " closed okay"
 				);
 			currentPort = null;
 		} catch (Exception e) {
-			LogManager.
-				warning(
+			LogManager
+				.warning(
 					"Error closing port "
 						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null"),
 					e

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -116,7 +116,7 @@ public class SerialHandler implements SerialPortMessageListener {
 					"Can't open serial port "
 						+ currentPort.getDescriptivePortName()
 						+ ", last error: "
-						currentPort.getLastErrorCode()
+						+ currentPort.getLastErrorCode()
 				);
 			currentPort = null;
 			return false;

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -83,7 +83,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		if (newPort == null) {
 			LogManager
 				.info(
-					"No serial ports found to connect to ("
+					"[SerialHandler] No serial ports found to connect to ("
 						+ ports.length
 						+ ") total ports"
 				);
@@ -98,7 +98,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			) {
 				LogManager
 					.info(
-						"Closing current serial port "
+						"[SerialHandler] Closing current serial port "
 							+ currentPort.getDescriptivePortName()
 					);
 				currentPort.removeDataListener();

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -81,6 +81,12 @@ public class SerialHandler implements SerialPortMessageListener {
 			}
 		}
 		if (newPort == null) {
+			LogManager
+				.info(
+					"No serial ports found to connect to ("
+						+ ports.length
+						+ ") total ports"
+					);
 			return false;
 		}
 		if (this.isConnected()) {
@@ -90,6 +96,11 @@ public class SerialHandler implements SerialPortMessageListener {
 			}
 		}
 		currentPort = newPort;
+		LogManager
+			.info(
+				"Trying to connect to new serial port "
+					+ currentPort.getDescriptivePortName()
+				);
 
 		currentPort.setBaudRate(115200);
 		currentPort.clearRTS();

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -91,6 +91,11 @@ public class SerialHandler implements SerialPortMessageListener {
 		}
 		if (this.isConnected()) {
 			if (currentPort != null && newPort != currentPort) {
+				LogManager
+					.info(
+						"Closing current serial port "
+							+ currentPort.getDescriptivePortName()
+					);
 				currentPort.removeDataListener();
 				currentPort.closePort();
 			}
@@ -105,7 +110,15 @@ public class SerialHandler implements SerialPortMessageListener {
 		currentPort.setBaudRate(115200);
 		currentPort.clearRTS();
 		currentPort.clearDTR();
-		if (!currentPort.openPort()) {
+		if (!currentPort.openPort(1000)) {
+			LogManager
+				.warning(
+					"Can't open serial port "
+						+ currentPort.getDescriptivePortName()
+						+ ", last error: "
+						currentPort.getLastErrorCode()
+				);
+			currentPort = null;
 			return false;
 		}
 

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -92,7 +92,9 @@ public class SerialHandler implements SerialPortMessageListener {
 		if (this.isConnected()) {
 			if (
 				!newPort.getPortLocation().equals(currentPort.getPortLocation())
-					|| !newPort.getDescriptivePortName().equals(currentPort.getDescriptivePortName())
+					|| !newPort
+						.getDescriptivePortName()
+						.equals(currentPort.getDescriptivePortName())
 			) {
 				LogManager
 					.info(

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -64,7 +64,7 @@ public class SerialHandler implements SerialPortMessageListener {
 	}
 
 	public boolean openSerial(String portLocation, boolean auto) {
-		LogManager.info("Trying to open:" + portLocation + "  auto: " + auto);
+		LogManager.info("[SerialHandler] Trying to open: " + portLocation + ", auto: " + auto);
 
 		SerialPort[] ports = SerialPort.getCommPorts();
 		lastKnownPorts = ports;
@@ -112,7 +112,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		currentPort = newPort;
 		LogManager
 			.info(
-				"Trying to connect to new serial port "
+				"[SerialHandler] Trying to connect to new serial port "
 					+ currentPort.getDescriptivePortName()
 			);
 
@@ -122,7 +122,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		if (!currentPort.openPort(1000)) {
 			LogManager
 				.warning(
-					"Can't open serial port "
+					"[SerialHandler] Can't open serial port "
 						+ currentPort.getDescriptivePortName()
 						+ ", last error: "
 						+ currentPort.getLastErrorCode()
@@ -133,7 +133,7 @@ public class SerialHandler implements SerialPortMessageListener {
 
 		currentPort.addDataListener(this);
 		this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
-		LogManager.info("Serial port " + newPort.getDescriptivePortName() + " is open");
+		LogManager.info("[SerialHandler] Serial port " + newPort.getDescriptivePortName() + " is open");
 		return true;
 	}
 
@@ -156,7 +156,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			this.listeners.forEach(SerialListener::onSerialDisconnected);
 			LogManager
 				.info(
-					"Port "
+					"[SerialHandler] Port "
 						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null")
 						+ " closed okay"
 				);
@@ -164,7 +164,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		} catch (Exception e) {
 			LogManager
 				.warning(
-					"Error closing port "
+					"[SerialHandler] Error closing port "
 						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null"),
 					e
 				);
@@ -182,7 +182,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			this.addLog("-> " + serialText + "\n");
 		} catch (IOException e) {
 			addLog("[!] Serial error: " + e.getMessage() + "\n");
-			LogManager.warning("Serial port write error", e);
+			LogManager.warning("[SerialHandler] Serial port write error", e);
 		}
 	}
 
@@ -197,7 +197,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			this.addLog("-> SET WIFI \"" + ssid + "\" \"" + passwd.replaceAll(".", "*") + "\"\n");
 		} catch (IOException e) {
 			addLog(e + "\n");
-			LogManager.warning("Serial port write error", e);
+			LogManager.warning("[SerialHandler] Serial port write error", e);
 		}
 	}
 
@@ -280,7 +280,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			lastKnownPorts = SerialPort.getCommPorts();
 			differences.forEach(this::onNewDevice);
 		} catch (Throwable e) {
-			LogManager.severe("Using serial ports is not supported on this platform", e);
+			LogManager.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
 			throw new RuntimeException("Serial unsupported");
 		}
 	}

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -64,7 +64,7 @@ public class SerialHandler implements SerialPortMessageListener {
 	}
 
 	public boolean openSerial(String portLocation, boolean auto) {
-		System.out.println("Trying to open:" + portLocation + "  auto: " + auto);
+		LogManager.info("Trying to open:" + portLocation + "  auto: " + auto);
 
 		SerialPort[] ports = SerialPort.getCommPorts();
 		lastKnownPorts = ports;
@@ -100,6 +100,7 @@ public class SerialHandler implements SerialPortMessageListener {
 
 		currentPort.addDataListener(this);
 		this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
+		LogManager.info("Serial port " + newPort.getDescriptivePortName() + " is open");
 		return true;
 	}
 
@@ -120,10 +121,10 @@ public class SerialHandler implements SerialPortMessageListener {
 			if (currentPort != null)
 				currentPort.closePort();
 			this.listeners.forEach(SerialListener::onSerialDisconnected);
-			System.out.println("Port closed okay");
+			LogManager.info("Port " + (currentPort != null ? currentPort.getDescriptivePortName() : "null") + " closed okay");
 			currentPort = null;
 		} catch (Exception e) {
-			System.out.println("Error closing port: " + e.getMessage());
+			LogManager.warning("Error closing port " + (currentPort != null ? currentPort.getDescriptivePortName() : "null"), e);
 		}
 	}
 
@@ -137,8 +138,8 @@ public class SerialHandler implements SerialPortMessageListener {
 			writer.flush();
 			this.addLog("-> " + serialText + "\n");
 		} catch (IOException e) {
-			addLog(e + "\n");
-			e.printStackTrace();
+			addLog("[!] Serial error: " + e.getMessage() + "\n");
+			LogManager.warning("Serial port write error", e);
 		}
 	}
 
@@ -153,7 +154,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			this.addLog("-> SET WIFI \"" + ssid + "\" \"" + passwd.replaceAll(".", "*") + "\"\n");
 		} catch (IOException e) {
 			addLog(e + "\n");
-			e.printStackTrace();
+			LogManager.warning("Serial port write error", e);
 		}
 	}
 
@@ -236,6 +237,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			differences.forEach(this::onNewDevice);
 		} catch (Throwable e) {
 			LogManager.severe("Using serial ports is not supported on this platform", e);
+			throw new RuntimeException("Serial unsupported");
 		}
 	}
 }

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -121,10 +121,20 @@ public class SerialHandler implements SerialPortMessageListener {
 			if (currentPort != null)
 				currentPort.closePort();
 			this.listeners.forEach(SerialListener::onSerialDisconnected);
-			LogManager.info("Port " + (currentPort != null ? currentPort.getDescriptivePortName() : "null") + " closed okay");
+			LogManager.
+				info(
+					"Port "
+						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null")
+						+ " closed okay"
+				);
 			currentPort = null;
 		} catch (Exception e) {
-			LogManager.warning("Error closing port " + (currentPort != null ? currentPort.getDescriptivePortName() : "null"), e);
+			LogManager.
+				warning(
+					"Error closing port "
+						+ (currentPort != null ? currentPort.getDescriptivePortName() : "null"),
+					e
+				);
 		}
 	}
 

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -133,7 +133,8 @@ public class SerialHandler implements SerialPortMessageListener {
 
 		currentPort.addDataListener(this);
 		this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
-		LogManager.info("[SerialHandler] Serial port " + newPort.getDescriptivePortName() + " is open");
+		LogManager
+			.info("[SerialHandler] Serial port " + newPort.getDescriptivePortName() + " is open");
 		return true;
 	}
 
@@ -280,7 +281,8 @@ public class SerialHandler implements SerialPortMessageListener {
 			lastKnownPorts = SerialPort.getCommPorts();
 			differences.forEach(this::onNewDevice);
 		} catch (Throwable e) {
-			LogManager.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
+			LogManager
+				.severe("[SerialHandler] Using serial ports is not supported on this platform", e);
 			throw new RuntimeException("Serial unsupported");
 		}
 	}

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -87,9 +87,9 @@ public class SerialHandler implements SerialPortMessageListener {
 			if (currentPort != null && newPort != currentPort) {
 				currentPort.removeDataListener();
 				currentPort.closePort();
-				Thread.sleep(500L);
 			}
 		}
+		currentPort = newPort;
 
 		currentPort.setBaudRate(115200);
 		currentPort.clearRTS();

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -86,7 +86,7 @@ public class SerialHandler implements SerialPortMessageListener {
 					"No serial ports found to connect to ("
 						+ ports.length
 						+ ") total ports"
-					);
+				);
 			return false;
 		}
 		if (this.isConnected()) {
@@ -100,7 +100,7 @@ public class SerialHandler implements SerialPortMessageListener {
 			.info(
 				"Trying to connect to new serial port "
 					+ currentPort.getDescriptivePortName()
-				);
+			);
 
 		currentPort.setBaudRate(115200);
 		currentPort.clearRTS();

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -104,7 +104,7 @@ public class SerialHandler implements SerialPortMessageListener {
 				currentPort.removeDataListener();
 				currentPort.closePort();
 			} else {
-				LogManager.info("Reusing already open port");
+				LogManager.info("[SerialHandler] Reusing already open port");
 				this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
 				return true;
 			}

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -64,28 +64,31 @@ public class SerialHandler implements SerialPortMessageListener {
 	}
 
 	public boolean openSerial(String portLocation, boolean auto) {
-		if (this.isConnected()) {
-			if (currentPort != null)
-				currentPort.closePort();
-		}
-
 		System.out.println("Trying to open:" + portLocation + "  auto: " + auto);
 
 		SerialPort[] ports = SerialPort.getCommPorts();
 		lastKnownPorts = ports;
+		SerialPort newPort = null;
 		for (SerialPort port : ports) {
 			if (!auto && port.getPortLocation().equals(portLocation)) {
-				currentPort = port;
+				newPort = port;
 				break;
 			}
 
 			if (auto && isKnownBoard(port.getDescriptivePortName())) {
-				currentPort = port;
+				newPort = port;
 				break;
 			}
 		}
-		if (currentPort == null) {
+		if (newPort == null) {
 			return false;
+		}
+		if (this.isConnected()) {
+			if (currentPort != null && newPort != currentPort) {
+				currentPort.removeDataListener();
+				currentPort.closePort();
+				Thread.sleep(500L);
+			}
 		}
 
 		currentPort.setBaudRate(115200);

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -103,6 +103,10 @@ public class SerialHandler implements SerialPortMessageListener {
 					);
 				currentPort.removeDataListener();
 				currentPort.closePort();
+			} else {
+				LogManager.info("Reusing already open port");
+				this.listeners.forEach((listener) -> listener.onSerialConnected(currentPort));
+				return;
 			}
 		}
 		currentPort = newPort;

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -63,7 +63,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		listeners.removeIf(listener -> l == listener);
 	}
 
-	public boolean openSerial(String portLocation, boolean auto) {
+	public synchronized boolean openSerial(String portLocation, boolean auto) {
 		LogManager.info("[SerialHandler] Trying to open: " + portLocation + ", auto: " + auto);
 
 		SerialPort[] ports = SerialPort.getCommPorts();
@@ -150,7 +150,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		this.writeSerial("GET INFO");
 	}
 
-	public void closeSerial() {
+	public synchronized void closeSerial() {
 		try {
 			if (currentPort != null)
 				currentPort.closePort();
@@ -172,7 +172,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		}
 	}
 
-	private void writeSerial(String serialText) {
+	private synchronized void writeSerial(String serialText) {
 		if (currentPort == null)
 			return;
 		OutputStream os = currentPort.getOutputStream();
@@ -187,7 +187,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		}
 	}
 
-	public void setWifi(String ssid, String passwd) {
+	public synchronized void setWifi(String ssid, String passwd) {
 		if (currentPort == null)
 			return;
 		OutputStream os = currentPort.getOutputStream();
@@ -224,7 +224,7 @@ public class SerialHandler implements SerialPortMessageListener {
 		}
 	}
 
-	public boolean isConnected() {
+	public synchronized boolean isConnected() {
 		return this.currentPort != null && this.currentPort.isOpen();
 	}
 


### PR DESCRIPTION
This PR does:
* Logs serial to console so it can be checked on any screen via debug window
* Add more explicit reporting of serial events and errors to console for debugging
* Tires to reuse serial port if it was already open but some new code tries to re-open it with triggering all required events
* Adds pause before opening serial port in case it was closed and opened too fast which may cause it be unresponsive
* WiFi provisioning re-tries opening serial port if it wasn't open

Some stuff is a bit broken:

* [ ] When wifi provisioning GUI is open, it starts flooding with requests to open serial more and more and more and faster (not relevant since the port is reused, but the GUI code needs to be investigated)
* [ ] Looks like WiFi popup doesn't close the serial port after it's opened or something like tha t(not relevant since the port is reused, but the GUI code needs to be investigated)
* [x] I broke Serial console
* [ ] Needs code cleanup