### PR TITLE
server: Log resets from all sources

### DIFF
--- a/server/src/main/java/dev/slimevr/Keybinding.java
+++ b/server/src/main/java/dev/slimevr/Keybinding.java
@@ -9,6 +9,8 @@ import io.eiren.util.logging.LogManager;
 
 
 public class Keybinding implements HotkeyListener {
+	private static final String resetSourceName = "Keybinding";
+
 	private static final int RESET = 1;
 	private static final int QUICK_RESET = 2;
 	private static final int RESET_MOUNTING = 3;
@@ -59,15 +61,19 @@ public class Keybinding implements HotkeyListener {
 		switch (identifier) {
 			case RESET -> {
 				LogManager.info("[Keybinding] Reset pressed");
-				server.scheduleResetTrackers(this.config.getResetDelay());
+				server.scheduleResetTrackers(resetSourceName, this.config.getResetDelay());
 			}
 			case QUICK_RESET -> {
 				LogManager.info("[Keybinding] Quick reset pressed");
-				server.scheduleResetTrackersYaw(this.config.getQuickResetDelay());
+				server.scheduleResetTrackersYaw(resetSourceName, this.config.getQuickResetDelay());
 			}
 			case RESET_MOUNTING -> {
 				LogManager.info("[Keybinding] Reset mounting pressed");
-				server.scheduleResetTrackersMounting(this.config.getResetMountingDelay());
+				server
+					.scheduleResetTrackersMounting(
+						resetSourceName,
+						this.config.getResetMountingDelay()
+					);
 			}
 		}
 	}

--- a/server/src/main/java/dev/slimevr/Keybinding.java
+++ b/server/src/main/java/dev/slimevr/Keybinding.java
@@ -60,15 +60,12 @@ public class Keybinding implements HotkeyListener {
 	public void onHotKey(int identifier) {
 		switch (identifier) {
 			case RESET -> {
-				LogManager.info("[Keybinding] Reset pressed");
 				server.scheduleResetTrackers(resetSourceName, this.config.getResetDelay());
 			}
 			case QUICK_RESET -> {
-				LogManager.info("[Keybinding] Quick reset pressed");
 				server.scheduleResetTrackersYaw(resetSourceName, this.config.getQuickResetDelay());
 			}
 			case RESET_MOUNTING -> {
-				LogManager.info("[Keybinding] Reset mounting pressed");
 				server
 					.scheduleResetTrackersMounting(
 						resetSourceName,

--- a/server/src/main/java/dev/slimevr/VRServer.java
+++ b/server/src/main/java/dev/slimevr/VRServer.java
@@ -326,49 +326,55 @@ public class VRServer extends Thread {
 		queueTask(humanPoseManager::updateSkeletonModelFromServer);
 	}
 
-	public void resetTrackers() {
-		queueTask(humanPoseManager::resetTrackersFull);
+	public void resetTrackers(String resetSourceName) {
+		queueTask(() -> {
+			humanPoseManager.resetTrackersFull(resetSourceName);
+		});
 	}
 
-	public void resetTrackersYaw() {
-		queueTask(humanPoseManager::resetTrackersYaw);
+	public void resetTrackersYaw(String resetSourceName) {
+		queueTask(() -> {
+			humanPoseManager.resetTrackersYaw(resetSourceName);
+		});
 	}
 
-	public void resetTrackersMounting() {
-		queueTask(humanPoseManager::resetTrackersMounting);
+	public void resetTrackersMounting(String resetSourceName) {
+		queueTask(() -> {
+			humanPoseManager.resetTrackersMounting(resetSourceName);
+		});
 	}
 
-	public void scheduleResetTrackers(long delay) {
-		TimerTask resetTask = new resetTask();
+	public void scheduleResetTrackers(String resetSourceName, long delay) {
+		TimerTask resetTask = new TimerTask() {
+			public void run() {
+				queueTask(() -> {
+					humanPoseManager.resetTrackersFull(resetSourceName);
+				});
+			}
+		};
 		timer.schedule(resetTask, delay);
 	}
 
-	public void scheduleResetTrackersYaw(long delay) {
-		TimerTask yawResetTask = new yawResetTask();
+	public void scheduleResetTrackersYaw(String resetSourceName, long delay) {
+		TimerTask yawResetTask = new TimerTask() {
+			public void run() {
+				queueTask(() -> {
+					humanPoseManager.resetTrackersYaw(resetSourceName);
+				});
+			}
+		};
 		timer.schedule(yawResetTask, delay);
 	}
 
-	public void scheduleResetTrackersMounting(long delay) {
-		TimerTask resetMountingTask = new resetMountingTask();
+	public void scheduleResetTrackersMounting(String resetSourceName, long delay) {
+		TimerTask resetMountingTask = new TimerTask() {
+			public void run() {
+				queueTask(() -> {
+					humanPoseManager.resetTrackersMounting(resetSourceName);
+				});
+			}
+		};
 		timer.schedule(resetMountingTask, delay);
-	}
-
-	class resetTask extends TimerTask {
-		public void run() {
-			queueTask(humanPoseManager::resetTrackersFull);
-		}
-	}
-
-	class yawResetTask extends TimerTask {
-		public void run() {
-			queueTask(humanPoseManager::resetTrackersYaw);
-		}
-	}
-
-	class resetMountingTask extends TimerTask {
-		public void run() {
-			queueTask(humanPoseManager::resetTrackersMounting);
-		}
 	}
 
 	public void setLegTweaksEnabled(boolean value) {

--- a/server/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
+++ b/server/src/main/java/dev/slimevr/bridge/ProtobufBridge.java
@@ -21,6 +21,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 
 public abstract class ProtobufBridge<T extends VRTracker> implements Bridge {
+	private static final String resetSourceNamePrefix = "ProtobufBridge";
 
 	@VRServerThread
 	protected final List<ShareableTracker> sharedTrackers = new FastList<>();
@@ -181,16 +182,17 @@ public abstract class ProtobufBridge<T extends VRTracker> implements Bridge {
 
 	@VRServerThread
 	protected void userActionReceived(UserAction userAction) {
+		String resetSourceName = "%s: %s".formatted(resetSourceNamePrefix, bridgeName);
 		switch (userAction.getName()) {
 			case "calibrate":
 				LogManager
 					.warning("[" + bridgeName + "] Received deprecated user action 'calibrate'!");
 			case "reset":
 				// TODO : Check pose field
-				Main.getVrServer().resetTrackers();
+				Main.getVrServer().resetTrackers(resetSourceName);
 				break;
 			case "fast_reset":
-				Main.getVrServer().resetTrackersYaw();
+				Main.getVrServer().resetTrackersYaw(resetSourceName);
 				break;
 		}
 	}

--- a/server/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.java
+++ b/server/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.java
@@ -32,6 +32,8 @@ import java.util.function.BiConsumer;
 public class RPCHandler extends ProtocolHandler<RpcMessageHeader>
 	implements AutoBoneListener {
 
+	private static final String resetSourceName = "WebSocketAPI";
+
 	private final ProtocolAPI api;
 
 	private long currTransactionId = 0;
@@ -197,12 +199,11 @@ public class RPCHandler extends ProtocolHandler<RpcMessageHeader>
 			return;
 
 		if (req.resetType() == ResetType.Quick)
-			this.api.server.resetTrackersYaw();
+			this.api.server.resetTrackersYaw(resetSourceName);
 		if (req.resetType() == ResetType.Full)
-			this.api.server.resetTrackers();
+			this.api.server.resetTrackers(resetSourceName);
 		if (req.resetType() == ResetType.Mounting)
-			this.api.server.resetTrackersMounting();
-		LogManager.info("[WebSocketAPI] Reset performed");
+			this.api.server.resetTrackersMounting(resetSourceName);
 	}
 
 	public void onAssignTrackerRequest(GenericConnection conn, RpcMessageHeader messageHeader) {

--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -517,9 +517,9 @@ public class HumanPoseManager {
 	}
 
 	@VRServerThread
-	public void resetTrackersFull() {
+	public void resetTrackersFull(String resetSourceName) {
 		if (isSkeletonPresent()) {
-			skeleton.resetTrackersFull();
+			skeleton.resetTrackersFull(resetSourceName);
 			if (server != null) {
 				server.getVrcOSCHandler().yawAlign();
 				server.getVMCHandler().alignVMCTracking(getRootNode().worldTransform.getRotation());
@@ -528,15 +528,15 @@ public class HumanPoseManager {
 	}
 
 	@VRServerThread
-	public void resetTrackersMounting() {
+	public void resetTrackersMounting(String resetSourceName) {
 		if (isSkeletonPresent())
-			skeleton.resetTrackersMounting();
+			skeleton.resetTrackersMounting(resetSourceName);
 	}
 
 	@VRServerThread
-	public void resetTrackersYaw() {
+	public void resetTrackersYaw(String resetSourceName) {
 		if (isSkeletonPresent()) {
-			skeleton.resetTrackersYaw();
+			skeleton.resetTrackersYaw(resetSourceName);
 			if (server != null) {
 				server.getVrcOSCHandler().yawAlign();
 				server.getVMCHandler().alignVMCTracking(getRootNode().worldTransform.getRotation());

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
@@ -1696,7 +1696,7 @@ public class HumanSkeleton {
 		}
 		this.legTweaks.resetBuffer();
 
-		LogManager.info("Reset: quick (%s)".formatted(resetSourceName));
+		LogManager.info("Reset: yaw (%s)".formatted(resetSourceName));
 	}
 
 	public void updateTapDetectionConfig() {

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
@@ -14,6 +14,7 @@ import dev.slimevr.tracking.trackers.*;
 import dev.slimevr.util.ann.VRServerThread;
 import io.eiren.util.ann.ThreadSafe;
 import io.eiren.util.collections.FastList;
+import io.eiren.util.logging.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1605,7 +1606,7 @@ public class HumanSkeleton {
 		};
 	}
 
-	public void resetTrackersFull() {
+	public void resetTrackersFull(String resetSourceName) {
 		// Pass all trackers through trackerPreUpdate
 		Tracker hmdTracker = trackerPreUpdate(this.hmdTracker);
 		Tracker[] trackersToReset = getTrackersToReset();
@@ -1628,6 +1629,8 @@ public class HumanSkeleton {
 		// of the computed trackers
 		this.legTweaks.resetFloorLevel();
 		this.legTweaks.resetBuffer();
+
+		LogManager.info("Reset: full (%s)".formatted(resetSourceName));
 	}
 
 	private boolean shouldResetMounting(TrackerPosition position) {
@@ -1653,7 +1656,7 @@ public class HumanSkeleton {
 	}
 
 	@VRServerThread
-	public void resetTrackersMounting() {
+	public void resetTrackersMounting(String resetSourceName) {
 		// Pass all trackers through trackerPreUpdate
 		Tracker[] trackersToReset = getTrackersToReset();
 
@@ -1668,10 +1671,12 @@ public class HumanSkeleton {
 			}
 		}
 		this.legTweaks.resetBuffer();
+
+		LogManager.info("Reset: mounting (%s)".formatted(resetSourceName));
 	}
 
 	@VRServerThread
-	public void resetTrackersYaw() {
+	public void resetTrackersYaw(String resetSourceName) {
 		// Pass all trackers through trackerPreUpdate
 		Tracker hmdTracker = trackerPreUpdate(this.hmdTracker);
 		Tracker[] trackersToReset = getTrackersToReset();
@@ -1690,6 +1695,8 @@ public class HumanSkeleton {
 			}
 		}
 		this.legTweaks.resetBuffer();
+
+		LogManager.info("Reset: quick (%s)".formatted(resetSourceName));
 	}
 
 	public void updateTapDetectionConfig() {

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.java
@@ -8,6 +8,7 @@ import dev.slimevr.tracking.trackers.Tracker;
 
 // handles tap detection for the skeleton
 public class TapDetectionManager {
+	private static final String resetSourceName = "TapDetection";
 
 	// server and related classes
 	private final HumanSkeleton skeleton;
@@ -101,9 +102,9 @@ public class TapDetectionManager {
 			tapped && System.nanoTime() - quickResetDetector.getDetectionTime() > quickResetDelayNs
 		) {
 			if (humanPoseManager != null)
-				humanPoseManager.resetTrackersYaw();
+				humanPoseManager.resetTrackersYaw(resetSourceName);
 			else
-				skeleton.resetTrackersYaw();
+				skeleton.resetTrackersYaw(resetSourceName);
 			quickResetDetector.resetDetector();
 		}
 	}
@@ -115,9 +116,9 @@ public class TapDetectionManager {
 			tapped && System.nanoTime() - resetDetector.getDetectionTime() > resetDelayNs
 		) {
 			if (humanPoseManager != null)
-				humanPoseManager.resetTrackersFull();
+				humanPoseManager.resetTrackersFull(resetSourceName);
 			else
-				skeleton.resetTrackersFull();
+				skeleton.resetTrackersFull(resetSourceName);
 			resetDetector.resetDetector();
 		}
 	}
@@ -130,7 +131,7 @@ public class TapDetectionManager {
 				&& System.nanoTime() - mountingResetDetector.getDetectionTime()
 					> mountingResetDelayNs
 		) {
-			skeleton.resetTrackersMounting();
+			skeleton.resetTrackersMounting(resetSourceName);
 			mountingResetDetector.resetDetector();
 		}
 	}

--- a/server/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.java
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.java
@@ -31,6 +31,8 @@ public class TrackersUDPServer extends Thread {
 	private static final Quaternion offset = new Quaternion()
 		.fromAngleAxis(-FastMath.HALF_PI, Vector3f.UNIT_X);
 
+	private static final String resetSourceName = "TrackerServer";
+
 	private final Quaternion buf = new Quaternion();
 	private final Random random = new Random();
 	private final List<UDPDevice> connections = new FastList<>();
@@ -576,15 +578,15 @@ public class TrackersUDPServer extends Thread {
 						switch (action.type) {
 							case UDPPacket21UserAction.RESET:
 								name = "Full";
-								Main.getVrServer().resetTrackers();
+								Main.getVrServer().resetTrackers(resetSourceName);
 								break;
 							case UDPPacket21UserAction.RESET_YAW:
 								name = "Yaw";
-								Main.getVrServer().resetTrackersYaw();
+								Main.getVrServer().resetTrackersYaw(resetSourceName);
 								break;
 							case UDPPacket21UserAction.RESET_MOUNTING:
 								name = "Mounting";
-								Main.getVrServer().resetTrackersMounting();
+								Main.getVrServer().resetTrackersMounting(resetSourceName);
 								break;
 						}
 						LogManager

--- a/server/src/main/java/dev/slimevr/websocketapi/WebSocketVRBridge.java
+++ b/server/src/main/java/dev/slimevr/websocketapi/WebSocketVRBridge.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 
 public class WebSocketVRBridge extends WebsocketAPI implements Bridge {
+	private static final String resetSourceName = "WebSocketVRBridge";
 
 	private final Vector3f vBuffer = new Vector3f();
 	private final Quaternion qBuffer = new Quaternion();
@@ -170,8 +171,8 @@ public class WebSocketVRBridge extends WebsocketAPI implements Bridge {
 
 	private void parseAction(ObjectNode json, WebSocket conn) {
 		switch (json.get("name").asText()) {
-			case "calibrate" -> Main.getVrServer().resetTrackersYaw();
-			case "full_calibrate" -> Main.getVrServer().resetTrackers();
+			case "calibrate" -> Main.getVrServer().resetTrackersYaw(resetSourceName);
+			case "full_calibrate" -> Main.getVrServer().resetTrackers(resetSourceName);
 		}
 	}
 


### PR DESCRIPTION
Currently resets are not logged in all cases. This PR adds reset logging for tap detection and feeder app bridge, unifies reset log message.

This can be useful for tracking time between resets.