### PR TITLE
Fix skeleton config loading

### DIFF
--- a/server/src/main/java/dev/slimevr/posestreamer/PoseFrameStreamer.java
+++ b/server/src/main/java/dev/slimevr/posestreamer/PoseFrameStreamer.java
@@ -1,5 +1,6 @@
 package dev.slimevr.posestreamer;
 
+import dev.slimevr.config.ConfigManager;
 import dev.slimevr.poserecorder.PoseFrameIO;
 import dev.slimevr.poserecorder.PoseFrames;
 import dev.slimevr.tracking.processor.HumanPoseManager;
@@ -24,6 +25,11 @@ public class PoseFrameStreamer extends PoseStreamer {
 		this.frames = new PoseFrames(frames);
 		humanPoseManager = new HumanPoseManager(this.frames.getTrackers());
 		skeleton = humanPoseManager.getSkeleton();
+	}
+
+	public PoseFrameStreamer(PoseFrames frames, ConfigManager configManager) {
+		this(frames);
+		humanPoseManager.loadFromConfig(configManager);
 	}
 
 	public PoseFrames getFrames() {

--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -2,6 +2,7 @@ package dev.slimevr.tracking.processor;
 
 import com.jme3.math.Vector3f;
 import dev.slimevr.VRServer;
+import dev.slimevr.config.ConfigManager;
 import dev.slimevr.tracking.processor.config.SkeletonConfigManager;
 import dev.slimevr.tracking.processor.config.SkeletonConfigOffsets;
 import dev.slimevr.tracking.processor.config.SkeletonConfigToggles;
@@ -53,6 +54,8 @@ public class HumanPoseManager {
 	public HumanPoseManager(List<? extends Tracker> trackers) {
 		this();
 		skeleton = new HumanSkeleton(this, trackers);
+		// Set default node offsets on the new skeleton
+		skeletonConfigManager.updateNodeOffsetsInSkeleton();
 		skeletonConfigManager.updateSettingsInSkeleton();
 	}
 
@@ -70,6 +73,8 @@ public class HumanPoseManager {
 	) {
 		this();
 		skeleton = new HumanSkeleton(this, trackers);
+		// Set default node offsets on the new skeleton
+		skeletonConfigManager.updateNodeOffsetsInSkeleton();
 		// Set offsetConfigs from given offsetConfigs on creation
 		skeletonConfigManager.setOffsets(offsetConfigs);
 		skeletonConfigManager.updateSettingsInSkeleton();
@@ -92,6 +97,8 @@ public class HumanPoseManager {
 	) {
 		this();
 		skeleton = new HumanSkeleton(this, trackers);
+		// Set default node offsets on the new skeleton
+		skeletonConfigManager.updateNodeOffsetsInSkeleton();
 		// Set offsetConfigs from given offsetConfigs on creation
 		if (altOffsetConfigs != null) {
 			// Set alts first, so if there's any overlap it doesn't affect
@@ -195,11 +202,18 @@ public class HumanPoseManager {
 			);
 	}
 
+	public void loadFromConfig(ConfigManager configManager) {
+		skeletonConfigManager.loadFromConfig(configManager);
+	}
+
 	@VRServerThread
 	public void updateSkeletonModelFromServer() {
 		disconnectComputedHumanPoseTrackers();
 		skeleton = new HumanSkeleton(this, server);
-		skeletonConfigManager.loadFromConfig(server.getConfigManager());
+		// This recomputes all node offsets, so the defaults don't need to be
+		// explicitly loaded into the skeleton (no need for
+		// `updateNodeOffsetsInSkeleton()`)
+		loadFromConfig(server.getConfigManager());
 		for (Consumer<HumanSkeleton> sc : onSkeletonUpdated)
 			sc.accept(skeleton);
 	}

--- a/server/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.java
@@ -5,6 +5,7 @@ import dev.slimevr.Main;
 import dev.slimevr.autobone.errors.BodyProportionError;
 import dev.slimevr.autobone.errors.proportions.ProportionLimiter;
 import dev.slimevr.config.ConfigManager;
+import dev.slimevr.config.SkeletonConfig;
 import dev.slimevr.tracking.processor.BoneType;
 import dev.slimevr.tracking.processor.HumanPoseManager;
 
@@ -73,6 +74,17 @@ public class SkeletonConfigManager {
 		for (SkeletonConfigValues config : SkeletonConfigValues.values) {
 			Float val = configValues.get(config);
 			humanPoseManager.updateValueState(config, val == null ? config.defaultValue : val);
+		}
+	}
+
+	public void updateNodeOffsetsInSkeleton() {
+		if (humanPoseManager == null)
+			return;
+
+		for (BoneType config : BoneType.values) {
+			Vector3f val = nodeOffsets.get(config);
+			if (val != null)
+				humanPoseManager.updateNodeOffset(config, val);
 		}
 	}
 
@@ -430,13 +442,12 @@ public class SkeletonConfigManager {
 	}
 
 	public void loadFromConfig(ConfigManager configManager) {
+		SkeletonConfig skeletonConfig = configManager.getVrConfig().getSkeleton();
+
 		// Load offsets
+		Map<String, Float> offsets = skeletonConfig.getOffsets();
 		for (SkeletonConfigOffsets configValue : SkeletonConfigOffsets.values) {
-			Float val = configManager
-				.getVrConfig()
-				.getSkeleton()
-				.getOffsets()
-				.get(configValue.configKey);
+			Float val = offsets.get(configValue.configKey);
 			if (val != null) {
 				// Do not recalculate the offsets, these are done in bulk at the
 				// end
@@ -445,12 +456,9 @@ public class SkeletonConfigManager {
 		}
 
 		// Load toggles
+		Map<String, Boolean> toggles = skeletonConfig.getToggles();
 		for (SkeletonConfigToggles configValue : SkeletonConfigToggles.values) {
-			Boolean val = configManager
-				.getVrConfig()
-				.getSkeleton()
-				.getToggles()
-				.get(configValue.configKey);
+			Boolean val = toggles.get(configValue.configKey);
 			if (val != null) {
 				setToggle(configValue, val);
 			} else if (humanPoseManager != null) {
@@ -459,12 +467,9 @@ public class SkeletonConfigManager {
 		}
 
 		// Load values
+		Map<String, Float> values = skeletonConfig.getValues();
 		for (SkeletonConfigValues configValue : SkeletonConfigValues.values) {
-			Float val = configManager
-				.getVrConfig()
-				.getSkeleton()
-				.getValues()
-				.get(configValue.configKey);
+			Float val = values.get(configValue.configKey);
 			if (val != null) {
 				setValue(configValue, val);
 			} else if (humanPoseManager != null) {


### PR DESCRIPTION
- Fix node offsets not being set on the HumanSkeleton by default when initialized from HumanSkeletonManager
- Fix skeleton configs not being loaded for PoseFrameStreamer or AutoBone
- Simplify `SkeletonConfigManager.loadFromConfig(ConfigManager)` by storing objects in variables