### PR TITLE
Update AutoBone steps on the GUI to match the docs

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -635,6 +635,7 @@ onboarding-automatic_proportions-put_trackers_on-next = I have all my trackers o
 onboarding-automatic_proportions-requirements-title = Requirements
 # Each line of text is a different list item
 onboarding-automatic_proportions-requirements-description =
+    You have at least enough trackers to track your feet (generally 5 trackers).
     You have your trackers and headset on.
     You are wearing your trackers and headset.
     Your trackers and headset are connected to the SlimeVR server.

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -632,22 +632,31 @@ onboarding-automatic_proportions-prev_step = Previous step
 onboarding-automatic_proportions-put_trackers_on-title = Put on your trackers
 onboarding-automatic_proportions-put_trackers_on-description = To calibrate your proportions, we're gonna use the trackers you just assigned. Put on all your trackers, you can see which are which in the figure to the right.
 onboarding-automatic_proportions-put_trackers_on-next = I have all my trackers on
-onboarding-automatic_proportions-preparation-title = Preparation
-onboarding-automatic_proportions-preparation-description = Place a chair directly behind you inside your play space. Be prepared to sit down during the autobone setup.
-onboarding-automatic_proportions-preparation-next = I am in front of a chair
+onboarding-automatic_proportions-requirements-title = Requirements
+# Each line of text is a different list item
+onboarding-automatic_proportions-requirements-description =
+    You have your trackers and headset on.
+    You are wearing your trackers and headset.
+    Your trackers and headset are connected to the SlimeVR server.
+    Your trackers and headset are working properly within the SlimeVR server.
+    Your headset is reporting positional data to the SlimeVR server (this generally means having SteamVR running and connected to SlimeVR using SlimeVR's SteamVR driver).
+onboarding-automatic_proportions-requirements-next = I have read the requirements
 onboarding-automatic_proportions-start_recording-title = Get ready to move
 onboarding-automatic_proportions-start_recording-description = We're now going to record some specific poses and moves. These will be prompted in the next screen. Be ready to start when the button is pressed!
 onboarding-automatic_proportions-start_recording-next = Start Recording
 onboarding-automatic_proportions-recording-title = REC
 onboarding-automatic_proportions-recording-description-p0 = Recording in progress...
 onboarding-automatic_proportions-recording-description-p1 = Make the moves shown below:
-onboarding-automatic_proportions-recording-steps-0 = Bend knees a few times.
-onboarding-automatic_proportions-recording-steps-1 = Sit on a chair then stand up.
-onboarding-automatic_proportions-recording-steps-2 = Twist upper body left, then bend right.
-onboarding-automatic_proportions-recording-steps-3 = Twist upper body right, then bend left.
-onboarding-automatic_proportions-recording-steps-4 = Wiggle around until timer ends.
+# Each line of text is a different list item
+onboarding-automatic_proportions-recording-steps =
+    Standing up straight, roll your head in a circle.
+    Bend your back forwards and squat. While squatting, look to your left, then to your right.
+    Twist your upper body to the left (counter-clockwise), then reach down towards the ground.
+    Twist your upper body to the right (clockwise), then reach down towards the ground.
+    Roll your hips in a circular motion as if you're using a hula hoop.
+    If there is time left on the recording, you can repeat these steps until it's finished.
 onboarding-automatic_proportions-recording-processing = Processing the result
-# $time (Number) - Seconds left for the automatic calibration recording to finish (max 15)
+# $time (Number) - Seconds left for the automatic calibration recording to finish (max 20)
 onboarding-automatic_proportions-recording-timer = { $time ->
     [one] 1 second left
     *[other] { $time } seconds left

--- a/gui/src/components/onboarding/pages/body-proportions/AutomaticProportions.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/AutomaticProportions.tsx
@@ -13,7 +13,7 @@ import { Button } from '../../../commons/Button';
 import { Typography } from '../../../commons/Typography';
 import { StepperSlider } from '../../StepperSlider';
 import { DoneStep } from './autobone-steps/Done';
-import { PreparationStep } from './autobone-steps/Preparation';
+import { RequirementsStep } from './autobone-steps/Requirements';
 import { PutTrackersOnStep } from './autobone-steps/PutTrackersOn';
 import { Recording } from './autobone-steps/Recording';
 import { StartRecording } from './autobone-steps/StartRecording';
@@ -69,7 +69,7 @@ export function AutomaticProportionsPage() {
               variant={state.alonePage ? 'alone' : 'onboarding'}
               steps={[
                 { type: 'numbered', component: PutTrackersOnStep },
-                { type: 'numbered', component: PreparationStep },
+                { type: 'numbered', component: RequirementsStep },
                 { type: 'numbered', component: StartRecording },
                 { type: 'fullsize', component: Recording },
                 { type: 'numbered', component: VerifyResultsStep },

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Recording.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Recording.tsx
@@ -35,23 +35,18 @@ export function Recording({ nextStep }: { nextStep: () => void }) {
           )}
         </Typography>
       </div>
-      <div>
-        <Typography color="secondary">
-          {l10n.getString('onboarding-automatic_proportions-recording-steps-0')}
-        </Typography>
-        <Typography color="secondary">
-          {l10n.getString('onboarding-automatic_proportions-recording-steps-1')}
-        </Typography>
-        <Typography color="secondary">
-          {l10n.getString('onboarding-automatic_proportions-recording-steps-2')}
-        </Typography>
-        <Typography color="secondary">
-          {l10n.getString('onboarding-automatic_proportions-recording-steps-3')}
-        </Typography>
-        <Typography color="secondary">
-          {l10n.getString('onboarding-automatic_proportions-recording-steps-4')}
-        </Typography>
-      </div>
+      <ol className="list-decimal">
+        <>
+          {l10n
+            .getString('onboarding-automatic_proportions-recording-steps')
+            .split('\n')
+            .map((line, i) => (
+              <li key={i}>
+                <Typography color="secondary">{line}</Typography>
+              </li>
+            ))}
+        </>
+      </ol>
       <div className="flex">
         <TipBox>{l10n.getString('tips-do_not_move_heels')}</TipBox>
       </div>
@@ -65,7 +60,7 @@ export function Recording({ nextStep }: { nextStep: () => void }) {
             : l10n.getString(
                 'onboarding-automatic_proportions-recording-timer',
                 {
-                  time: 15,
+                  time: 20,
                 }
               )}
         </Typography>

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Requirements.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Requirements.tsx
@@ -1,9 +1,8 @@
 import { Button } from '../../../../commons/Button';
-import { FromtOfChairIcon } from '../../../../commons/icon/FrontOfChair';
 import { Typography } from '../../../../commons/Typography';
 import { useLocalization } from '@fluent/react';
 
-export function PreparationStep({
+export function RequirementsStep({
   nextStep,
   prevStep,
   variant,
@@ -17,19 +16,26 @@ export function PreparationStep({
   return (
     <>
       <div className="flex flex-col flex-grow">
-        <div className="flex flex-grow flex-col gap-4 max-w-sm">
+        <div className="flex flex-grow flex-col gap-4">
           <Typography variant="main-title" bold>
             {l10n.getString(
-              'onboarding-automatic_proportions-preparation-title'
+              'onboarding-automatic_proportions-requirements-title'
             )}
           </Typography>
-          <div>
-            <Typography color="secondary">
-              {l10n.getString(
-                'onboarding-automatic_proportions-preparation-description'
-              )}
-            </Typography>
-          </div>
+          <ul className="list-disc">
+            <>
+              {l10n
+                .getString(
+                  'onboarding-automatic_proportions-requirements-description'
+                )
+                .split('\n')
+                .map((line, i) => (
+                  <li key={i}>
+                    <Typography color="secondary">{line}</Typography>
+                  </li>
+                ))}
+            </>
+          </ul>
         </div>
 
         <div className="flex gap-3">
@@ -41,13 +47,10 @@ export function PreparationStep({
           </Button>
           <Button variant="primary" onClick={nextStep}>
             {l10n.getString(
-              'onboarding-automatic_proportions-preparation-next'
+              'onboarding-automatic_proportions-requirements-next'
             )}
           </Button>
         </div>
-      </div>
-      <div className="flex flex-col pt-1 items-center fill-background-50 justify-center px-12">
-        <FromtOfChairIcon width={180} />
       </div>
     </>
   );

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/StartRecording.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/StartRecording.tsx
@@ -24,7 +24,7 @@ export function StartRecording({
   return (
     <>
       <div className="flex flex-col flex-grow">
-        <div className="flex flex-grow flex-col gap-4 max-w-sm">
+        <div className="flex flex-grow flex-col gap-4">
           <Typography variant="main-title" bold>
             {l10n.getString(
               'onboarding-automatic_proportions-start_recording-title'
@@ -37,8 +37,20 @@ export function StartRecording({
               )}
             </Typography>
           </div>
+          <ol className="list-decimal">
+            <>
+              {l10n
+                .getString('onboarding-automatic_proportions-recording-steps')
+                .split('\n')
+                .map((line, i) => (
+                  <li key={i}>
+                    <Typography color="secondary">{line}</Typography>
+                  </li>
+                ))}
+            </>
+          </ol>
           <div className="flex">
-            <TipBox>{l10n.getString('tips-find_tracker')}</TipBox>
+            <TipBox>{l10n.getString('tips-do_not_move_heels')}</TipBox>
           </div>
         </div>
 


### PR DESCRIPTION
- Removes the chair step (yippeee!!)
- Adds a "Requirements" page that explains all that is required to use AutoBone
- Updates the steps for AutoBone movements to match the docs
- Adds steps for AutoBone movements on the "Get ready to move" page (as a temporary workaround to show them before starting the recording)
- Fixes the tip on the "Get ready to move" page