### PR TITLE
Fixes for sound feedback PR

### DIFF
--- a/gui/src/hooks/websocket-api.ts
+++ b/gui/src/hooks/websocket-api.ts
@@ -36,7 +36,6 @@ export type DataFeedPacketType = DataFeedMessageHeaderT['message'];
 export function useProvideWebsocketApi(): WebSocketApi {
   const rpcPacketCounterRef = useRef<number>(0);
   const webSocketRef = useRef<WebSocket | null>(null);
-  let wsCurrent: WebSocket | null = null;
   const rpclistenerRef = useRef<EventTarget>(new EventTarget());
   const pubsublistenerRef = useRef<EventTarget>(new EventTarget());
   const datafeedlistenerRef = useRef<EventTarget>(new EventTarget());
@@ -158,8 +157,6 @@ export function useProvideWebsocketApi(): WebSocketApi {
     webSocketRef.current.addEventListener('open', onConnected);
     webSocketRef.current.addEventListener('close', onConnectionClose);
     webSocketRef.current.addEventListener('message', onMessage);
-
-    wsCurrent = webSocketRef.current;
   };
 
   const disconnect = () => {
@@ -168,11 +165,9 @@ export function useProvideWebsocketApi(): WebSocketApi {
     webSocketRef.current.removeEventListener('open', onConnected);
     webSocketRef.current.removeEventListener('close', onConnectionClose);
     webSocketRef.current.removeEventListener('message', onMessage);
-    if (wsCurrent) {
-      setConnected(false);
-      wsCurrent.close();
-      wsCurrent = null;
-    }
+    webSocketRef.current.close();
+    webSocketRef.current = null;
+    setConnected(false);
   };
 
   const reconnect = () => {

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.java
@@ -144,7 +144,7 @@ public class TapDetectionManager {
 				skeleton.resetTrackersFull(resetSourceName);
 
 			fullResetDetector.resetDetector();
-			yawResetAllowPlaySound = true;
+			fullResetAllowPlaySound = true;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes some issues I mentioned in #576:
- Full reset sound on tap played only once;
- The websocket disconnect cleanup fix broke other `reconnect()` calls.

Please test if this PR results in intended behavior @marcozzxx810.