### PR TITLE
Simplify code and fix Android crash

### DIFF
--- a/server/src/main/java/dev/slimevr/config/serializers/BooleanMapDeserializer.java
+++ b/server/src/main/java/dev/slimevr/config/serializers/BooleanMapDeserializer.java
@@ -5,8 +5,11 @@ package dev.slimevr.config.serializers;
  * takes the Value of a map as its Generic parameter. It is so you can use that
  * class in a @JsonDeserialize annotation on the Map field inside the config
  * instance
- * 
+ *
  * @see dev.slimevr.config.VRConfig
  */
 public class BooleanMapDeserializer extends MapDeserializer<Boolean> {
+	public BooleanMapDeserializer() {
+		super(Boolean.class);
+	}
 }

--- a/server/src/main/java/dev/slimevr/config/serializers/BridgeConfigMapDeserializer.java
+++ b/server/src/main/java/dev/slimevr/config/serializers/BridgeConfigMapDeserializer.java
@@ -8,8 +8,11 @@ import dev.slimevr.config.BridgeConfig;
  * takes the Value of a map as its Generic parameter. It is so you can use that
  * class in a @JsonDeserialize annotation on the Map field inside the config
  * instance
- * 
+ *
  * @see dev.slimevr.config.VRConfig
  */
 public class BridgeConfigMapDeserializer extends MapDeserializer<BridgeConfig> {
+	public BridgeConfigMapDeserializer() {
+		super(BridgeConfig.class);
+	}
 }

--- a/server/src/main/java/dev/slimevr/config/serializers/FloatMapDeserializer.java
+++ b/server/src/main/java/dev/slimevr/config/serializers/FloatMapDeserializer.java
@@ -5,8 +5,11 @@ package dev.slimevr.config.serializers;
  * takes the Value of a map as its Generic parameter. It is so you can use that
  * class in a @JsonDeserialize annotation on the Map field inside the config
  * instance
- * 
+ *
  * @see dev.slimevr.config.VRConfig
  */
 public class FloatMapDeserializer extends MapDeserializer<Float> {
+	public FloatMapDeserializer() {
+		super(Float.class);
+	}
 }

--- a/server/src/main/java/dev/slimevr/config/serializers/MapDeserializer.java
+++ b/server/src/main/java/dev/slimevr/config/serializers/MapDeserializer.java
@@ -1,49 +1,36 @@
 package dev.slimevr.config.serializers;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.util.HashMap;
 
 
 /**
- * This class is an utility class that allows to write Map serializers easily to
+ * This class is a utility class that allows to write Map serializers easily to
  * be used in the VRConfig (@see {@link dev.slimevr.config.VRConfig})
- * 
+ *
  * @see BooleanMapDeserializer to see how it is used
  */
-public class MapDeserializer<T> extends JsonDeserializer<HashMap<String, T>> {
+public abstract class MapDeserializer<T> extends JsonDeserializer<HashMap<String, T>> {
 
-	public MapDeserializer() {
+	private final Class<T> valueClass;
+
+	public MapDeserializer(Class<T> valueClass) {
 		super();
-	}
-
-	private Class<T> getGenericTypeClass() {
-		try {
-			String className = ((ParameterizedType) getClass().getGenericSuperclass())
-				.getActualTypeArguments()[0].getTypeName();
-			Class<?> clazz = Class.forName(className);
-			return (Class<T>) clazz;
-		} catch (Exception e) {
-			throw new IllegalStateException(
-				"Class is not parametrized with generic type!!! Please use extends <> "
-			);
-		}
+		this.valueClass = valueClass;
 	}
 
 	@Override
 	public HashMap<String, T> deserialize(JsonParser p, DeserializationContext dc)
-		throws IOException, JsonProcessingException {
+		throws IOException {
 		TypeFactory typeFactory = dc.getTypeFactory();
 		MapType mapType = typeFactory
-			.constructMapType(HashMap.class, String.class, getGenericTypeClass());
-		HashMap<String, T> map = dc.readValue(p, mapType);
-		return map;
+			.constructMapType(HashMap.class, String.class, valueClass);
+		return dc.readValue(p, mapType);
 	}
 }

--- a/server/src/main/java/dev/slimevr/config/serializers/TrackerConfigMapDeserializer.java
+++ b/server/src/main/java/dev/slimevr/config/serializers/TrackerConfigMapDeserializer.java
@@ -8,8 +8,11 @@ import dev.slimevr.config.TrackerConfig;
  * takes the Value of a map as its Generic parameter. It is so you can use that
  * class in a @JsonDeserialize annotation on the Map field inside the config
  * instance
- * 
+ *
  * @see dev.slimevr.config.VRConfig
  */
 public class TrackerConfigMapDeserializer extends MapDeserializer<TrackerConfig> {
+	public TrackerConfigMapDeserializer() {
+		super(TrackerConfig.class);
+	}
 }

--- a/server/src/main/java/dev/slimevr/serial/SerialHandler.java
+++ b/server/src/main/java/dev/slimevr/serial/SerialHandler.java
@@ -37,7 +37,16 @@ public class SerialHandler implements SerialPortMessageListener {
 		this.watchingNewDevices = true;
 		this.getDevicesTimer.scheduleAtFixedRate(new TimerTask() {
 			public void run() {
-				detectNewPorts();
+				try {
+					detectNewPorts();
+				} catch (Throwable t) {
+					LogManager
+						.severe(
+							"[SerialHandler] Error while watching for new devices, cancelling the \"getDevicesTimer\".",
+							t
+						);
+					getDevicesTimer.cancel();
+				}
 			}
 		}, 0, 3000);
 	}

--- a/server/src/main/java/dev/slimevr/tracking/trackers/ComputedTracker.java
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/ComputedTracker.java
@@ -61,11 +61,7 @@ public class ComputedTracker implements Tracker, TrackerWithTPS {
 			setCustomName(config.getCustomName());
 			Optional<TrackerPosition> trackerPosition = TrackerPosition
 				.getByDesignation(config.getDesignation());
-			if (trackerPosition.isEmpty()) {
-				bodyPosition = null;
-			} else {
-				bodyPosition = trackerPosition.get();
-			}
+			bodyPosition = trackerPosition.orElse(null);
 		}
 	}
 

--- a/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
@@ -136,11 +136,7 @@ public class IMUTracker
 			}
 			Optional<TrackerPosition> trackerPosition = TrackerPosition
 				.getByDesignation(config.getDesignation());
-			if (trackerPosition.isEmpty()) {
-				bodyPosition = null;
-			} else {
-				bodyPosition = trackerPosition.get();
-			}
+			bodyPosition = trackerPosition.orElse(null);
 			if (config.getAllowDriftCompensation() == null) {
 				// If value didn't exist, default to true and save
 				allowDriftCompensation = true;

--- a/server/src/main/java/io/eiren/util/logging/LogManager.java
+++ b/server/src/main/java/io/eiren/util/logging/LogManager.java
@@ -26,12 +26,19 @@ public class LogManager {
 			return;
 		FileLogFormatter loc = new FileLogFormatter();
 		if (mainLogDir != null) {
+			// Ensure the log directory exists
 			if (!mainLogDir.exists())
 				mainLogDir.mkdirs();
-			for (File f : mainLogDir.listFiles()) {
-				if (f.getName().startsWith("log_last"))
-					f.delete();
+
+			// Clean old log files if they exist
+			File[] logFiles = mainLogDir.listFiles();
+			if (logFiles != null) {
+				for (File f : logFiles) {
+					if (f.getName().startsWith("log_last"))
+						f.delete();
+				}
 			}
+
 			String lastLogPattern = Path.of(mainLogDir.getPath(), "log_last_%g.log").toString();
 			FileHandler filehandler = new FileHandler(lastLogPattern, 25 * 1000000, 2);
 			filehandler.setFormatter(loc);


### PR DESCRIPTION
- Fixes Android builds crashing from the `SerialHandler.getDevicesTimer` thread.
- Simplifies `MapDeserializer` by removing reflection. This slightly limits the usage of `MapDeserializer`, but it greatly simplifies the code and usage of it, plus none of the current code uses it in any way that requires it.
  - This also fixes compiling on Android. ^w^
  - This may be entirely avoided by using [kotlinx.serialization](https://kotlinlang.org/docs/serialization.html) to parse the config instead.
- Simplifies some usages of `Optional` to take advantage of provided methods and fix compilation for lower API versions of Android.
- Fixes log clearing not checking for the possible `null` response from `File.listFiles()`, this caused crashing on Android in certain cases.