### PR TITLE
Fix default tracker mounting state to be front correctly

### DIFF
--- a/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/IMUTracker.java
@@ -28,7 +28,7 @@ public class IMUTracker
 	// public final Vector3f magVector = new Vector3f();
 	public final Quaternion rotQuaternion = new Quaternion();
 	public final Quaternion rotMagQuaternion = new Quaternion();
-	public final Quaternion mountAdjust = new Quaternion();
+	public final Quaternion mountAdjust = new Quaternion().fromAngles(0, FastMath.PI, 0);
 	public final UDPDevice device;
 	public final int trackerNum;
 	public final Vector3f rotVector = new Vector3f();
@@ -132,7 +132,7 @@ public class IMUTracker
 				mounting = config.getMountingOrientation();
 				mountAdjust.set(config.getMountingOrientation());
 			} else {
-				mountAdjust.loadIdentity();
+				mountAdjust.fromAngles(0, FastMath.PI, 0);
 			}
 			Optional<TrackerPosition> trackerPosition = TrackerPosition
 				.getByDesignation(config.getDesignation());
@@ -165,7 +165,7 @@ public class IMUTracker
 		if (mounting != null) {
 			mountAdjust.set(mounting);
 		} else {
-			mountAdjust.loadIdentity();
+			mountAdjust.fromAngles(0, FastMath.PI, 0);
 		}
 
 		// Clear the mounting reset now that it's been set manually


### PR DESCRIPTION
By default GUI shows the trackers are mounted to front, as they should, when the mounting orientation is null. But server loads identity for orientation when it's null, which is wrong, because FRONT is 180deg. This leads to wrong default state for frount moutned trackers. It can be fixed if orentation is changed to any other side and then to front again. This PR fixes this.

Found with Poly during testing of official slimes.