### PR TITLE
Fix TPS display for devices with >1 tracker

### DIFF
--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -293,9 +293,7 @@ export function TrackersTable({
         label: l10n.getString('tracker-table-column-tps'),
         row: ({ tracker }) => (
           <Typography color={fontColor}>
-            {(tracker?.tps != null && (
-              <>{tracker.tps || 0}</>
-            )) || <></>}
+            {tracker?.tps != null ? <>{tracker.tps}</> : <></>}
           </Typography>
         ),
       })}

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -291,10 +291,10 @@ export function TrackersTable({
       {column({
         id: DisplayColumn.TPS,
         label: l10n.getString('tracker-table-column-tps'),
-        row: ({ device }) => (
+        row: ({ tracker }) => (
           <Typography color={fontColor}>
-            {(device?.hardwareStatus?.tps != null && (
-              <>{device.hardwareStatus.tps || 0}</>
+            {(tracker?.tps != null && (
+              <>{tracker.tps || 0}</>
             )) || <></>}
           </Typography>
         ),

--- a/gui/src/hooks/datafeed-config.ts
+++ b/gui/src/hooks/datafeed-config.ts
@@ -16,6 +16,7 @@ export function useDataFeedConfig() {
   trackerData.linearAcceleration = true;
   trackerData.rotationReferenceAdjusted = true;
   trackerData.rotationIdentityAdjusted = true;
+  trackerData.tps = true;
 
   const dataMask = new DeviceDataMaskT();
   dataMask.deviceData = true;

--- a/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -201,6 +201,9 @@ public class DataFeedBuilder {
 				TrackerData.addRotationIdentityAdjusted(fbb, createQuat(fbb, quaternion));
 			}
 		}
+		if (mask.getTps() && tracker instanceof TrackerWithTPS trackerWithTps) {
+			TrackerData.addTps(fbb, (int) trackerWithTps.getTPS());
+		}
 
 		return TrackerData.endTrackerData(fbb);
 	}
@@ -251,9 +254,6 @@ public class DataFeedBuilder {
 
 		HardwareStatus.startHardwareStatus(fbb);
 		HardwareStatus.addErrorStatus(fbb, tracker.getStatus().id);
-
-		if (tracker instanceof TrackerWithTPS)
-			HardwareStatus.addTps(fbb, (int) ((TrackerWithTPS) tracker).getTPS());
 
 		if (tracker instanceof TrackerWithBattery twb) {
 			HardwareStatus.addBatteryVoltage(fbb, twb.getBatteryVoltage());


### PR DESCRIPTION
This PR fixes aux tracker showing its TPS identical to the main tracker - [by moving TPS field from `HardwareStatus` to `TrackerData`](https://github.com/SlimeVR/SolarXR-Protocol/pull/108).

Also protocol was updated to expand TPS type from `uint8` to `uint16`, as TPS can be higher than 255/s for other devices.

![image](https://user-images.githubusercontent.com/114709761/230307125-be8e3fb7-ebba-40fc-ab0f-8c07925a5759.png)
