### PR TITLE
Log yaw drift and reset all trackers

### DIFF
--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -18,6 +18,7 @@ import io.eiren.util.collections.FastList;
 import io.eiren.util.logging.LogManager;
 import io.github.axisangles.ktmath.Quaternion;
 import io.github.axisangles.ktmath.Vector3;
+import org.apache.commons.math3.util.Precision;
 
 import java.util.List;
 import java.util.Map;
@@ -685,6 +686,10 @@ public class HumanPoseManager {
 				tracker.getNeedsReset()
 					&& tracker.getResetsHandler().getLastResetQuaternion() != null
 			) {
+				if (!trackersDriftText.isEmpty()) {
+					trackersDriftText.append(" | ");
+				}
+
 				// Get the difference between last reset and now
 				Quaternion difference = tracker
 					.getRotation()
@@ -699,13 +704,9 @@ public class HumanPoseManager {
 				// Fix for polarity or something
 				if (trackerDriftAngle > 180)
 					trackerDriftAngle = Math.abs(trackerDriftAngle - 360);
-				// Round it to 4 decimal places
-				trackerDriftAngle = Math.round(trackerDriftAngle * 10000f) / 10000f;
 
 				// Calculate drift per minute
 				float driftPerMin = trackerDriftAngle / (timeSinceLastReset / 60f);
-				// Round it to 4 decimal places
-				driftPerMin = Math.round(driftPerMin * 10000f) / 10000f;
 
 				trackersDriftText.append(tracker.getName());
 				TrackerPosition trackerPosition = tracker.getTrackerPosition();
@@ -714,10 +715,10 @@ public class HumanPoseManager {
 
 				trackersDriftText
 					.append(", ")
-					.append(trackerDriftAngle)
+					.append(Precision.round(trackerDriftAngle, 4))
 					.append(" deg (")
-					.append(driftPerMin)
-					.append(" deg/min) | ");
+					.append(Precision.round(driftPerMin, 4))
+					.append(" deg/min)");
 			}
 		}
 

--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -644,7 +644,6 @@ public class HumanPoseManager {
 		skeletonConfigManager.computeNodeOffset(node);
 	}
 
-	@VRServerThread
 	public void resetTrackersFull(String resetSourceName) {
 		if (isSkeletonPresent()) {
 			skeleton.resetTrackersFull(resetSourceName);
@@ -658,7 +657,6 @@ public class HumanPoseManager {
 		}
 	}
 
-	@VRServerThread
 	public void resetTrackersYaw(String resetSourceName) {
 		if (isSkeletonPresent()) {
 			skeleton.resetTrackersYaw(resetSourceName);
@@ -680,22 +678,25 @@ public class HumanPoseManager {
 		long timeSinceLastReset = (System.currentTimeMillis() - timeAtLastReset) / 1000L;
 		timeAtLastReset = System.currentTimeMillis();
 
+		// Build String for trackers drifts
 		StringBuilder trackersDriftText = new StringBuilder();
 		for (Tracker tracker : server.getAllTrackers()) {
 			if (
 				tracker.getNeedsReset()
 					&& tracker.getResetsHandler().getLastResetQuaternion() != null
 			) {
-				// Get the absolute drift amount since last reset in degrees
+				// Get the difference between last reset and now
 				Quaternion difference = tracker
 					.getRotation()
 					.times(tracker.getResetsHandler().getLastResetQuaternion().inv());
+				// Get the pure yaw
 				float trackerDriftAngle = Math
 					.abs(
 						FastMath.atan2(difference.getY(), difference.getW())
 							* 2
 							* FastMath.RAD_TO_DEG
 					);
+				// Fix for polarity or something
 				if (trackerDriftAngle > 180)
 					trackerDriftAngle = Math.abs(trackerDriftAngle - 360);
 				// Round it to 4 decimal places
@@ -727,7 +728,6 @@ public class HumanPoseManager {
 		}
 	}
 
-	@VRServerThread
 	public void resetTrackersMounting(String resetSourceName) {
 		if (isSkeletonPresent())
 			skeleton.resetTrackersMounting(resetSourceName);

--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -707,8 +707,13 @@ public class HumanPoseManager {
 				// Round it to 4 decimal places
 				driftPerMin = Math.round(driftPerMin * 10000f) / 10000f;
 
+				String trackerName = tracker.getName();
+				TrackerPosition trackerPosition = tracker.getTrackerPosition();
+				if (trackerPosition != null)
+					trackerName += " (" + trackerPosition.name() + ")";
+
 				trackersDriftText
-					.append(tracker.getName())
+					.append(trackerName)
 					.append(", ")
 					.append(trackerDriftAngle)
 					.append(" deg (")

--- a/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.java
@@ -707,13 +707,12 @@ public class HumanPoseManager {
 				// Round it to 4 decimal places
 				driftPerMin = Math.round(driftPerMin * 10000f) / 10000f;
 
-				String trackerName = tracker.getName();
+				trackersDriftText.append(tracker.getName());
 				TrackerPosition trackerPosition = tracker.getTrackerPosition();
 				if (trackerPosition != null)
-					trackerName += " (" + trackerPosition.name() + ")";
+					trackersDriftText.append(" (").append(trackerPosition.name()).append(")");
 
 				trackersDriftText
-					.append(trackerName)
 					.append(", ")
 					.append(trackerDriftAngle)
 					.append(" deg (")

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
@@ -1457,31 +1457,6 @@ public class HumanSkeleton {
 		LogManager.info("[HumanSkeleton] Reset: yaw (%s)".formatted(resetSourceName));
 	}
 
-	@VRServerThread
-	public void resetTrackersYaw(String resetSourceName) {
-		// Pass all trackers through trackerPreUpdate
-		Tracker headTracker = trackerPreUpdate(this.headTracker);
-		Tracker[] trackersToReset = getTrackersToReset();
-
-		// Resets the yaw of the trackers with the head as reference.
-		Quaternion referenceRotation = Quaternion.Companion.getIDENTITY();
-		if (headTracker != null) {
-			if (headTracker.getNeedsReset())
-				headTracker.getResetsHandler().resetYaw(referenceRotation);
-			else
-				referenceRotation = headTracker.getRotation();
-		}
-
-		for (Tracker tracker : trackersToReset) {
-			if (tracker != null && tracker.getNeedsReset()) {
-				tracker.getResetsHandler().resetYaw(referenceRotation);
-			}
-		}
-		this.legTweaks.resetBuffer();
-
-		LogManager.info("Reset: yaw (%s)".formatted(resetSourceName));
-	}
-
 	private boolean shouldResetMounting(TrackerPosition position) {
 		return position != null
 			// TODO: Feet can't currently be reset using this method, maybe

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.java
@@ -536,12 +536,6 @@ public class HumanSkeleton {
 	}
 
 	// #region Processing
-	// Useful for subclasses that need to return a sub-tracker (like
-	// PoseFrameTracker -> TrackerFrame)
-	protected Tracker trackerPreUpdate(Tracker tracker) {
-		return tracker;
-	}
-
 	// Updates the pose from tracker positions
 	@VRServerThread
 	public void updatePose() {
@@ -573,32 +567,6 @@ public class HumanSkeleton {
 
 	// #region Update the node transforms from the trackers
 	protected void updateLocalTransforms() {
-		// #region Pass all trackers through trackerPreUpdate for Autobone
-		Tracker headTracker = trackerPreUpdate(this.headTracker);
-
-		Tracker neckTracker = trackerPreUpdate(this.neckTracker);
-		Tracker chestTracker = trackerPreUpdate(this.chestTracker);
-		Tracker waistTracker = trackerPreUpdate(this.waistTracker);
-		Tracker hipTracker = trackerPreUpdate(this.hipTracker);
-
-		Tracker leftUpperLegTracker = trackerPreUpdate(this.leftUpperLegTracker);
-		Tracker leftLowerLegTracker = trackerPreUpdate(this.leftLowerLegTracker);
-		Tracker leftFootTracker = trackerPreUpdate(this.leftFootTracker);
-
-		Tracker rightUpperLegTracker = trackerPreUpdate(this.rightUpperLegTracker);
-		Tracker rightLowerLegTracker = trackerPreUpdate(this.rightLowerLegTracker);
-		Tracker rightFootTracker = trackerPreUpdate(this.rightFootTracker);
-
-		Tracker leftLowerArmTracker = trackerPreUpdate(this.leftLowerArmTracker);
-		Tracker rightLowerArmTracker = trackerPreUpdate(this.rightLowerArmTracker);
-		Tracker leftUpperArmTracker = trackerPreUpdate(this.leftUpperArmTracker);
-		Tracker rightUpperArmTracker = trackerPreUpdate(this.rightUpperArmTracker);
-		Tracker leftHandTracker = trackerPreUpdate(this.leftHandTracker);
-		Tracker rightHandTracker = trackerPreUpdate(this.rightHandTracker);
-		Tracker leftShoulderTracker = trackerPreUpdate(this.leftShoulderTracker);
-		Tracker rightShoulderTracker = trackerPreUpdate(this.rightShoulderTracker);
-		// #endregion
-
 		// HMD, head and neck
 		Quaternion headRot = Quaternion.Companion.getIDENTITY();
 		if (headTracker != null) {
@@ -1383,30 +1351,28 @@ public class HumanSkeleton {
 	public List<Tracker> getLocalTrackers() {
 		return List
 			.of(
-				trackerPreUpdate(this.neckTracker),
-				trackerPreUpdate(this.chestTracker),
-				trackerPreUpdate(this.waistTracker),
-				trackerPreUpdate(this.hipTracker),
-				trackerPreUpdate(this.leftUpperLegTracker),
-				trackerPreUpdate(this.leftLowerLegTracker),
-				trackerPreUpdate(this.leftFootTracker),
-				trackerPreUpdate(this.rightUpperLegTracker),
-				trackerPreUpdate(this.rightLowerLegTracker),
-				trackerPreUpdate(this.rightFootTracker),
-				trackerPreUpdate(this.leftLowerArmTracker),
-				trackerPreUpdate(this.rightLowerArmTracker),
-				trackerPreUpdate(this.leftUpperArmTracker),
-				trackerPreUpdate(this.rightUpperArmTracker),
-				trackerPreUpdate(this.leftHandTracker),
-				trackerPreUpdate(this.rightHandTracker),
-				trackerPreUpdate(this.leftShoulderTracker),
-				trackerPreUpdate(this.rightShoulderTracker)
+				this.neckTracker,
+				this.chestTracker,
+				this.waistTracker,
+				this.hipTracker,
+				this.leftUpperLegTracker,
+				this.leftLowerLegTracker,
+				this.leftFootTracker,
+				this.rightUpperLegTracker,
+				this.rightLowerLegTracker,
+				this.rightFootTracker,
+				this.leftLowerArmTracker,
+				this.rightLowerArmTracker,
+				this.leftUpperArmTracker,
+				this.rightUpperArmTracker,
+				this.leftHandTracker,
+				this.rightHandTracker,
+				this.leftShoulderTracker,
+				this.rightShoulderTracker
 			);
 	}
 
 	public void resetTrackersFull(String resetSourceName) {
-		// Pass all trackers through trackerPreUpdate
-		Tracker headTracker = trackerPreUpdate(this.headTracker);
 		List<Tracker> trackersToReset = humanPoseManager.getTrackersToReset();
 
 		// Resets all axis of the trackers with the HMD as reference.
@@ -1434,8 +1400,6 @@ public class HumanSkeleton {
 
 	@VRServerThread
 	public void resetTrackersYaw(String resetSourceName) {
-		// Pass all trackers through trackerPreUpdate
-		Tracker headTracker = trackerPreUpdate(this.headTracker);
 		List<Tracker> trackersToReset = humanPoseManager.getTrackersToReset();
 
 		// Resets the yaw of the trackers with the head as reference.
@@ -1489,8 +1453,6 @@ public class HumanSkeleton {
 
 	@VRServerThread
 	public void resetTrackersMounting(String resetSourceName) {
-		// Pass all trackers through trackerPreUpdate
-		Tracker headTracker = trackerPreUpdate(this.headTracker);
 		List<Tracker> trackersToReset = humanPoseManager.getTrackersToReset();
 
 		// Resets the mounting rotation of the trackers with the HMD as

--- a/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -27,6 +27,7 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	private var driftSince: Long = 0
 	private var timeAtLastReset: Long = 0
 	var allowDriftCompensation = false
+	var lastResetQuaternion: Quaternion? = null
 
 	// Manual mounting orientation
 	var mountingOrientation: Quaternion = EulerAngles(
@@ -139,7 +140,9 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	 * 0). This allows the tracker to be strapped to body at any pitch and roll.
 	 */
 	fun resetFull(reference: Quaternion) {
-		val rot = adjustToReference(tracker.getRawRotation())
+		lastResetQuaternion = adjustToReference(tracker.getRawRotation())
+
+		val rot: Quaternion = adjustToReference(tracker.getRawRotation())
 
 		if (tracker.needsMounting) {
 			fixGyroscope(tracker.getRawRotation() * mountingOrientation)
@@ -164,7 +167,9 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	 * position should be corrected in the source.
 	 */
 	fun resetYaw(reference: Quaternion) {
-		val rot = adjustToReference(tracker.getRawRotation())
+		lastResetQuaternion = adjustToReference(tracker.getRawRotation())
+
+		val rot: Quaternion = adjustToReference(tracker.getRawRotation())
 
 		fixYaw(tracker.getRawRotation() * mountingOrientation, reference)
 


### PR DESCRIPTION
This logs tracker yaw difference between every full or yaw reset in the format `[INFO] [HumanPoseManager] x seconds since last reset. Tracker yaw drifts: tracker mac address, x deg (x deg/min) | etc `

Example with 3 BNO085: `[INFO] [HumanPoseManager] 1162 seconds since last reset. Tracker yaw drifts: udp://F4:CF:A2:4C:B5:FB/0, 0.5888 deg (0.0304 deg/min) | udp://E8:DB:84:98:84:C2/0, 0.3599 deg (0.0186 deg/min) | udp://98:CD:AC:31:AE:B9/0, 0.5923 deg (0.0306 deg/min) | `

Also reset every tracker to prevent the need to use logic where it doesn't belong. This is good anyways for visualizing trackers in GUI and should've been done a while ago.

Needs https://github.com/SlimeVR/SlimeVR-Server/pull/647