### PR TITLE
Require the use of run command for running server

### DIFF
--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
 		log::info!("Using Java binary: {:?}", java_bin);
 		let (recv, child) = Command::new(java_bin.to_str().unwrap())
 			.current_dir(p)
-			.args(["-Xmx512M", "-jar", "slimevr.jar", "--no-gui"])
+			.args(["-Xmx512M", "-jar", "slimevr.jar", "run"])
 			.spawn()
 			.expect("Unable to start the server jar");
 		backend = Some(child);

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -182,4 +182,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 	}
 }
 
-tasks.getByName("run", JavaExec::class) { standardInput = System.`in` }
+tasks.getByName("run", JavaExec::class) {
+	standardInput = System.`in`
+	args = listOf("run")
+}

--- a/server/src/main/java/dev/slimevr/Main.kt
+++ b/server/src/main/java/dev/slimevr/Main.kt
@@ -7,7 +7,6 @@ import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.CommandLineParser
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
-import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.lang3.SystemUtils
 import java.io.File
@@ -31,16 +30,15 @@ fun main(args: Array<String>) {
 	val parser: CommandLineParser = DefaultParser()
 	val formatter = HelpFormatter()
 	val options = Options()
-	val help = Option("h", "help", false, "Show help")
-	val version = Option("V", "version", false, "Show version")
-	options.addOption(help)
-	options.addOption(version)
+	options.addOption("h", "help", false, "Show help")
+	options.addOption("V", "version", false, "Show version")
 	val cmd: CommandLine = try {
 		parser.parse(options, args, true)
 	} catch (e: org.apache.commons.cli.ParseException) {
 		formatter.printHelp("slimevr.jar", options)
 		exitProcess(1)
 	}
+
 	if (cmd.hasOption("help")) {
 		formatter.printHelp("slimevr.jar", options)
 		exitProcess(0)
@@ -49,6 +47,16 @@ fun main(args: Array<String>) {
 		println("SlimeVR Server $VERSION")
 		exitProcess(0)
 	}
+
+	if (cmd.args.isEmpty()) {
+		System.err.println("No command specified, expected 'run'")
+		exitProcess(1)
+	}
+	if (cmd.args[0] != "run") {
+		System.err.println("Unknown command: ${cmd.args[0]}, expected 'run'")
+		exitProcess(1)
+	}
+
 	val dir = File("").absoluteFile
 	try {
 		LogManager.initialize(dir)

--- a/server/src/main/java/dev/slimevr/Main.kt
+++ b/server/src/main/java/dev/slimevr/Main.kt
@@ -52,7 +52,7 @@ fun main(args: Array<String>) {
 		System.err.println("No command specified, expected 'run'")
 		exitProcess(1)
 	}
-	if (!cmd.args[0].equalsIgnoreCase("run")) {
+	if (!cmd.args[0].equals("run", true)) {
 		System.err.println("Unknown command: ${cmd.args[0]}, expected 'run'")
 		exitProcess(1)
 	}

--- a/server/src/main/java/dev/slimevr/Main.kt
+++ b/server/src/main/java/dev/slimevr/Main.kt
@@ -52,7 +52,7 @@ fun main(args: Array<String>) {
 		System.err.println("No command specified, expected 'run'")
 		exitProcess(1)
 	}
-	if (cmd.args[0] != "run") {
+	if (!cmd.args[0].equalsIgnoreCase("run")) {
 		System.err.println("Unknown command: ${cmd.args[0]}, expected 'run'")
 		exitProcess(1)
 	}


### PR DESCRIPTION
This forces the use of a command line to run the server, so people who double click it don't accidentally run the server in the background.