### PR TITLE
Fix user height calculation and AutoBone targetHeight initialization order

### DIFF
--- a/server/src/main/java/dev/slimevr/autobone/AutoBone.kt
+++ b/server/src/main/java/dev/slimevr/autobone/AutoBone.kt
@@ -372,9 +372,11 @@ class AutoBone(server: VRServer) {
 		skeleton1.setLegTweaksEnabled(false)
 		skeleton2.setLegTweaksEnabled(false)
 
-		val intermediateOffsets = EnumMap(
-			offsets
-		)
+		val intermediateOffsets = EnumMap(offsets)
+		// If target height isn't specified, auto-detect
+		if (targetHeight < 0f) {
+			targetHeight = getTargetHeight(frames)
+		}
 		val trainingStep = AutoBoneTrainingStep(
 			targetHeight,
 			skeleton1,
@@ -383,10 +385,6 @@ class AutoBone(server: VRServer) {
 			intermediateOffsets
 		)
 
-		// If target height isn't specified, auto-detect
-		if (targetHeight < 0f) {
-			targetHeight = getTargetHeight(frames)
-		}
 		val errorStats = StatsCalculator()
 
 		// Epoch loop, each epoch is one full iteration over the full dataset

--- a/server/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.java
@@ -35,7 +35,7 @@ public class SkeletonConfigManager {
 
 	protected final boolean autoUpdateOffsets;
 	protected HumanPoseManager humanPoseManager;
-	protected float userHeight;
+	protected float userHeight = calculateUserHeight();
 	static final float FLOOR_OFFSET = 0.05f;
 
 	public SkeletonConfigManager(boolean autoUpdateOffsets) {
@@ -107,12 +107,7 @@ public class SkeletonConfigManager {
 		}
 
 		// Re-calculate user height
-		userHeight = getOffset(SkeletonConfigOffsets.NECK)
-			+ getOffset(SkeletonConfigOffsets.CHEST)
-			+ getOffset(SkeletonConfigOffsets.WAIST)
-			+ getOffset(SkeletonConfigOffsets.HIP)
-			+ getOffset(SkeletonConfigOffsets.UPPER_LEG)
-			+ getOffset(SkeletonConfigOffsets.LOWER_LEG);
+		userHeight = calculateUserHeight();
 	}
 
 	public void setOffset(SkeletonConfigOffsets config, Float newValue) {
@@ -126,6 +121,15 @@ public class SkeletonConfigManager {
 
 		Float val = configOffsets.get(config);
 		return val != null ? val : config.defaultValue;
+	}
+
+	private float calculateUserHeight() {
+		return getOffset(SkeletonConfigOffsets.NECK)
+			+ getOffset(SkeletonConfigOffsets.CHEST)
+			+ getOffset(SkeletonConfigOffsets.WAIST)
+			+ getOffset(SkeletonConfigOffsets.HIP)
+			+ getOffset(SkeletonConfigOffsets.UPPER_LEG)
+			+ getOffset(SkeletonConfigOffsets.LOWER_LEG);
 	}
 
 	public float getUserHeightFromOffsets() {


### PR DESCRIPTION
- Fixes a small bug in the order of `targetHeight` initialization stuff that caused it to not be set properly in `AutoBoneStep`. This should fix the functionality of height error.
- Fixes `userHeight` not being initially calculated by `SkeletonConfigManager`.