### PR TITLE
Fix player trackers not being found or assigned in HumanSkeleton

### DIFF
--- a/server/src/main/java/dev/slimevr/poseframeformat/trackerdata/TrackerFrames.kt
+++ b/server/src/main/java/dev/slimevr/poseframeformat/trackerdata/TrackerFrames.kt
@@ -42,7 +42,8 @@ data class TrackerFrames(val name: String = "", val frames: FastList<TrackerFram
 			hasPosition = firstFrame.hasPosition(),
 			hasRotation = firstFrame.hasRotation(),
 			hasAcceleration = firstFrame.hasAcceleration(),
-			isInternal = true,
+			// Make sure this is false!! Otherwise HumanSkeleton ignores it
+			isInternal = false,
 			isComputed = true
 		)
 


### PR DESCRIPTION
uh oops, AutoBone completely brokey since #647
- Sets the `Tracker`s used in `PlayerTracker` to be non-internal so they are recognized by `HumanSkeleton`