### PR TITLE
Fix reset status on yaw reset

### DIFF
--- a/server/src/main/java/dev/slimevr/protocol/rpc/setup/RPCUtil.kt
+++ b/server/src/main/java/dev/slimevr/protocol/rpc/setup/RPCUtil.kt
@@ -6,7 +6,7 @@ object RPCUtil {
 	@JvmStatic
 	fun getLocalIp(): String =
 		NetworkInterface.getNetworkInterfaces().asSequence().first {
-			it.isUp && !it.isLoopback && !it.isVirtual
+			it.isUp && !it.isLoopback && !it.isVirtual && it.interfaceAddresses.any { it.broadcast != null }
 		}.interfaceAddresses.first {
 			it.broadcast != null
 		}.address.hostAddress

--- a/server/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -56,10 +56,23 @@ class Tracker @JvmOverloads constructor(
 	var temperature: Float? = null
 	var customName: String? = null
 
+	/**
+	 * If the tracker has gotten disconnected after it was initialized first time
+	 */
+	var disconnectedRecently = false
+	private var alreadyInitialized = false
 	var status = TrackerStatus.DISCONNECTED
 		set(value) {
 			if (field == value) return
+
 			field = value
+
+			if (field == TrackerStatus.DISCONNECTED && alreadyInitialized) {
+				disconnectedRecently = true
+			}
+			if (field.sendData) {
+				alreadyInitialized = true
+			}
 			if (!isInternal) {
 				// If the status of a non-internal tracker has changed, inform
 				// the VRServer to recreate the skeleton, as it may need to

--- a/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -183,9 +183,11 @@ class TrackerResetsHandler(val tracker: Tracker) {
 
 		calculateDrift(rot)
 
-		// Let's just remove the status if you do yaw reset, apparently it works
-		if (this.tracker.lastResetStatus != 0u) {
+		// Let's just remove the status if you do yaw reset if the tracker was
+		// disconnected and then connected back
+		if (this.tracker.lastResetStatus != 0u && this.tracker.disconnectedRecently) {
 			vrServer.statusSystem.removeStatus(this.tracker.lastResetStatus)
+			this.tracker.disconnectedRecently = false
 			this.tracker.lastResetStatus = 0u
 		}
 	}

--- a/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -182,6 +182,12 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		makeIdentityAdjustmentQuatsYaw()
 
 		calculateDrift(rot)
+
+		// Let's just remove the status if you do yaw reset, apparently it works
+		if (this.tracker.lastResetStatus != 0u) {
+			vrServer.statusSystem.removeStatus(this.tracker.lastResetStatus)
+			this.tracker.lastResetStatus = 0u
+		}
 	}
 
 	/**


### PR DESCRIPTION
Apparently doing yaw reset is enough to fix the status, but I don't want it to always be based on that, so let's do this
If the tracker was recently disconnected (after already being initialized) then you can do yaw reset and it will fix the status.
I added this extra logic to prevent people being able to just press yaw reset and always fixing the status

I also had a bug that didn't let me work on this, I had more interfaces and the IP lookup code was crashing so I fixed that