### PR TITLE
PoseFrame fix & AutoBone change

### DIFF
--- a/server/src/main/java/dev/slimevr/autobone/AutoBone.kt
+++ b/server/src/main/java/dev/slimevr/autobone/AutoBone.kt
@@ -314,7 +314,7 @@ class AutoBone(server: VRServer) {
 		val targetHeight: Float
 		// Get the current skeleton from the server
 		val humanPoseManager = humanPoseManager
-		if (humanPoseManager != null) {
+		if (config.useSkeletonHeight && humanPoseManager != null) {
 			// If there is a skeleton available, calculate the target height
 			// from its configs
 			targetHeight = humanPoseManager.userHeightFromConfig

--- a/server/src/main/java/dev/slimevr/config/AutoBoneConfig.kt
+++ b/server/src/main/java/dev/slimevr/config/AutoBoneConfig.kt
@@ -22,4 +22,5 @@ class AutoBoneConfig {
 	var sampleCount = 1000
 	var sampleRateMs: Long = 20
 	var saveRecordings = false
+	var useSkeletonHeight = false
 }

--- a/server/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
+++ b/server/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
@@ -93,8 +93,8 @@ class PoseRecorder(private val server: VRServer) {
 		// Update tracker list
 		this.trackers.ensureCapacity(trackers.size)
 		for (tracker in trackers) {
-			// Ignore null trackers
-			if (tracker == null) {
+			// Ignore null and internal trackers
+			if (tracker == null || tracker.isInternal) {
 				continue
 			}
 

--- a/server/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
+++ b/server/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
@@ -93,8 +93,8 @@ class PoseRecorder(private val server: VRServer) {
 		// Update tracker list
 		this.trackers.ensureCapacity(trackers.size)
 		for (tracker in trackers) {
-			// Ignore null and computed trackers
-			if (tracker == null || tracker.isComputed) {
+			// Ignore null trackers
+			if (tracker == null) {
 				continue
 			}
 


### PR DESCRIPTION
- Fix ignoring computed trackers instead of internal trackers, HMD and controllers are now computed and they cannot be ignored
  - This caused issues with AutoBone recordings not including the HMD and giving terrible results
- Added a config `useSkeletonHeight` (defaults to false) to choose to use the skeleton height if possible
  - Warning: This changes the default behaviour of AutoBone to use the recording's HMD height rather than the skeleton height