### PR TITLE
Track connection by SocketAddress instead of IP address.

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -12,7 +12,12 @@ import io.github.axisangles.ktmath.Quaternion.Companion.fromRotationVector
 import io.github.axisangles.ktmath.Vector3
 import org.apache.commons.lang3.ArrayUtils
 import solarxr_protocol.rpc.ResetType
-import java.net.*
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.SocketAddress
+import java.net.SocketTimeoutException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
@@ -73,9 +78,9 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 						[TrackerServer] Tracker $i handed over to address ${handshakePacket.socketAddress}.
 						Board type: ${handshake.boardType},
 						imu type: ${handshake.imuType},
-						firmware: ${handshake.firmware} (${firmwareBuild}),
+						firmware: ${handshake.firmware} ($firmwareBuild),
 						mac: ${handshake.macString},
-						name: ${name}
+						name: $name
 						""".trimIndent()
 					)
 			}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -12,12 +12,7 @@ import io.github.axisangles.ktmath.Quaternion.Companion.fromRotationVector
 import io.github.axisangles.ktmath.Vector3
 import org.apache.commons.lang3.ArrayUtils
 import solarxr_protocol.rpc.ResetType
-import java.net.DatagramPacket
-import java.net.DatagramSocket
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.NetworkInterface
-import java.net.SocketTimeoutException
+import java.net.*
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
@@ -32,7 +27,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 	Thread(name) {
 	private val random = Random()
 	private val connections: MutableList<UDPDevice> = FastList()
-	private val connectionsByAddress: MutableMap<InetAddress, UDPDevice> = HashMap()
+	private val connectionsByAddress: MutableMap<SocketAddress, UDPDevice> = HashMap()
 	private val connectionsByMAC: MutableMap<String, UDPDevice> = HashMap()
 	private val broadcastAddresses: List<InetSocketAddress> = try {
 		NetworkInterface.getNetworkInterfaces().asSequence().filter {
@@ -60,7 +55,31 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 		LogManager.info("[TrackerServer] Handshake received from ${handshakePacket.address}:${handshakePacket.port}")
 		val addr = handshakePacket.address
 
-		val connection: UDPDevice = synchronized(connections) { connectionsByAddress[addr] } ?: run {
+		val connection: UDPDevice = synchronized(connections) {
+			connectionsByMAC[handshake.macString]?.apply {
+				connectionsByAddress.remove(address)
+				address = handshakePacket.socketAddress
+				lastPacketNumber = 0
+				ipAddress = addr
+				name = handshake.macString?.let { "udp://$it" }
+				descriptiveName = "udp:/${handshakePacket.address}"
+				firmwareBuild = handshake.firmwareBuild
+				connectionsByAddress[address] = this
+
+				val i = connections.indexOf(this)
+				LogManager
+					.info(
+						"""
+						[TrackerServer] Tracker $i handed over to address ${handshakePacket.socketAddress}.
+						Board type: ${handshake.boardType},
+						imu type: ${handshake.imuType},
+						firmware: ${handshake.firmware} (${firmwareBuild}),
+						mac: ${handshake.macString},
+						name: ${name}
+						""".trimIndent()
+					)
+			}
+		} ?: run {
 			val connection = UDPDevice(
 				handshakePacket.socketAddress,
 				addr,
@@ -87,13 +106,13 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				if (handshake.macString != null && connectionsByMAC.containsKey(handshake.macString)) {
 					val previousConnection = connectionsByMAC[handshake.macString]!!
 					val i = connections.indexOf(previousConnection)
-					connectionsByAddress.remove(previousConnection.ipAddress)
+					connectionsByAddress.remove(previousConnection.address)
 					previousConnection.lastPacketNumber = 0
 					previousConnection.ipAddress = addr
 					previousConnection.address = handshakePacket.socketAddress
 					previousConnection.name = connection.name
 					previousConnection.descriptiveName = connection.descriptiveName
-					connectionsByAddress[addr] = previousConnection
+					connectionsByAddress[handshakePacket.socketAddress] = previousConnection
 					LogManager
 						.info(
 							"""
@@ -108,7 +127,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				} else {
 					val i = connections.size
 					connections.add(connection)
-					connectionsByAddress[addr] = connection
+					connectionsByAddress[handshakePacket.socketAddress] = connection
 					if (handshake.macString != null) {
 						connectionsByMAC[handshake.macString!!] = connection
 					}
@@ -194,7 +213,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 					socket.receive(received)
 					bb.limit(received.length)
 					bb.rewind()
-					val connection = synchronized(connections) { connectionsByAddress[received.address] }
+					val connection = synchronized(connections) { connectionsByAddress[received.socketAddress] }
 					parser.parse(bb, connection)
 						.filterNotNull()
 						.forEach { processPacket(received, it, connection) }


### PR DESCRIPTION
Reconnections are detected via MAC address instead of by IP address, as well.

This file feels like it needs some cleanup after this change -- those of you that have a better idea of exactly what's going on here, feel free to clean it up. Alternatively, I might have fucked something up.

The goal of this change is to allow slimevr server to talk to trackers through a NAT-like proxy, such as sudppipe (from  <http://aluigi.altervista.org/mytoolz.htm>), or allow multiple programs that work like slimevr wrangler to run on the same machine.

In terms of testing, we need someone to test this with tracker connect/disconnect/reconnect to make sure I didn't break things, and eventually someone who can test proxying multiple trackers to slimevr server. (I might be able to pull off the latter test myself once the house cools down.)