### PR TITLE
Adjusted com calcs

### DIFF
--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweakBuffer.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweakBuffer.java
@@ -83,10 +83,9 @@ public class LegTweakBuffer {
 	// hyperparameters
 	public static final float SKATING_DISTANCE_CUTOFF = 0.5f;
 	static float SKATING_VELOCITY_THRESHOLD = 2.4f;
-	static float SKATING_ACCELERATION_THRESHOLD = 0.7f;
+	static float SKATING_ACCELERATION_THRESHOLD = 0.8f;
 	private static final float SKATING_ROTVELOCITY_THRESHOLD = 4.5f;
 	private static final float SKATING_LOCK_ENGAGE_PERCENT = 0.85f;
-	private static final float SKATING_ACCELERATION_Y_USE_PERCENT = 0.25f;
 	private static final float FLOOR_DISTANCE_CUTOFF = 0.125f;
 	private static final float SIX_TRACKER_TOLERANCE = -0.10f;
 	private static final Vector3 FORCE_VECTOR_TO_PRESSURE = new Vector3(0.25f, 1.0f, 0.25f);
@@ -523,17 +522,9 @@ public class LegTweakBuffer {
 	// compute the acceleration magnitude of the feet from the acceleration
 	// given by the imus (exclude y)
 	private void computeAccelerationMagnitude() {
-		leftFootAccelerationMagnitude = new Vector3(
-			leftFootAcceleration.getX(),
-			leftFootAcceleration.getY() * SKATING_ACCELERATION_Y_USE_PERCENT,
-			leftFootAcceleration.getZ()
-		).len();
+		leftFootAccelerationMagnitude = leftFootAcceleration.len();
 
-		rightFootAccelerationMagnitude = new Vector3(
-			rightFootAcceleration.getX(),
-			rightFootAcceleration.getY() * SKATING_ACCELERATION_Y_USE_PERCENT,
-			rightFootAcceleration.getZ()
-		).len();
+		rightFootAccelerationMagnitude = rightFootAcceleration.len();
 	}
 
 	// compute the velocity and acceleration of the center of mass

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
@@ -47,15 +47,6 @@ public class LegTweaks {
 
 	// hyperparameters (COM calculation)
 	// mass percentages of the body
-
-	/**
-	 * Averaged male/female body masses per segment for the average person
-	 * Forearm and Hand: 2.24 Upper Arm: 2.63 Leg And Foot: 6.20 Thigh: 11.22
-	 * Head and Trunk total: 55.45 Head: 8.27 Thorax / mid-point of upper chest
-	 * to chest: 18.7 Abdomen / mid-point of chest to waist: 13.2 Pelvis /
-	 * mip-point of waist to hip: 15.3
-	 */
-
 	private static final float HEAD_MASS = 0.0827f;
 	private static final float THORAX_MASS = 0.1870f;
 	private static final float ABDOMEN_MASS = 0.1320f;

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
@@ -47,14 +47,28 @@ public class LegTweaks {
 
 	// hyperparameters (COM calculation)
 	// mass percentages of the body
-	private static final float HEAD_MASS = 0.082f;
-	private static final float UPPER_CHEST_MASS = 0.125f;
-	private static final float CHEST_MASS = 0.125f;
-	private static final float WAIST_MASS = 0.209f;
-	private static final float THIGH_MASS = 0.128f;
-	private static final float CALF_MASS = 0.0535f;
-	private static final float UPPER_ARM_MASS = 0.031f;
-	private static final float FOREARM_MASS = 0.017f;
+
+	/**
+	 * Averaged male/female body masses per segment for the average person
+	 * Forearm and Hand: 2.24
+	 * Upper Arm: 2.63
+	 * Leg And Foot: 6.20
+	 * Thigh: 11.22
+	 * Head and Trunk total: 55.45
+	 * Head: 8.27
+	 * Thorax / mid-point of upper chest to chest: 18.7
+	 * Abdomen / mid-point of chest to waist: 13.2
+	 * Pelvis / mip-point of waist to hip: 15.3
+	 */
+
+	private static final float HEAD_MASS = 0.0827f;
+	private static final float THORAX_MASS = 0.1870f;
+	private static final float ABDOMEN_MASS = 0.1320f;
+	private static final float PELVIS_MASS = 0.1530f;
+	private static final float THIGH_MASS = 0.1122f;
+	private static final float LEG_AND_FOOT_MASS = 0.0620f;
+	private static final float UPPER_ARM_MASS = 0.0263f;
+	private static final float FOREARM_AND_HAND_MASS = 0.0224f;
 
 	// hyperparameters (rotation correction)
 	private static final float ROTATION_CORRECTION_VERTICAL = 0.1f;
@@ -1097,19 +1111,19 @@ public class LegTweaks {
 		// compute the center of mass of smaller body parts and then sum them up
 		// with their respective weights
 		Vector3 head = skeleton.headNode.getWorldTransform().getTranslation();
-		Vector3 upperChest = skeleton.upperChestNode.getWorldTransform().getTranslation();
-		Vector3 chest = skeleton.chestNode.getWorldTransform().getTranslation();
-		Vector3 hip = skeleton.hipNode.getWorldTransform().getTranslation();
+		Vector3 thorax = skeleton.chestNode.getWorldTransform().getTranslation();
+		Vector3 abdomen = getCenterOfJoint(skeleton.chestNode, skeleton.waistNode);
+		Vector3 pelvis = skeleton.hipNode.getWorldTransform().getTranslation();
 		Vector3 leftCalf = getCenterOfJoint(skeleton.leftAnkleNode, skeleton.leftKneeNode);
 		Vector3 rightCalf = getCenterOfJoint(skeleton.rightAnkleNode, skeleton.rightKneeNode);
 		Vector3 leftThigh = getCenterOfJoint(skeleton.leftKneeNode, skeleton.leftHipNode);
 		Vector3 rightThigh = getCenterOfJoint(skeleton.rightKneeNode, skeleton.rightHipNode);
 		centerOfMass = centerOfMass.plus(head.times(HEAD_MASS));
-		centerOfMass = centerOfMass.plus(upperChest.times(UPPER_CHEST_MASS));
-		centerOfMass = centerOfMass.plus(chest.times(CHEST_MASS));
-		centerOfMass = centerOfMass.plus(hip.times(WAIST_MASS));
-		centerOfMass = centerOfMass.plus(leftCalf.times(CALF_MASS));
-		centerOfMass = centerOfMass.plus(rightCalf.times(CALF_MASS));
+		centerOfMass = centerOfMass.plus(thorax.times(THORAX_MASS));
+		centerOfMass = centerOfMass.plus(abdomen.times(ABDOMEN_MASS));
+		centerOfMass = centerOfMass.plus(pelvis.times(PELVIS_MASS));
+		centerOfMass = centerOfMass.plus(leftCalf.times(LEG_AND_FOOT_MASS));
+		centerOfMass = centerOfMass.plus(rightCalf.times(LEG_AND_FOOT_MASS));
 		centerOfMass = centerOfMass.plus(leftThigh.times(THIGH_MASS));
 		centerOfMass = centerOfMass.plus(rightThigh.times(THIGH_MASS));
 
@@ -1129,17 +1143,17 @@ public class LegTweaks {
 			);
 			centerOfMass = centerOfMass.plus(leftUpperArm.times(UPPER_ARM_MASS));
 			centerOfMass = centerOfMass.plus(rightUpperArm.times(UPPER_ARM_MASS));
-			centerOfMass = centerOfMass.plus(leftForearm.times(FOREARM_MASS));
-			centerOfMass = centerOfMass.plus(rightForearm.times(FOREARM_MASS));
+			centerOfMass = centerOfMass.plus(leftForearm.times(FOREARM_AND_HAND_MASS));
+			centerOfMass = centerOfMass.plus(rightForearm.times(FOREARM_AND_HAND_MASS));
 		} else {
 			// if the arms are not available put them slightly in front
 			// of the upper chest.
 			Vector3 chestUnitVector = computeUnitVector(
 				skeleton.upperChestNode.getWorldTransform().getRotation()
 			);
-			Vector3 armLocation = chest.plus(chestUnitVector.times(DEFAULT_ARM_DISTANCE));
+			Vector3 armLocation = abdomen.plus(chestUnitVector.times(DEFAULT_ARM_DISTANCE));
 			centerOfMass = centerOfMass.plus(armLocation.times(UPPER_ARM_MASS * 2.0f));
-			centerOfMass = centerOfMass.plus(armLocation.times(FOREARM_MASS * 2.0f));
+			centerOfMass = centerOfMass.plus(armLocation.times(FOREARM_AND_HAND_MASS * 2.0f));
 		}
 
 		// finally translate in to tracker space

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
@@ -1106,8 +1106,8 @@ public class LegTweaks {
 		// compute the center of mass of smaller body parts and then sum them up
 		// with their respective weights
 		Vector3 head = skeleton.headNode.getWorldTransform().getTranslation();
-		Vector3 thorax = skeleton.chestNode.getWorldTransform().getTranslation();
-		Vector3 abdomen = getCenterOfJoint(skeleton.chestNode, skeleton.waistNode);
+		Vector3 thorax = getCenterOfJoint(skeleton.chestNode, skeleton.upperChestNode);
+		Vector3 abdomen = skeleton.waistNode.getWorldTransform().getTranslation();
 		Vector3 pelvis = skeleton.hipNode.getWorldTransform().getTranslation();
 		Vector3 leftCalf = getCenterOfJoint(skeleton.leftAnkleNode, skeleton.leftKneeNode);
 		Vector3 rightCalf = getCenterOfJoint(skeleton.rightAnkleNode, skeleton.rightKneeNode);

--- a/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
+++ b/server/src/main/java/dev/slimevr/tracking/processor/skeleton/LegTweaks.java
@@ -50,15 +50,10 @@ public class LegTweaks {
 
 	/**
 	 * Averaged male/female body masses per segment for the average person
-	 * Forearm and Hand: 2.24
-	 * Upper Arm: 2.63
-	 * Leg And Foot: 6.20
-	 * Thigh: 11.22
-	 * Head and Trunk total: 55.45
-	 * Head: 8.27
-	 * Thorax / mid-point of upper chest to chest: 18.7
-	 * Abdomen / mid-point of chest to waist: 13.2
-	 * Pelvis / mip-point of waist to hip: 15.3
+	 * Forearm and Hand: 2.24 Upper Arm: 2.63 Leg And Foot: 6.20 Thigh: 11.22
+	 * Head and Trunk total: 55.45 Head: 8.27 Thorax / mid-point of upper chest
+	 * to chest: 18.7 Abdomen / mid-point of chest to waist: 13.2 Pelvis /
+	 * mip-point of waist to hip: 15.3
 	 */
 
 	private static final float HEAD_MASS = 0.0827f;


### PR DESCRIPTION
adjusts how the COM is calculated to account for the upper chest and removes a redundant removal of Y acceleration in leg tweaks (if anything high y accel should indicate the foot is not planted)