### PR TITLE
Minor: Updated battery indicator V placement

### DIFF
--- a/gui/src/components/tracker/TrackerBattery.tsx
+++ b/gui/src/components/tracker/TrackerBattery.tsx
@@ -42,7 +42,7 @@ export function TrackerBattery({
         </Typography>
         {voltage && config?.debug && (
           <Typography color={textColor}>
-            {voltageFormatter.format(voltage)} V
+            {voltageFormatter.format(voltage)}V
           </Typography>
         )}
       </div>


### PR DESCRIPTION
PR Minor Edit: Tweaked Battery voltage "V" to be beside numbers instead of separated.

Should resolve GUI issue where V is in a separate line when font scaling 13+.