### PR TITLE
Fix HMD designation

### DIFF
--- a/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -254,6 +254,24 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 					}
 				}
 			}
+			if (version < 11) {
+				// Sets HMD's designation to "body:head"
+				ObjectNode oldTrackersNode = (ObjectNode) modelData.get("trackers");
+				if (oldTrackersNode != null) {
+					var trackersIter = oldTrackersNode.iterator();
+					var fieldNamesIter = oldTrackersNode.fieldNames();
+					ObjectNode trackersNode = nodeFactory.objectNode();
+					String fieldName;
+					while (trackersIter.hasNext()) {
+						ObjectNode node = (ObjectNode) trackersIter.next();
+						fieldName = fieldNamesIter.next();
+						if (fieldName.equals("HMD"))
+							node.set("designation", new TextNode("body:head"));
+						trackersNode.set(fieldName, node);
+					}
+					modelData.set("trackers", trackersNode);
+				}
+			}
 		} catch (Exception e) {
 			LogManager.severe("Error during config migration: " + e);
 		}

--- a/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.*;
 import com.github.jonpeterson.jackson.module.versioning.VersionedModelConverter;
 import dev.slimevr.tracking.processor.config.SkeletonConfigOffsets;
+import dev.slimevr.tracking.trackers.TrackerPosition;
 import io.eiren.util.logging.LogManager;
 
 import java.util.Map;
@@ -260,7 +261,11 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 				if (trackersNode != null) {
 					ObjectNode HMDNode = (ObjectNode) trackersNode.get("HMD");
 					if (HMDNode != null) {
-						HMDNode.set("designation", new TextNode("body:head"));
+						HMDNode
+							.set(
+								"designation",
+								new TextNode(TrackerPosition.HEAD.getDesignation())
+							);
 						trackersNode.set("HMD", HMDNode);
 						modelData.set("trackers", trackersNode);
 					}

--- a/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
+++ b/server/core/src/main/java/dev/slimevr/config/CurrentVRConfigConverter.java
@@ -256,20 +256,14 @@ public class CurrentVRConfigConverter implements VersionedModelConverter {
 			}
 			if (version < 11) {
 				// Sets HMD's designation to "body:head"
-				ObjectNode oldTrackersNode = (ObjectNode) modelData.get("trackers");
-				if (oldTrackersNode != null) {
-					var trackersIter = oldTrackersNode.iterator();
-					var fieldNamesIter = oldTrackersNode.fieldNames();
-					ObjectNode trackersNode = nodeFactory.objectNode();
-					String fieldName;
-					while (trackersIter.hasNext()) {
-						ObjectNode node = (ObjectNode) trackersIter.next();
-						fieldName = fieldNamesIter.next();
-						if (fieldName.equals("HMD"))
-							node.set("designation", new TextNode("body:head"));
-						trackersNode.set(fieldName, node);
+				ObjectNode trackersNode = (ObjectNode) modelData.get("trackers");
+				if (trackersNode != null) {
+					ObjectNode HMDNode = (ObjectNode) trackersNode.get("HMD");
+					if (HMDNode != null) {
+						HMDNode.set("designation", new TextNode("body:head"));
+						trackersNode.set("HMD", HMDNode);
+						modelData.set("trackers", trackersNode);
 					}
-					modelData.set("trackers", trackersNode);
 				}
 			}
 		} catch (Exception e) {

--- a/server/core/src/main/java/dev/slimevr/config/VRConfig.java
+++ b/server/core/src/main/java/dev/slimevr/config/VRConfig.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 
 @JsonVersionedModel(
-	currentVersion = "10", defaultDeserializeToVersion = "10", toCurrentConverterClass = CurrentVRConfigConverter.class
+	currentVersion = "11", defaultDeserializeToVersion = "11", toCurrentConverterClass = CurrentVRConfigConverter.class
 )
 public class VRConfig {
 

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.java
@@ -84,7 +84,6 @@ public abstract class SteamVRBridge extends ProtobufBridge implements Runnable {
 	@Override
 	@VRServerThread
 	protected Tracker createNewTracker(ProtobufMessages.TrackerAdded trackerAdded) {
-		// Todo: We need the manufacturer
 		Device device = VRServer.Companion.getInstance().deviceManager
 			.createDevice(
 				trackerAdded.getTrackerName(),
@@ -99,7 +98,7 @@ public abstract class SteamVRBridge extends ProtobufBridge implements Runnable {
 				displayName = "SteamVR Driver HMD";
 			else
 				displayName = "Feeder App HMD";
-			// TODO support needsReset = true if HMD isn't assigned to head
+			// TODO support needsReset = true for VTubing (GUI toggle?)
 			needsReset = false;
 		} else {
 			displayName = trackerAdded.getTrackerName();


### PR DESCRIPTION
At some point, the designation for the HMD was "HMD", which is invalid (it should be "body:head").
Since we've never given the option to change the HMD's role, we just force its role to the head as a config migration.