### PR TITLE
Fix a few issues in UDP connection logic

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -14,9 +14,9 @@ import org.apache.commons.lang3.ArrayUtils
 import solarxr_protocol.rpc.ResetType
 import java.net.DatagramPacket
 import java.net.DatagramSocket
-import java.net.SocketAddress
 import java.net.InetSocketAddress
 import java.net.NetworkInterface
+import java.net.SocketAddress
 import java.net.SocketTimeoutException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder


### PR DESCRIPTION
Makes the following changes:
* Stores connections by SocketAddress (ip:port) instead of InetAddress (ip only)
* * This behaves properly when a client connects, disconnects, then tries to connect with a different port but same IP (if the udp port is randomly assigned for example)
* * Previously re-connecting to the server would work if the client always bound to the same UDP port (as the trackers do: https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/5fe244423a52ae21d1fc15e4bc057166ff73e91d/src/network/connection.cpp#L608 )
* * If the port differed but IP remained the same, setUpNewConnection would see the same InetAddress and re-use the existing UDPDevice without updating the old socketAddress (which still has the old port!)
* * With this change the SocketAddress differs so a new UDPDevice is made. If the MAC hasn't changed then the previous connection will be found by MAC and updated by the already existing logic
* * This also now allows running multiple clients from the same IP address (as long as the reported MACs differ)
* Uses the correct UDPDevice later in the case when a previous connection with same MAC is found and reused
* * Previously `setUpSensor(connection, 0, handshake.imuType, 1)` would be called on the newly created UDPDevice, which never ends up being used because previousConnection is updated instead, so each new connection would add a phantom tracker for a device that's never used  (this only would happen if firmwareBuild < 9 and the address differed)
* * I also moved `VRServer.instance.deviceManager.addDevice(connection)` to only the branch when the new UDPDevice is added, although I'm not sure what this is supposed to do, I couldn't find any uses of deviceManager's device list

You can reproduce the bugs on the original server using https://gist.github.com/abb128/15c31fcdda6388818276710d52b08406 , and with this PR the bugs disappear