### PR TITLE
Track connection by socket address if HWID is unavailable

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -57,15 +57,19 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 	private fun setUpNewConnection(handshakePacket: DatagramPacket, handshake: UDPPacket3Handshake) {
 		LogManager.info("[TrackerServer] Handshake received from ${handshakePacket.address}:${handshakePacket.port}")
 		val addr = handshakePacket.address
+		val socketAddr = handshakePacket.socketAddress
 
+		// Get a connection either by an existing one, or by creating a new one
 		val connection: UDPDevice = synchronized(connections) {
 			connectionsByMAC[handshake.macString]?.apply {
+				// Look for an existing connection by the MAC address and update the
+				// connection information
 				connectionsByAddress.remove(address)
-				address = handshakePacket.socketAddress
+				address = socketAddr
 				lastPacketNumber = 0
 				ipAddress = addr
 				name = handshake.macString?.let { "udp://$it" }
-				descriptiveName = "udp:/${handshakePacket.address}"
+				descriptiveName = "udp:/$addr"
 				firmwareBuild = handshake.firmwareBuild
 				connectionsByAddress[address] = this
 
@@ -73,7 +77,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				LogManager
 					.info(
 						"""
-						[TrackerServer] Tracker $i handed over to address ${handshakePacket.socketAddress}.
+						[TrackerServer] Tracker $i handed over to address $socketAddr.
 						Board type: ${handshake.boardType},
 						imu type: ${handshake.imuType},
 						firmware: ${handshake.firmware} ($firmwareBuild),
@@ -81,10 +85,32 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 						name: $name
 						""".trimIndent()
 					)
-			} ?: connectionsByAddress[handshakePacket.socketAddress]
+			} ?: connectionsByAddress[socketAddr]?.apply {
+				// Look for an existing connection by the socket address (IP and port)
+				// and update the connection information
+				lastPacketNumber = 0
+				ipAddress = addr
+				name = handshake.macString?.let { "udp://$it" }
+					?: "udp:/$addr"
+				descriptiveName = "udp:/$addr"
+				firmwareBuild = handshake.firmwareBuild
+				val i = connections.indexOf(this)
+				LogManager
+					.info(
+						"""
+						[TrackerServer] Tracker $i reconnected from address $socketAddr.
+						Board type: ${handshake.boardType},
+						imu type: ${handshake.imuType},
+						firmware: ${handshake.firmware} ($firmwareBuild),
+						mac: ${handshake.macString},
+						name: $name
+						""".trimIndent()
+					)
+			}
 		} ?: run {
+			// No existing connection could be found, create a new one
 			val connection = UDPDevice(
-				handshakePacket.socketAddress,
+				socketAddr,
 				addr,
 				handshake.macString ?: addr.hostAddress,
 				handshake.boardType,
@@ -99,53 +125,31 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				NetworkProtocol.SLIMEVR_RAW
 			}
 			connection.name = handshake.macString?.let { "udp://$it" }
-				?: "udp:/${handshakePacket.address}"
+				?: "udp:/$addr"
 			// TODO: The missing slash in udp:// was intended because InetAddress.toString()
 			// 		returns "hostname/address" but it wasn't known that if hostname is empty
 			// 		string it just looks like "/address" lol.
 			// 		Fixing this would break config!
-			connection.descriptiveName = "udp:/${handshakePacket.address}"
+			connection.descriptiveName = "udp:/$addr"
 			synchronized(connections) {
-				if (handshake.macString != null && connectionsByMAC.containsKey(handshake.macString)) {
-					val previousConnection = connectionsByMAC[handshake.macString]!!
-					val i = connections.indexOf(previousConnection)
-					connectionsByAddress.remove(previousConnection.address)
-					previousConnection.lastPacketNumber = 0
-					previousConnection.ipAddress = addr
-					previousConnection.address = handshakePacket.socketAddress
-					previousConnection.name = connection.name
-					previousConnection.descriptiveName = connection.descriptiveName
-					connectionsByAddress[handshakePacket.socketAddress] = previousConnection
-					LogManager
-						.info(
-							"""
-							[TrackerServer] Tracker $i handed over to address ${handshakePacket.socketAddress}.
-							Board type: ${handshake.boardType},
-							imu type: ${handshake.imuType},
-							firmware: ${handshake.firmware} (${connection.firmwareBuild}),
-							mac: ${handshake.macString},
-							name: ${previousConnection.name}
-							""".trimIndent()
-						)
-				} else {
-					val i = connections.size
-					connections.add(connection)
-					connectionsByAddress[handshakePacket.socketAddress] = connection
-					if (handshake.macString != null) {
-						connectionsByMAC[handshake.macString!!] = connection
-					}
-					LogManager
-						.info(
-							"""
-							[TrackerServer] Tracker $i handed over to address ${handshakePacket.socketAddress}.
-							Board type: ${handshake.boardType},
-							imu type: ${handshake.imuType},
-							firmware: ${handshake.firmware} (${connection.firmwareBuild}),
-							mac: ${handshake.macString},
-							name: ${connection.name}
-							""".trimIndent()
-						)
+				// Register the new connection
+				val i = connections.size
+				connections.add(connection)
+				connectionsByAddress[socketAddr] = connection
+				if (handshake.macString != null) {
+					connectionsByMAC[handshake.macString!!] = connection
 				}
+				LogManager
+					.info(
+						"""
+						[TrackerServer] Tracker $i connected from address $socketAddr.
+						Board type: ${handshake.boardType},
+						imu type: ${handshake.imuType},
+						firmware: ${handshake.firmware} (${connection.firmwareBuild}),
+						mac: ${handshake.macString},
+						name: ${connection.name}
+						""".trimIndent()
+					)
 			}
 			if (connection.protocol == NetworkProtocol.OWO_LEGACY || connection.firmwareBuild < 9) {
 				// Set up new sensor for older firmware.

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -81,7 +81,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 						name: $name
 						""".trimIndent()
 					)
-			}
+			} ?: connectionsByAddress[handshakePacket.socketAddress]
 		} ?: run {
 			val connection = UDPDevice(
 				handshakePacket.socketAddress,


### PR DESCRIPTION
It seems that sometimes owoTrack or the sort doesn't send HWID properly. That's not really good, but we should be able to handle it anyways by falling back to tracking the connection by the IP address and port. This isn't necessarily a bug, but it was changed in the last release and has broken previously "functioning" connection tracking.

I've also tried to clean up `TrackersUDPServer.kt` a bit and explain some of the things with comments. I removed the second MAC address check because the first one should find all of them and handle it just fine.