### PR TITLE
Fix NPE when tracking arms from controllers

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -1071,8 +1071,8 @@ class HumanSkeleton(
 				BoneType.RIGHT_FOOT_TRACKER -> trackerRightFootNode
 				BoneType.LEFT_SHOULDER -> leftShoulderTailNode
 				BoneType.RIGHT_SHOULDER -> rightShoulderTailNode
-				BoneType.LEFT_UPPER_ARM -> if (!isTrackingLeftArmFromController) leftElbowNode else null
-				BoneType.RIGHT_UPPER_ARM -> if (!isTrackingLeftArmFromController) rightElbowNode else null
+				BoneType.LEFT_UPPER_ARM -> leftElbowNode
+				BoneType.RIGHT_UPPER_ARM -> rightElbowNode
 				BoneType.LEFT_ELBOW_TRACKER -> trackerLeftElbowNode
 				BoneType.RIGHT_ELBOW_TRACKER -> trackerRightElbowNode
 				BoneType.LEFT_LOWER_ARM -> if (isTrackingLeftArmFromController) leftElbowNode else leftWristNode


### PR DESCRIPTION
Since all `BoneInfo` values are requested at [HumanSkeleton.kt line 270](https://github.com/SlimeVR/SlimeVR-Server/blob/main/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt#L270C24-L270C24), if `isTrackingLeftArmFromController` returns `true`, then there is no way there could not be a null exception.

Current workaround for 0.10.0 is to make sure "Force arms from HMD" is enabled in the settings.
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/5095026/6e49c0ee-fc7a-45ac-b31e-8b69c542cce7)