### PR TITLE
Force git tag fetching

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: recursive
       - name: Get tags
-        run: git fetch --tags origin --recurse-submodules=no
+        run: git fetch --tags origin --recurse-submodules=no --force
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
If a tag gets removed, if tried again, CI might fail. This fixes that