### PR TITLE
Fix pipe crash when SteamVR fails to boot

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.java
@@ -5,6 +5,7 @@ import dev.slimevr.desktop.platform.ProtobufMessages.*;
 import dev.slimevr.config.BridgeConfig;
 import dev.slimevr.tracking.trackers.*;
 import dev.slimevr.util.ann.VRServerThread;
+import dev.slimevr.bridge.BridgeThread;
 import io.eiren.util.collections.FastList;
 import solarxr_protocol.rpc.StatusData;
 import solarxr_protocol.rpc.StatusDataUnion;
@@ -383,11 +384,10 @@ public abstract class SteamVRBridge extends ProtobufBridge implements Runnable {
 	 */
 	protected int lastSteamVRStatus = 0;
 
+	@BridgeThread
 	protected void reportDisconnected() {
 		if (lastSteamVRStatus != 0) {
-			throw new IllegalStateException(
-				"lastSteamVRStatus wasn't 0 and it was " + lastSteamVRStatus + " instead"
-			);
+			return;
 		}
 		var statusData = new StatusSteamVRDisconnectedT();
 		statusData.setBridgeSettingsName(bridgeSettingsKey);
@@ -398,5 +398,15 @@ public abstract class SteamVRBridge extends ProtobufBridge implements Runnable {
 		lastSteamVRStatus = VRServer.Companion.getInstance().statusSystem
 			.addStatusInt(status, false);
 
+	}
+
+	@BridgeThread
+	protected void reportConnected() {
+		if (lastSteamVRStatus == 0) {
+			return;
+		}
+		VRServer.Companion.getInstance().statusSystem
+			.removeStatusInt(lastSteamVRStatus);
+		lastSteamVRStatus = 0;
 	}
 }

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
@@ -82,12 +82,10 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 					try {
 						boolean updated = this.updateSocket();
 						updateMessageQueue();
-						if (!updated) {
+						if (updated) {
+							reportConnected();
+						} else {
 							this.waitForData(10);
-						} else if (lastSteamVRStatus != 0) {
-							VRServer.Companion.getInstance().statusSystem
-								.removeStatusInt(lastSteamVRStatus);
-							lastSteamVRStatus = 0;
 						}
 					} catch (IOException ioError) {
 						this.resetChannel();

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
@@ -79,10 +79,8 @@ public class WindowsNamedPipeBridge extends SteamVRBridge {
 				}
 				if (pipe.state == PipeState.OPEN) {
 					pipesUpdated = updatePipe();
-					if (lastSteamVRStatus != 0 && pipesUpdated) {
-						VRServer.Companion.getInstance().statusSystem
-							.removeStatusInt(lastSteamVRStatus);
-						lastSteamVRStatus = 0;
+					if (pipesUpdated) {
+						reportConnected();
 					}
 					updateMessageQueue();
 				}


### PR DESCRIPTION
Replacing `IllegalStateException` with `return` as it causes pipe thread to exit when SteamVR crashes immediately after starting.

In this case pipe gets closed immediately, and as old status gets removed only after receiving data, `reportDisconnected()` gets called twice in a row and throws.
```
[SEVERE] Exception in thread "Named pipe thread" java.lang.IllegalStateException: lastSteamVRStatus wasn't 0 and it was 34 instead
[SEVERE]       at dev.slimevr.desktop.platform.SteamVRBridge.reportDisconnected(SteamVRBridge.java:388)
[SEVERE]       at dev.slimevr.desktop.platform.windows.WindowsNamedPipeBridge.run(WindowsNamedPipeBridge.java:77)
[SEVERE]       at java.base/java.lang.Thread.run(Thread.java:833)
```