### PR TITLE
Add a `TrackerStatus.TIMED_OUT` for temporal timeouts

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -139,6 +139,7 @@ tracker-status-error = Error
 tracker-status-disconnected = Disconnected
 tracker-status-occluded = Occluded
 tracker-status-ok = OK
+tracker-status-timed_out = Timed out
 
 ## Tracker status columns
 tracker-table-column-name = Name

--- a/gui/src/components/TopBar.tsx
+++ b/gui/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import {
   RpcMessage,
   ServerInfosRequestT,
   ServerInfosResponseT,
+  TrackerStatus,
 } from 'solarxr-protocol';
 import { useWebsocketAPI } from '@/hooks/websocket-api';
 import { CloseIcon } from './commons/icon/CloseIcon';
@@ -212,7 +213,9 @@ export function TopBar({
                   onClick={() => {
                     if (
                       config?.connectedTrackersWarning &&
-                      connectedIMUTrackers.length > 0
+                      connectedIMUTrackers.filter(
+                        (t) => t.tracker.status !== TrackerStatus.TIMED_OUT
+                      ).length > 0
                     ) {
                       setConnectedTrackerWarning(true);
                     } else {

--- a/gui/src/components/tracker/TrackerStatus.tsx
+++ b/gui/src/components/tracker/TrackerStatus.tsx
@@ -11,6 +11,7 @@ const statusLabelMap: { [key: number]: string } = {
   [TrackerStatusEnum.DISCONNECTED]: 'tracker-status-disconnected',
   [TrackerStatusEnum.OCCLUDED]: 'tracker-status-occluded',
   [TrackerStatusEnum.OK]: 'tracker-status-ok',
+  [TrackerStatusEnum.TIMED_OUT]: 'tracker-status-timed_out',
 };
 
 const statusClassMap: { [key: number]: string } = {
@@ -20,6 +21,7 @@ const statusClassMap: { [key: number]: string } = {
   [TrackerStatusEnum.DISCONNECTED]: 'bg-background-30',
   [TrackerStatusEnum.OCCLUDED]: 'bg-status-warning',
   [TrackerStatusEnum.OK]: 'bg-status-success',
+  [TrackerStatusEnum.TIMED_OUT]: 'bg-status-warning',
 };
 
 export function TrackerStatus({ status }: { status: number }) {

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -15,7 +15,8 @@ import solarxr_protocol.rpc.StatusTrackerErrorT
 import solarxr_protocol.rpc.StatusTrackerResetT
 import kotlin.properties.Delegates
 
-const val TIMEOUT_MS = 2000L
+const val TIMEOUT_MS = 2_000L
+const val DISCONNECT_MS = 10_000L + TIMEOUT_MS
 
 /**
  * Generic tracker class for input and output tracker,
@@ -65,7 +66,7 @@ class Tracker @JvmOverloads constructor(
 	val needsMounting: Boolean = false,
 ) {
 	private val timer = BufferedTimer(1f)
-	private var timeAtLastUpdate: Long = 0
+	private var timeAtLastUpdate: Long = System.currentTimeMillis()
 	private var rotation = Quaternion.IDENTITY
 	private var acceleration = Vector3.NULL
 	var position = Vector3.NULL
@@ -254,8 +255,10 @@ class Tracker @JvmOverloads constructor(
 	 */
 	fun tick() {
 		if (usesTimeout) {
-			if (System.currentTimeMillis() - timeAtLastUpdate > TIMEOUT_MS) {
+			if (System.currentTimeMillis() - timeAtLastUpdate > DISCONNECT_MS) {
 				status = TrackerStatus.DISCONNECTED
+			} else if (System.currentTimeMillis() - timeAtLastUpdate > TIMEOUT_MS) {
+				status = TrackerStatus.TIMED_OUT
 			}
 		}
 		filteringHandler.tick()
@@ -268,6 +271,13 @@ class Tracker @JvmOverloads constructor(
 		timer.update()
 		timeAtLastUpdate = System.currentTimeMillis()
 		filteringHandler.dataTick(rotation)
+	}
+
+	/**
+	 * A way to delay the timeout of the tracker
+	 */
+	fun heartbeat() {
+		timeAtLastUpdate = System.currentTimeMillis()
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -16,7 +16,7 @@ import solarxr_protocol.rpc.StatusTrackerResetT
 import kotlin.properties.Delegates
 
 const val TIMEOUT_MS = 2_000L
-const val DISCONNECT_MS = 10_000L + TIMEOUT_MS
+const val DISCONNECT_MS = 3_000L + TIMEOUT_MS
 
 /**
  * Generic tracker class for input and output tracker,

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerStatus.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerStatus.kt
@@ -7,11 +7,12 @@ enum class TrackerStatus(val id: Int, val sendData: Boolean, val reset: Boolean)
 	BUSY(2, true, false),
 	ERROR(3, false, true),
 	OCCLUDED(4, false, false),
+	TIMED_OUT(5, false, false),
 	;
 
 	companion object {
 
-		private val byId = values().associateBy { it.id }
+		private val byId = entries.associateBy { it.id }
 
 		@JvmStatic
 		fun getById(id: Int): TrackerStatus? = byId[id]

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
@@ -26,10 +26,13 @@ object TrackerUtils {
 	private fun getNonInternalTrackerForBodyPosition(
 		allTrackers: List<Tracker>,
 		position: TrackerPosition,
-	): Tracker? = allTrackers.firstOrNull {
-		it.trackerPosition === position &&
-			!it.isInternal &&
-			!it.status.reset
+	): Tracker? {
+		val resetTrackers = allTrackers.filter {
+			it.trackerPosition === position &&
+				!it.isInternal &&
+				!it.status.reset
+		}
+		return resetTrackers.firstOrNull { it.status != TrackerStatus.TIMED_OUT } ?: resetTrackers.firstOrNull()
 	}
 
 	/**
@@ -41,11 +44,14 @@ object TrackerUtils {
 	private fun getNonInternalNonComputedTrackerForBodyPosition(
 		allTrackers: List<Tracker>,
 		position: TrackerPosition,
-	): Tracker? = allTrackers.firstOrNull {
-		it.trackerPosition === position &&
-			!it.isComputed &&
-			!it.isInternal &&
-			!it.status.reset
+	): Tracker? {
+		val resetTrackers = allTrackers.filter {
+			it.trackerPosition === position &&
+				!it.isComputed &&
+				!it.isInternal &&
+				!it.status.reset
+		}
+		return resetTrackers.firstOrNull { it.status != TrackerStatus.TIMED_OUT } ?: resetTrackers.firstOrNull()
 	}
 
 	/**
@@ -58,11 +64,14 @@ object TrackerUtils {
 	fun getNonInternalNonImuTrackerForBodyPosition(
 		allTrackers: List<Tracker>,
 		position: TrackerPosition,
-	): Tracker? = allTrackers.firstOrNull {
-		it.trackerPosition === position &&
-			!it.isImu() &&
-			!it.isInternal &&
-			!it.status.reset
+	): Tracker? {
+		val resetTrackers = allTrackers.filter {
+			it.trackerPosition === position &&
+				!it.isImu() &&
+				!it.isInternal &&
+				!it.status.reset
+		}
+		return resetTrackers.firstOrNull { it.status != TrackerStatus.TIMED_OUT } ?: resetTrackers.firstOrNull()
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
@@ -5,7 +5,10 @@ object TrackerUtils {
 	/**
 	 * Finds a suitable tracker for use in the SlimeVR skeleton
 	 * in allTrackers matching the position.
-	 * This won't return disconnected, errored or internal trackers.
+	 *
+	 * This won't return disconnected, errored or internal trackers,
+	 * but it will return timed out trackers, and they have a lower
+	 * priority than normal trackers.
 	 *
 	 * @return A tracker for use in the SlimeVR skeleton
 	 */
@@ -19,7 +22,9 @@ object TrackerUtils {
 
 	/**
 	 * Finds the first non-internal tracker from allTrackers
-	 * matching the position, that is not DISCONNECTED
+	 * matching the position, that is not `TrackerStatus.reset`.
+	 * It will also choose timed out trackers, but they have a lower
+	 * priority than the rest of the trackers
 	 *
 	 * @return A non-internal tracker
 	 */
@@ -37,7 +42,9 @@ object TrackerUtils {
 
 	/**
 	 * Finds the first non-internal non-computed tracker from allTrackers
-	 * matching the position, that is not DISCONNECTED.
+	 * matching the position, that is not `TrackerStatus.reset`.
+	 * It will also choose timed out trackers, but they have a lower
+	 * priority than the rest of the trackers
 	 *
 	 * @return A non-internal non-computed tracker
 	 */
@@ -56,8 +63,9 @@ object TrackerUtils {
 
 	/**
 	 * Finds the first non-internal and non-imu tracker from allTrackers
-	 * matching the position, that is not DISCONNECTED.
-	 *
+	 * matching the position, that is not `TrackerStatus.reset`.
+	 * It will also choose timed out trackers, but they have a lower
+	 * priority than the rest of the trackers
 	 * @return A non-internal non-imu tracker
 	 */
 	@JvmStatic

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -250,7 +250,6 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 									LogManager.info("[TrackerServer] Tracker timed out: $conn")
 								}
 							} else {
-								conn.timedOut = false
 								for (value in conn.trackers.values) {
 									if (value.status == TrackerStatus.DISCONNECTED ||
 										value.status == TrackerStatus.TIMED_OUT
@@ -258,6 +257,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 										value.status = TrackerStatus.OK
 									}
 								}
+								conn.timedOut = false
 							}
 
 							if (conn.serialBuffer.isNotEmpty() &&

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -251,16 +251,12 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 								}
 							} else {
 								conn.timedOut = false
-								// If before the change of sending sensor info every second
-								if (conn.firmwareBuild < 17) {
-									conn.trackers.values
-										.filter {
-											it.status == TrackerStatus.TIMED_OUT ||
-												it.status == TrackerStatus.DISCONNECTED
-										}
-										.forEach {
-											it.status = TrackerStatus.OK
-										}
+								for (value in conn.trackers.values) {
+									if (value.status == TrackerStatus.DISCONNECTED ||
+										value.status == TrackerStatus.TIMED_OUT
+									) {
+										value.status = TrackerStatus.OK
+									}
 								}
 							}
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -297,12 +297,18 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				rot = AXES_OFFSET.times(rot)
 				tracker = connection?.getTracker(packet.sensorId)
 				if (tracker == null) return
+				if (tracker.status == TrackerStatus.DISCONNECTED) {
+					tracker.status = TrackerStatus.OK
+				}
 				tracker.setRotation(rot)
 				tracker.dataTick()
 			}
 			is UDPPacket17RotationData -> {
 				tracker = connection?.getTracker(packet.sensorId)
 				if (tracker == null) return
+				if (tracker.status == TrackerStatus.DISCONNECTED) {
+					tracker.status = TrackerStatus.OK
+				}
 				var rot17 = packet.rotation
 				rot17 = AXES_OFFSET * rot17
 				when (packet.dataType) {

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -251,6 +251,17 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 								}
 							} else {
 								conn.timedOut = false
+								// If before the change of sending sensor info every second
+								if (conn.firmwareBuild < 17) {
+									conn.trackers.values
+										.filter {
+											it.status == TrackerStatus.TIMED_OUT ||
+												it.status == TrackerStatus.DISCONNECTED
+										}
+										.forEach {
+											it.status = TrackerStatus.OK
+										}
+								}
 							}
 
 							if (conn.serialBuffer.isNotEmpty() &&

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -245,9 +245,6 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 							parser.write(bb, conn, UDPPacket1Heartbeat)
 							socket.send(DatagramPacket(rcvBuffer, bb.position(), conn.address))
 							if (conn.lastPacket + 1000 < System.currentTimeMillis()) {
-// 								for (value in conn.trackers.values) {
-// 									value.status = TrackerStatus.DISCONNECTED
-// 								}
 								if (!conn.timedOut) {
 									conn.timedOut = true
 									LogManager.info("[TrackerServer] Tracker timed out: $conn")

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
@@ -17,6 +17,9 @@ class UDPProtocolParser {
 				)
 			}
 			connection.lastPacket = System.currentTimeMillis()
+			connection.trackers.forEach { (_, tracker) ->
+				tracker.heartbeat()
+			}
 		}
 		if (packetId == PACKET_BUNDLE) {
 			bundlePackets.clear()


### PR DESCRIPTION
Fixes an error on #883 saying tracker is disconnected when it's still sending rotation packets

~~Needs https://github.com/SlimeVR/SolarXR-Protocol/pull/128~~