### PR TITLE
Add new IMUs, show IMU calibration during onboarding for LSM6DSV

### DIFF
--- a/gui/src/hooks/imu-logic.ts
+++ b/gui/src/hooks/imu-logic.ts
@@ -8,7 +8,7 @@ export function useBnoExists(connectedTrackers: FlatDeviceTracker[]): boolean {
       connectedTrackers.some(
         (tracker) =>
           tracker.tracker.info?.imuType &&
-          [ImuType.BNO055, ImuType.BNO080, ImuType.BNO085].includes(
+          [ImuType.BNO055, ImuType.BNO080, ImuType.BNO085, ImuType.LSM6DSV].includes(
             tracker.tracker.info?.imuType
           )
       ),

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -11,6 +11,9 @@ enum class IMUType(val id: UInt) {
 	BNO086(7u),
 	BMI160(8u),
 	ICM20948(9u),
+	ICM42688(10u),
+	BMI270(11u),
+	LSM6DSV(12u),
 	;
 
 	fun getSolarType(): Int = this.id.toInt()

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -12,7 +12,7 @@ enum class IMUType(val id: UInt) {
 	BMI160(8u),
 	ICM20948(9u),
 	ICM42688(10u),
-	BMI270(11u),
+	BMI323(11u),
 	LSM6DSV(12u),
 	;
 


### PR DESCRIPTION
Depends on https://github.com/SlimeVR/SolarXR-Protocol/pull/129

Adds new IMUs so they show up in tracker info, and displays IMU calibration tutorial during onboarding if an LSM6DSV tracker is connected