### PR TITLE
Clarify headset wording and update AutoBone requirements

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -117,7 +117,7 @@ widget-developer_mode = Developer Mode
 widget-developer_mode-high_contrast = High contrast
 widget-developer_mode-precise_rotation = Precise rotation
 widget-developer_mode-fast_data_feed = Fast data feed
-widget-developer_mode-filter_slimes_and_hmd = Filter slimes and HMD
+widget-developer_mode-filter_slimes_and_hmd = Filter Slimes and HMD
 widget-developer_mode-sort_by_name = Sort by name
 widget-developer_mode-raw_slime_rotation = Raw rotation
 widget-developer_mode-more_info = More info
@@ -330,7 +330,7 @@ settings-general-fk_settings-leg_fk = Leg tracking
 settings-general-fk_settings-leg_fk-reset_mounting_feet-description = Enable feet Mounting Reset by tiptoeing.
 settings-general-fk_settings-leg_fk-reset_mounting_feet = Feet Mounting Reset
 settings-general-fk_settings-arm_fk = Arm tracking
-settings-general-fk_settings-arm_fk-description = Force arms to be tracked from the HMD even if positional hand data is available.
+settings-general-fk_settings-arm_fk-description = Force arms to be tracked from the headset (HMD) even if positional hand data is available.
 settings-general-fk_settings-arm_fk-force_arms = Force arms from HMD
 settings-general-fk_settings-arm_fk-reset_mode-description = Change which arm pose is expected for mounting reset.
 settings-general-fk_settings-arm_fk-back = Back
@@ -471,7 +471,7 @@ settings-osc-router-network-address-placeholder = IPV4 address
 settings-osc-vrchat = VRChat OSC Trackers
 # This cares about multilines
 settings-osc-vrchat-description =
-    Change VRChat-specific settings to receive HMD data and send
+    Change VRChat-specific settings to receive headset (HMD) data and send
     tracker data for FBT without SteamVR (ex. Quest standalone).
 settings-osc-vrchat-enable = Enable
 settings-osc-vrchat-enable-description = Toggle the sending and receiving of data.
@@ -562,7 +562,7 @@ onboarding-reset_tutorial-skip = Skip step
 # Cares about multiline
 onboarding-reset_tutorial-0 = Tap { $taps } times the highlighted tracker for triggering yaw reset.
 
-    This will make the trackers face the same direction as your HMD.
+    This will make the trackers face the same direction as your headset (HMD).
 # Cares about multiline
 onboarding-reset_tutorial-1 = Tap { $taps } times the highlighted tracker for triggering full reset.
 
@@ -763,10 +763,10 @@ onboarding-choose_proportions-description = Body proportions are used to know th
 onboarding-choose_proportions-auto_proportions = Automatic proportions
 # Italized text
 onboarding-choose_proportions-auto_proportions-subtitle = Recommended
-onboarding-choose_proportions-auto_proportions-descriptionv2 =
+onboarding-choose_proportions-auto_proportions-descriptionv3 =
     This will guess your proportions by recording a sample of your movements and passing it through an algorithm.
 
-    <b>This requires having your HMD connected to SlimeVR!</b>
+    <b>This requires having your headset (HMD) connected to SlimeVR and on your head!</b>
 onboarding-choose_proportions-manual_proportions = Manual proportions
 # Italized text
 onboarding-choose_proportions-manual_proportions-subtitle = For small touches
@@ -795,16 +795,15 @@ onboarding-automatic_proportions-put_trackers_on-description = To calibrate your
 onboarding-automatic_proportions-put_trackers_on-next = I have all my trackers on
 onboarding-automatic_proportions-requirements-title = Requirements
 # Each line of text is a different list item
-onboarding-automatic_proportions-requirements-description =
+onboarding-automatic_proportions-requirements-descriptionv2 =
     You have at least enough trackers to track your feet (generally 5 trackers).
-    You have your trackers and headset on.
-    You are wearing your trackers and headset.
-    Your trackers and headset are connected to the SlimeVR server.
-    Your trackers and headset are working properly within the SlimeVR server.
+    You have your trackers and headset on and are wearing them.
+    Your trackers and headset are connected to the SlimeVR server and are working properly (ex. no stuttering, disconnecting, etc).
     Your headset is reporting positional data to the SlimeVR server (this generally means having SteamVR running and connected to SlimeVR using SlimeVR's SteamVR driver).
+    Your tracking is working and is accurately representing your movements (ex. they move the right direction when kicking, bending over, sitting, etc).
 onboarding-automatic_proportions-requirements-next = I have read the requirements
 onboarding-automatic_proportions-check_height-title = Check your height
-onboarding-automatic_proportions-check_height-description = We use your height as a basis of our measurements by using the HMD's height as an approximation of your actual height, but it's better to check if they are right yourself!
+onboarding-automatic_proportions-check_height-description = We use your height as a basis of our measurements by using the headset's (HMD) height as an approximation of your actual height, but it's better to check if they are right yourself!
 # All the text is in bold!
 onboarding-automatic_proportions-check_height-calculation_warning = Please press the button while standing <u>upright</u> to calculate your height. You have 3 seconds after you press the button!
 onboarding-automatic_proportions-check_height-fetch_height = I'm standing!

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -800,7 +800,7 @@ onboarding-automatic_proportions-requirements-descriptionv2 =
     You have your trackers and headset on and are wearing them.
     Your trackers and headset are connected to the SlimeVR server and are working properly (ex. no stuttering, disconnecting, etc).
     Your headset is reporting positional data to the SlimeVR server (this generally means having SteamVR running and connected to SlimeVR using SlimeVR's SteamVR driver).
-    Your tracking is working and is accurately representing your movements (ex. they move the right direction when kicking, bending over, sitting, etc).
+    Your tracking is working and is accurately representing your movements (ex. you have performed a full reset and they move the right direction when kicking, bending over, sitting, etc).
 onboarding-automatic_proportions-requirements-next = I have read the requirements
 onboarding-automatic_proportions-check_height-title = Check your height
 onboarding-automatic_proportions-check_height-description = We use your height as a basis of our measurements by using the headset's (HMD) height as an approximation of your actual height, but it's better to check if they are right yourself!

--- a/gui/src/components/onboarding/pages/body-proportions/ProportionsChoose.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/ProportionsChoose.tsx
@@ -244,7 +244,7 @@ export function ProportionsChoose() {
                   </div>
                   <div>
                     <Localized
-                      id="onboarding-choose_proportions-auto_proportions-descriptionv2"
+                      id="onboarding-choose_proportions-auto_proportions-descriptionv3"
                       elems={{ b: <b></b> }}
                     >
                       <Typography

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Requirements.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Requirements.tsx
@@ -26,7 +26,7 @@ export function RequirementsStep({
             <>
               {l10n
                 .getString(
-                  'onboarding-automatic_proportions-requirements-description'
+                  'onboarding-automatic_proportions-requirements-descriptionv2'
                 )
                 .split('\n')
                 .map((line, i) => (


### PR DESCRIPTION
- Some minor clarification on "HMD", as a decent number of people don't know the term, replacing it with "headset" instead as it's more widely recognized.
- Updates the AutoBone requirements list to condense the information, add more examples, and clarify that you need working tracking as a baseline.