### PR TITLE
Add build dependencies to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,9 @@
               librsvg
               freetype
               expat
+              husky
+              cargo
+              rustc
             ])
             ++ lib.optionals pkgs.stdenv.isDarwin [
               pkgs.darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
These dependencies are required for building on nixos, they should be in the flake.