### PR TITLE
don't send packets of bones we don't have

### DIFF
--- a/server/core/src/main/java/dev/slimevr/osc/VMCHandler.java
+++ b/server/core/src/main/java/dev/slimevr/osc/VMCHandler.java
@@ -423,8 +423,9 @@ public class VMCHandler implements OSCHandler {
 					// Add Unity humanoid bones transforms
 					for (UnityBone bone : UnityBone.getEntries()) {
 						if (
-							!(humanPoseManager.isTrackingLeftArmFromController()
-								&& isLeftArmUnityBone(bone))
+							bone.getBoneType() != null
+								&& !(humanPoseManager.isTrackingLeftArmFromController()
+									&& isLeftArmUnityBone(bone))
 								&& !(humanPoseManager.isTrackingRightArmFromController()
 									&& isRightArmUnityBone(bone))
 						) {


### PR DESCRIPTION
I used to just send (0, 0, 0) and (0, 0, 0, 1), but this makes it so bones we can't have just don't have any packet for them at all.

not sure if there was a reason I was sending meaningless packets, but eh.