### PR TITLE
Remove Futura from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,18 +2,18 @@
 * @Eirenliel
 
 # Make everyone be able to approve SolarXR submodule changes
-/solarxr-protocol @ButterscotchV @Louka3000 @loucass003 @ImUrX
+/solarxr-protocol @ButterscotchV @Louka3000 @ImUrX
 
 # Make Loucas and Uriel the owners of all GUI stuff
-/gui/ @loucass003 @ImUrX
-/package-lock.json @loucass003 @ImUrX
+/gui/ @ImUrX
+/package-lock.json @ImUrX
 
 # Uriel and Erimel responsible for i18n
 /gui/public/i18n/ @ImUrX @Louka3000
 /gui/src/i18n/ @ImUrX @Louka3000
 /l10n.toml @ImUrX @Louka3000
 
-/gui/src/components/settings/ @Louka3000 @loucass003 @ImUrX
+/gui/src/components/settings/ @Louka3000 @ImUrX
 
 # Rust part of the GUI
 /gui/src-tauri/ @ImUrX
@@ -29,5 +29,3 @@
 /server/src/main/java/dev/slimevr/osc/ @Louka3000
 /server/src/main/java/dev/slimevr/tracking/processor/ @Louka3000
 /server/src/main/java/dev/slimevr/filtering/ @Louka3000
-
-server/src/main/java/dev/slimevr/config/ @loucass003


### PR DESCRIPTION
Futura is taking a leave as maintainer, I asked Anna if she was interested but she is not interested in being a reviewer.

My GUI PRs currently needs approval of him because he is a codeowner but if I'm the only codeowner, I just need approval of anyone with write permissions so I'm able to merge my PRs without bothering Futura or Eiren.