### PR TITLE
Change mounting position/rotation/direction to mounting orientation

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -182,7 +182,7 @@ tracker-settings-title = Tracker settings
 tracker-settings-assignment_section = Assignment
 tracker-settings-assignment_section-description = What part of the body the tracker is assigned to.
 tracker-settings-assignment_section-edit = Edit assignment
-tracker-settings-mounting_section = Mounting position
+tracker-settings-mounting_section = Mounting orientation
 tracker-settings-mounting_section-description = Where is the tracker mounted?
 tracker-settings-mounting_section-edit = Edit mounting
 tracker-settings-drift_compensation_section = Allow drift compensation
@@ -719,11 +719,11 @@ onboarding-choose_mounting-description = Mounting orientation corrects for the p
 onboarding-choose_mounting-auto_mounting = Automatic mounting
 # Italized text
 onboarding-choose_mounting-auto_mounting-label = Experimental
-onboarding-choose_mounting-auto_mounting-description = This will automatically detect the mounting directions for all of your trackers from 2 poses
+onboarding-choose_mounting-auto_mounting-description = This will automatically detect the mounting orientations for all of your trackers from 2 poses
 onboarding-choose_mounting-manual_mounting = Manual mounting
 # Italized text
 onboarding-choose_mounting-manual_mounting-label = Recommended
-onboarding-choose_mounting-manual_mounting-description = This will let you choose the mounting direction manually for each tracker
+onboarding-choose_mounting-manual_mounting-description = This will let you choose the mounting orientation manually for each tracker
 # Multiline text
 onboarding-choose_mounting-manual_modal-title = Are you sure you want to do
     the automatic mounting calibration?
@@ -741,21 +741,21 @@ onboarding-manual_mounting-next = Next step
 ## Tracker automatic mounting setup
 onboarding-automatic_mounting-back = Go Back to Enter VR
 onboarding-automatic_mounting-title = Mounting Calibration
-onboarding-automatic_mounting-description = For SlimeVR trackers to work, we need to assign a mounting rotation to your trackers to align them with your physical tracker mounting.
+onboarding-automatic_mounting-description = For SlimeVR trackers to work, we need to assign a mounting orientation to your trackers to align them with your physical tracker mounting.
 onboarding-automatic_mounting-manual_mounting = Manual mounting
 onboarding-automatic_mounting-next = Next step
 onboarding-automatic_mounting-prev_step = Previous step
-onboarding-automatic_mounting-done-title = Mounting rotations calibrated.
+onboarding-automatic_mounting-done-title = Mounting orientations calibrated.
 onboarding-automatic_mounting-done-description = Your mounting calibration is complete!
 onboarding-automatic_mounting-done-restart = Try again
 onboarding-automatic_mounting-mounting_reset-title = Mounting Reset
 onboarding-automatic_mounting-mounting_reset-step-0 = 1. Squat in a "skiing" pose with your legs bent, your upper body tilted forwards, and your arms bent.
-onboarding-automatic_mounting-mounting_reset-step-1 = 2. Press the "Reset Mounting" button and wait for 3 seconds before the trackers' mounting rotations will reset.
+onboarding-automatic_mounting-mounting_reset-step-1 = 2. Press the "Reset Mounting" button and wait for 3 seconds before the trackers' mounting orientations will reset.
 onboarding-automatic_mounting-preparation-title = Preparation
 onboarding-automatic_mounting-preparation-step-0 = 1. Stand upright with your arms to your sides.
 onboarding-automatic_mounting-preparation-step-1 = 2. Press the "Full Reset" button and wait for 3 seconds before the trackers will reset.
 onboarding-automatic_mounting-put_trackers_on-title = Put on your trackers
-onboarding-automatic_mounting-put_trackers_on-description = To calibrate mounting rotations, we're gonna use the trackers you just assigned. Put on all your trackers, you can see which are which in the figure to the right.
+onboarding-automatic_mounting-put_trackers_on-description = To calibrate mounting orientations, we're gonna use the trackers you just assigned. Put on all your trackers, you can see which are which in the figure to the right.
 onboarding-automatic_mounting-put_trackers_on-next = I have all my trackers on
 
 ## Tracker proportions method choose

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -1094,7 +1094,7 @@ class HumanSkeleton(
 	fun resetTrackersMounting(resetSourceName: String?) {
 		val trackersToReset = humanPoseManager.getTrackersToReset()
 
-		// Resets the mounting rotation of the trackers with the HMD as
+		// Resets the mounting orientation of the trackers with the HMD as
 		// reference.
 		var referenceRotation = IDENTITY
 		headTracker?.let {

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -111,7 +111,7 @@ class Tracker @JvmOverloads constructor(
 		if (old == new) return@observable
 
 		if (!isInternal) {
-			// Set default mounting position for that body part
+			// Set default mounting orientation for that body part
 			new?.let { resetsHandler.mountingOrientation = it.defaultMounting() }
 
 			checkReportRequireReset()

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerPosition.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerPosition.kt
@@ -37,7 +37,7 @@ enum class TrackerPosition(
 	;
 
 	/**
-	 * Returns the default mounting position for the body part
+	 * Returns the default mounting orientation for the body part
 	 */
 	fun defaultMounting(): Quaternion = when (this) {
 		LEFT_LOWER_ARM, LEFT_HAND -> Quaternion.SLIMEVR.LEFT


### PR DESCRIPTION
We have super inconsistent wording regarding mounting as a different term is basically used in each usage... This just makes everything "mounting orientation" as that seems to be the best dictionary fit, what is used in the code, and idk I prefer it lol. The only usage of "mounting rotation" left would be in SolarXR in a single comment.