### PR TITLE
Fix state bug on tray exit

### DIFF
--- a/gui/src/components/TopBar.tsx
+++ b/gui/src/components/TopBar.tsx
@@ -102,7 +102,7 @@ export function TopBar({
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, []);
+  }, [config?.useTray, config?.connectedTrackersWarning]);
 
   useEffect(() => {
     sendRPCPacket(RpcMessage.ServerInfosRequest, new ServerInfosRequestT());
@@ -265,6 +265,7 @@ export function TopBar({
         accept={async (useTray) => {
           await setConfig({ useTray });
           setShowTrayOrExitModal(false);
+          // forceUpdate()
 
           // Doing this in here just in case config doesn't get updated in time
           if (useTray) {

--- a/gui/src/components/TopBar.tsx
+++ b/gui/src/components/TopBar.tsx
@@ -265,7 +265,6 @@ export function TopBar({
         accept={async (useTray) => {
           await setConfig({ useTray });
           setShowTrayOrExitModal(false);
-          // forceUpdate()
 
           // Doing this in here just in case config doesn't get updated in time
           if (useTray) {


### PR DESCRIPTION
The first time you configure if you want to use the tray, the topbar might still think config is null for `useTray`. This just fixes it