### PR TITLE
Fix NaN rotation on reset with a zero quaternion

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
@@ -346,7 +346,10 @@ class UDPUtils {
 			val z = byteBuffer.getFloat()
 			val w = byteBuffer.getFloat()
 
-			return if (x.isNaN() || y.isNaN() || z.isNaN() || w.isNaN()) {
+			return if (
+				(x.isNaN() || y.isNaN() || z.isNaN() || w.isNaN()) ||
+				(x == 0f && y == 0f && z == 0f && w == 0f)
+			) {
 				Quaternion.IDENTITY
 			} else {
 				Quaternion(w, x, y, z)


### PR DESCRIPTION
I've encountered this naturally before when using SlimeVR on a Quest 2 and eventually figured out the root cause to be from zero quaternions. This PR just replaces zero quaternions with identity to avoid NaN values.