### PR TITLE
Make mounting reset follow headset rotation

### DIFF
--- a/server/core/src/main/java/com/jme3/math/FastMath.java
+++ b/server/core/src/main/java/com/jme3/math/FastMath.java
@@ -85,7 +85,7 @@ final public class FastMath {
 	 * value.
 	 */
 	public static boolean isApproxZero(float value, float tolerance) {
-		return value < tolerance && value > tolerance;
+		return value < tolerance && value > -tolerance;
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -257,7 +257,8 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		buffer = gyroFix * buffer
 		buffer *= attachmentFix
 
-		// TODO adjust buffer to reference
+		// Adjust buffer to reference
+		buffer = reference.project(Vector3.POS_Y).inv().unit() * buffer
 
 		// Rotate a vector pointing up by the quat
 		val rotVector = buffer.sandwich(Vector3.POS_Y)

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -141,8 +141,8 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		rot *= mountingOrientation
 		rot = gyroFix * rot
 		rot *= attachmentFix
-		rot = yawFix * rot
 		rot = mountRotFix.inv() * (rot * mountRotFix)
+		rot = yawFix * rot
 		return rot * tposeFix
 	}
 
@@ -310,6 +310,7 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	private fun fixYaw(sensorRotation: Quaternion, reference: Quaternion): Quaternion {
 		var rot = gyroFix * sensorRotation
 		rot *= attachmentFix
+		rot = mountRotFix.inv() * (rot * mountRotFix)
 		rot = getYawQuaternion(rot)
 		return rot.inv() * reference.project(Vector3.POS_Y).unit()
 	}

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -7,7 +7,7 @@ import dev.slimevr.tracking.trackers.udp.IMUType
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
 import io.github.axisangles.ktmath.Quaternion
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.AssertionFailureBuilder
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import kotlin.math.*
@@ -54,8 +54,9 @@ class MountingResetTests {
 		tracker.resetsHandler.resetMounting(mountRef)
 		val resultYaw = yaw(tracker.resetsHandler.mountRotFix)
 
-		Assertions.assertTrue(
-			angleApproxEqual(expectedYaw, resultYaw),
+		assertAnglesApproxEqual(
+			expectedYaw,
+			resultYaw,
 			"Resulting mounting yaw is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})"
 		)
 	}
@@ -87,10 +88,17 @@ class MountingResetTests {
 		return deg(yaw(rot))
 	}
 
-	private fun angleApproxEqual(a: Float, b: Float): Boolean {
+	private fun anglesApproxEqual(a: Float, b: Float): Boolean {
 		return FastMath.isApproxEqual(a, b) ||
 			FastMath.isApproxEqual(a - FastMath.TWO_PI, b) ||
 			FastMath.isApproxEqual(a, b - FastMath.TWO_PI)
+	}
+
+	private fun assertAnglesApproxEqual(expected: Float, actual: Float, message: String?) {
+		if (!anglesApproxEqual(expected, actual)) {
+			AssertionFailureBuilder.assertionFailure().message(message)
+				.expected(expected).actual(actual).buildAndThrow()
+		}
 	}
 
 	companion object {

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -1,0 +1,102 @@
+package dev.slimevr.unit
+
+import com.jme3.math.FastMath
+import dev.slimevr.VRServer.Companion.getNextLocalTrackerId
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.udp.IMUType
+import io.github.axisangles.ktmath.EulerAngles
+import io.github.axisangles.ktmath.EulerOrder
+import io.github.axisangles.ktmath.Quaternion
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+/**
+ * Tests [TrackerResetsHandler.resetMounting]
+ */
+class MountingResetTests {
+
+	@TestFactory
+	fun testMounting(): List<DynamicTest> {
+		return arrayOf(
+			MountTest(Quaternion.SLIMEVR.FRONT, Quaternion.IDENTITY),
+			MountTest(Quaternion.SLIMEVR.BACK, Quaternion.IDENTITY),
+			MountTest(Quaternion.SLIMEVR.FRONT, q(0f, 90f, 0f)),
+			MountTest(Quaternion.SLIMEVR.LEFT, q(0f, 42f, 0f)),
+			MountTest(Quaternion.SLIMEVR.FRONT, q(0f, 90f, 0f)),
+			MountTest(Quaternion.SLIMEVR.FRONT, q(10f, 90f, 0f)),
+			MountTest(Quaternion.SLIMEVR.FRONT, q(0f, 90f, 20f))
+		).map { test: MountTest ->
+			DynamicTest.dynamicTest(
+				"Mounting Reset Test of Tracker (Expected: ${deg(yaw(test.expected))}, reference: ${deg(yaw(test.reference))})"
+			) {
+				checkMounting(test.expected, test.reference)
+			}
+		}
+	}
+
+	private fun checkMounting(expected: Quaternion, reference: Quaternion) {
+		val expectedYaw = yaw(expected)
+		// Offset front mounting by the expected mounting
+		val mountOffset = reference * Quaternion.SLIMEVR.FRONT.inv() * expected * frontMounting
+		val tracker = Tracker(
+			null,
+			getNextLocalTrackerId(),
+			"test",
+			"test",
+			null,
+			hasRotation = true,
+			isInternal = true,
+			imuType = IMUType.UNKNOWN,
+			needsReset = true,
+			needsMounting = true
+		)
+
+		tracker.setRotation(mountOffset)
+		tracker.resetsHandler.resetMounting(reference)
+		val resultYaw = yaw(tracker.resetsHandler.mountRotFix)
+
+		Assertions.assertEquals(
+			expectedYaw,
+			resultYaw,
+			FastMath.ZERO_TOLERANCE,
+			"Resulting mounting yaw is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})"
+		)
+	}
+
+	/**
+	 * Makes a radian angle positive
+	 */
+	private fun posRad(rot: Float): Float {
+		return (if (rot < 0f) FastMath.TWO_PI + rot else rot) % FastMath.TWO_PI
+	}
+
+	/**
+	 * Gets the yaw of a rotation in radians
+	 */
+	private fun yaw(rot: Quaternion): Float {
+		return posRad(rot.toEulerAngles(EulerOrder.YZX).y)
+	}
+
+	/**
+	 * Converts radians to degrees
+	 */
+	private fun deg(rot: Float): Float {
+		return rot * FastMath.RAD_TO_DEG
+	}
+
+	companion object {
+		val frontMounting = q(90f, 0f, 0f)
+
+		fun q(pitch: Float, yaw: Float, roll: Float): Quaternion {
+			return EulerAngles(
+				EulerOrder.YZX,
+				pitch * FastMath.DEG_TO_RAD,
+				yaw * FastMath.DEG_TO_RAD,
+				roll * FastMath.DEG_TO_RAD
+			).toQuaternion()
+		}
+	}
+
+	data class MountTest(val expected: Quaternion, val reference: Quaternion)
+}

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -161,15 +161,6 @@ class MountingResetTests {
 			Quaternion.SLIMEVR.BACK
 		)
 
-		val frontRot = q(90f, 0f, 0f)
-
-		private fun q(pitch: Float, yaw: Float, roll: Float): Quaternion {
-			return EulerAngles(
-				EulerOrder.YZX,
-				pitch * FastMath.DEG_TO_RAD,
-				yaw * FastMath.DEG_TO_RAD,
-				roll * FastMath.DEG_TO_RAD
-			).toQuaternion()
-		}
+		val frontRot = EulerAngles(EulerOrder.YZX, FastMath.HALF_PI, 0f, 0f).toQuaternion()
 	}
 }

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -23,19 +23,21 @@ class MountingResetTests {
 			DynamicTest.dynamicTest(
 				"Full and Mounting Reset Test of Tracker (Expected: ${deg(e)})"
 			) {
-				directions.forEach { f ->
-					directions.forEach { m ->
-						checkResetMounting(e, f, m)
+				frontMountings.forEach { a ->
+					directions.forEach { f ->
+						directions.forEach { m ->
+							checkResetMounting(e, a, f, m)
+						}
 					}
 				}
 			}
 		}
 	}
 
-	private fun checkResetMounting(expected: Quaternion, fullRef: Quaternion, mountRef: Quaternion) {
+	private fun checkResetMounting(expected: Quaternion, trackerAngle: Quaternion, fullRef: Quaternion, mountRef: Quaternion) {
 		val expectedYaw = yaw(expected)
 		// Offset front mounting by the expected mounting
-		val mountOffset = mountRef * expected * frontMounting
+		val mountOffset = mountRef * expected * trackerAngle
 		val tracker = Tracker(
 			null,
 			getNextLocalTrackerId(),
@@ -113,7 +115,7 @@ class MountingResetTests {
 			Quaternion.SLIMEVR.BACK
 		)
 
-		val frontMounting = q(90f, 0f, 0f)
+		val frontMountings = (5..175 step 5).map { q(it.toFloat(), 0f, 0f) }
 
 		fun q(pitch: Float, yaw: Float, roll: Float): Quaternion {
 			return EulerAngles(

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -10,6 +10,7 @@ import io.github.axisangles.ktmath.Quaternion
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import kotlin.math.*
 
 /**
  * Tests [TrackerResetsHandler.resetMounting]
@@ -68,7 +69,9 @@ class MountingResetTests {
 	 * Makes a radian angle positive
 	 */
 	private fun posRad(rot: Float): Float {
-		return (if (rot < 0f) FastMath.TWO_PI + rot else rot) % FastMath.TWO_PI
+		// Reduce the rotation to the smallest form
+		val redRot = rot % FastMath.TWO_PI
+		return abs(if (rot < 0f) FastMath.TWO_PI + redRot else redRot)
 	}
 
 	/**

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -67,7 +67,10 @@ class MountingResetTests {
 		// Apply full reset and mounting plus offset
 		tracker.setRotation(Quaternion.IDENTITY)
 		tracker.resetsHandler.resetFull(reference)
+		// Apply an offset of reference to the rotation
 		tracker.setRotation(reference * trackerRot)
+		// Since reference is the offset from quat identity (reset) and the rotation,
+		// it needs to be applied twice
 		tracker.resetsHandler.resetMounting(reference * reference)
 
 		val expectedYaw2 = yaw(expected)
@@ -97,7 +100,10 @@ class MountingResetTests {
 		tracker.setRotation(Quaternion.IDENTITY)
 		tracker.resetsHandler.resetFull(Quaternion.IDENTITY)
 		tracker.resetsHandler.resetYaw(reference)
+		// Apply an offset of reference to the rotation
 		tracker.setRotation(reference * trackerRot)
+		// Since reference is the offset from quat identity (reset) and the rotation,
+		// it needs to be applied twice
 		tracker.resetsHandler.resetMounting(reference * reference)
 
 		val expectedYaw4 = yaw(expected)

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -22,14 +22,12 @@ import kotlin.math.*
 class MountingResetTests {
 
 	@TestFactory
-	fun testResetAndMounting(): List<DynamicTest> {
-		return directions.flatMap { e ->
-			directions.map { m ->
-				DynamicTest.dynamicTest(
-					"Full and Mounting Reset Test of Tracker (Expected: ${deg(e)}, reference: ${deg(m)})"
-				) {
-					checkResetMounting(e, m)
-				}
+	fun testResetAndMounting(): List<DynamicTest> = directions.flatMap { e ->
+		directions.map { m ->
+			DynamicTest.dynamicTest(
+				"Full and Mounting Reset Test of Tracker (Expected: ${deg(e)}, reference: ${deg(m)})",
+			) {
+				checkResetMounting(e, m)
 			}
 		}
 	}
@@ -48,7 +46,7 @@ class MountingResetTests {
 			isInternal = true,
 			imuType = IMUType.UNKNOWN,
 			needsReset = true,
-			needsMounting = true
+			needsMounting = true,
 		)
 
 		// Apply full reset and mounting
@@ -62,7 +60,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw,
 			resultYaw,
-			"Resulting mounting yaw after full reset is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})"
+			"Resulting mounting yaw after full reset is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})",
 		)
 
 		// Apply full reset and mounting plus offset
@@ -79,7 +77,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw2,
 			resultYaw2,
-			"Resulting mounting yaw after full reset with offset is not equal to reference yaw (${deg(expectedYaw2)} vs ${deg(resultYaw2)})"
+			"Resulting mounting yaw after full reset with offset is not equal to reference yaw (${deg(expectedYaw2)} vs ${deg(resultYaw2)})",
 		)
 
 		// Apply yaw reset and mounting
@@ -94,7 +92,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw3,
 			resultYaw3,
-			"Resulting mounting yaw after yaw reset is not equal to reference yaw (${deg(expectedYaw3)} vs ${deg(resultYaw3)})"
+			"Resulting mounting yaw after yaw reset is not equal to reference yaw (${deg(expectedYaw3)} vs ${deg(resultYaw3)})",
 		)
 
 		// Apply yaw reset and mounting plus offset
@@ -112,7 +110,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw3,
 			resultYaw3,
-			"Resulting mounting yaw after yaw reset with offset is not equal to reference yaw (${deg(expectedYaw4)} vs ${deg(resultYaw4)})"
+			"Resulting mounting yaw after yaw reset with offset is not equal to reference yaw (${deg(expectedYaw4)} vs ${deg(resultYaw4)})",
 		)
 	}
 
@@ -133,7 +131,7 @@ class MountingResetTests {
 			isInternal = true,
 			imuType = IMUType.UNKNOWN,
 			needsReset = true,
-			needsMounting = true
+			needsMounting = true,
 		)
 
 		// Apply full reset and mounting
@@ -147,7 +145,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw,
 			resultYaw,
-			"Resulting mounting yaw after full reset is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})"
+			"Resulting mounting yaw after full reset is not equal to reference yaw (${deg(expectedYaw)} vs ${deg(resultYaw)})",
 		)
 
 		tracker.setRotation(reference * reference)
@@ -158,7 +156,7 @@ class MountingResetTests {
 		assertAnglesApproxEqual(
 			expectedYaw2,
 			resultYaw2,
-			"Resulting rotation after yaw reset is not equal to reference yaw (${deg(expectedYaw2)} vs ${deg(resultYaw2)})"
+			"Resulting rotation after yaw reset is not equal to reference yaw (${deg(expectedYaw2)} vs ${deg(resultYaw2)})",
 		)
 	}
 
@@ -174,26 +172,18 @@ class MountingResetTests {
 	/**
 	 * Gets the yaw of a rotation in radians
 	 */
-	private fun yaw(rot: Quaternion): Float {
-		return posRad(rot.toEulerAngles(EulerOrder.YZX).y)
-	}
+	private fun yaw(rot: Quaternion): Float = posRad(rot.toEulerAngles(EulerOrder.YZX).y)
 
 	/**
 	 * Converts radians to degrees
 	 */
-	private fun deg(rot: Float): Float {
-		return rot * FastMath.RAD_TO_DEG
-	}
+	private fun deg(rot: Float): Float = rot * FastMath.RAD_TO_DEG
 
-	private fun deg(rot: Quaternion): Float {
-		return deg(yaw(rot))
-	}
+	private fun deg(rot: Quaternion): Float = deg(yaw(rot))
 
-	private fun anglesApproxEqual(a: Float, b: Float): Boolean {
-		return FastMath.isApproxEqual(a, b) ||
-			FastMath.isApproxEqual(a - FastMath.TWO_PI, b) ||
-			FastMath.isApproxEqual(a, b - FastMath.TWO_PI)
-	}
+	private fun anglesApproxEqual(a: Float, b: Float): Boolean = FastMath.isApproxEqual(a, b) ||
+		FastMath.isApproxEqual(a - FastMath.TWO_PI, b) ||
+		FastMath.isApproxEqual(a, b - FastMath.TWO_PI)
 
 	private fun assertAnglesApproxEqual(expected: Float, actual: Float, message: String?) {
 		if (!anglesApproxEqual(expected, actual)) {
@@ -211,7 +201,7 @@ class MountingResetTests {
 			Quaternion.SLIMEVR.FRONT_RIGHT,
 			Quaternion.SLIMEVR.RIGHT,
 			Quaternion.SLIMEVR.BACK_RIGHT,
-			Quaternion.SLIMEVR.BACK
+			Quaternion.SLIMEVR.BACK,
 		)
 
 		val frontRot = EulerAngles(EulerOrder.YZX, FastMath.HALF_PI, 0f, 0f).toQuaternion()


### PR DESCRIPTION
It took a bazillion years, but finally I think I can say it's done!!! Writing the tests for this was an enormous pain in the ass, so please if you can, verify the logic behind it. I also tested this quickly and it seemed to work as intended.

Corresponding beta on the Discord: https://discord.com/channels/817184208525983775/1215578136419377183

To test this:

- Ensure manual mounting, full reset, and yaw reset all retain prior functionality.
- Try mounting reset directly after a full reset.
- Try mounting reset directly after a yaw reset.
- Try mounting reset at a different rotation after a full/yaw reset.