### PR TITLE
fastSeek is not available on most browsers, use currentTime

### DIFF
--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Recording.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/Recording.tsx
@@ -47,7 +47,7 @@ export function Recording({
       videoRef.current.play();
     } else {
       videoRef.current.pause();
-      videoRef.current.fastSeek(0);
+      videoRef.current.currentTime = 0;
     }
     setPaused(videoRef.current.paused);
   }

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/StartRecording.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/StartRecording.tsx
@@ -28,7 +28,7 @@ export function StartRecording({
       videoRef.current.play();
     } else {
       videoRef.current.pause();
-      videoRef.current.fastSeek(0);
+      videoRef.current.currentTime = 0;
     }
     setPaused(videoRef.current.paused);
   }


### PR DESCRIPTION
`fastSeek` is only available on Firefox and Safari, `currentTime` is available on all browsers
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/fastSeek
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime