### PR TITLE
Tpose down fix

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -20,6 +20,12 @@ private const val DRIFT_COOLDOWN_MS = 50000L
  */
 class TrackerResetsHandler(val tracker: Tracker) {
 
+	private val HalfHorizontal = EulerAngles(
+		EulerOrder.YZX,
+		0f,
+		Math.PI.toFloat(),
+		0f,
+	).toQuaternion()
 	private var driftAmount = 0f
 	private var averagedDriftQuat = Quaternion.IDENTITY
 	private var rotationSinceReset = Quaternion.IDENTITY
@@ -36,12 +42,7 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	var lastResetQuaternion: Quaternion? = null
 
 	// Manual mounting orientation
-	var mountingOrientation: Quaternion = EulerAngles(
-		EulerOrder.YZX,
-		0f,
-		Math.PI.toFloat(),
-		0f,
-	).toQuaternion()
+	var mountingOrientation = HalfHorizontal
 		set(value) {
 			field = value
 			// Clear the mounting reset now that it's been set manually
@@ -196,6 +197,11 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			mountRotFix = getYawQuaternion(reference)
 		}
 		attachmentFix = fixAttachment(mountingAdjustedRotation)
+
+		// Rotate attachmentFix by 180 degrees as a workaround for tpose (down)
+		if (tposeDownFix != Quaternion.IDENTITY && tracker.needsMounting) {
+			attachmentFix *= HalfHorizontal
+		}
 
 		makeIdentityAdjustmentQuatsFull()
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -186,20 +186,20 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		val oldRot = adjustToReference(tracker.getRawRotation())
 		lastResetQuaternion = oldRot
 
-		val adjustedRotation = tracker.getRawRotation() * mountingOrientation
+		val mountingAdjustedRotation = tracker.getRawRotation() * mountingOrientation
 
 		if (tracker.needsMounting) {
-			gyroFix = fixGyroscope(adjustedRotation)
+			gyroFix = fixGyroscope(mountingAdjustedRotation * tposeDownFix)
 		} else {
 			// Set mounting to the HMD's yaw so that the non-mounting-adjusted
 			// tracker goes forward.
 			mountRotFix = getYawQuaternion(reference)
 		}
-		attachmentFix = fixAttachment(adjustedRotation)
+		attachmentFix = fixAttachment(mountingAdjustedRotation)
 
 		makeIdentityAdjustmentQuatsFull()
 
-		yawFix = fixYaw(adjustedRotation, reference)
+		yawFix = fixYaw(mountingAdjustedRotation, reference)
 
 		calculateDrift(oldRot)
 


### PR DESCRIPTION
TPose (down) requires the user to Full Reset in a tpose and Mounting Reset in a i-pose. It never really worked, even tho TPose (up) worked fine due to my sloppy implementation that wasn't tested thoroughly.

One problem was not testing twist, as I tested with SteamVR trackers.

The other problem is that all of our reset code is made with the assumption that trackers are pointing down below the horizon line (because of yaw or idk), so I probably got lucky on testing and it worked.

This fixes both of these issues.

I spent way too much time on this, so this is as far as I go. It works. I'm open to code improvements ^^
