### PR TITLE
macOS app naming improvements

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -263,16 +263,21 @@ jobs:
         run: |
           cd target/universal-apple-darwin/release/bundle/macos/slimevr.app/Contents/MacOS
           cp $( git rev-parse --show-toplevel )/server/desktop/build/libs/slimevr.jar ./
-          cd ../../../../dmg/
-          ./bundle_dmg.sh --volname slimevr --icon slimevr 180 170 --app-drop-link 480 170 \
-          --window-size 660 400 --hide-extension ../macos/slimevr.app \
-          --volicon ../macos/slimevr.app/Contents/Resources/icon.icns --skip-jenkins \
-          --eula ../../../../LICENSE-MIT slimevr.dmg ../macos/slimevr.app
+          cd ../../../
+          /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName SlimeVR" slimevr.app/Contents/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleName SlimeVR" slimevr.app/Contents/Info.plist
+          codesign --sign - --deep --force slimevr.app
+          mv slimevr.app SlimeVR.app
+          cd ../dmg/
+          ./bundle_dmg.sh --volname SlimeVR --icon slimevr 180 170 --app-drop-link 480 170 \
+          --window-size 660 400 --hide-extension ../macos/SlimeVR.app \
+          --volicon ../macos/SlimeVR.app/Contents/Resources/icon.icns --skip-jenkins \
+          --eula ../../../../LICENSE-MIT slimevr.dmg ../macos/SlimeVR.app
 
       - uses: actions/upload-artifact@v3.1.0
         with:
           name: SlimeVR-GUI-MacApp
-          path: target/universal-apple-darwin/release/bundle/macos/slimevr*.app
+          path: target/universal-apple-darwin/release/bundle/macos/SlimeVR*.app
 
       - uses: actions/upload-artifact@v3.1.0
         with:


### PR DESCRIPTION
Sets "SlimeVR" as app name in multiple locations. In the future this could be replaced by `displayName` if [tauri ever implement it](https://github.com/tauri-apps/tauri/issues/8109).