### PR TITLE
Fix missing space in BVH

### DIFF
--- a/server/core/src/main/java/dev/slimevr/posestreamer/BVHFileStream.kt
+++ b/server/core/src/main/java/dev/slimevr/posestreamer/BVHFileStream.kt
@@ -187,6 +187,9 @@ class BVHFileStream : PoseDataStream {
 		val positionScale = bvhSettings.positionScale
 		writer
 			.write("${rootPos.x * positionScale} ${rootPos.y * positionScale} ${rootPos.z * positionScale}")
+
+		// Add spacing
+		writer.write(" ")
 		writeBoneHierarchyRotation(rootBone, null)
 
 		writer.newLine()


### PR DESCRIPTION
Space got thrown out when the file was converted to Kotlin in 472c502badd18e12808ebcc70c797eb33fb58357
Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/995