### PR TITLE
Support Datagrams up to 1472 bytes

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -46,8 +46,8 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 		emptyList()
 	}
 	private val parser = UDPProtocolParser()
-	// 1500 is a common network MTU
-	// 1472 is the maximum size of a UDP packet (1500 - 20 for IPv4 header - 8 for UDP header)
+
+	// 1500 is a common network MTU. 1472 is the maximum size of a UDP packet (1500 - 20 for IPv4 header - 8 for UDP header)
 	private val rcvBuffer = ByteArray(1500 - 20 - 8)
 	private val bb = ByteBuffer.wrap(rcvBuffer).order(ByteOrder.BIG_ENDIAN)
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -46,7 +46,9 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 		emptyList()
 	}
 	private val parser = UDPProtocolParser()
-	private val rcvBuffer = ByteArray(512)
+	// 1500 is a common network MTU
+	// 1472 is the maximum size of a UDP packet (1500 - 20 for IPv4 header - 8 for UDP header - 4 for CRC32)
+	private val rcvBuffer = ByteArray(1500 - 20 - 8 - 4)
 	private val bb = ByteBuffer.wrap(rcvBuffer).order(ByteOrder.BIG_ENDIAN)
 
 	// Gets initialized in this.run()

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -47,8 +47,8 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 	}
 	private val parser = UDPProtocolParser()
 	// 1500 is a common network MTU
-	// 1472 is the maximum size of a UDP packet (1500 - 20 for IPv4 header - 8 for UDP header - 4 for CRC32)
-	private val rcvBuffer = ByteArray(1500 - 20 - 8 - 4)
+	// 1472 is the maximum size of a UDP packet (1500 - 20 for IPv4 header - 8 for UDP header)
+	private val rcvBuffer = ByteArray(1500 - 20 - 8)
 	private val bb = ByteBuffer.wrap(rcvBuffer).order(ByteOrder.BIG_ENDIAN)
 
 	// Gets initialized in this.run()


### PR DESCRIPTION
Gesture mobile app can send large datagrams because it combines information from multiple sensors.