### PR TITLE
Create tarball of GUI bundle on release

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -185,6 +185,15 @@ jobs:
           pnpm i
           pnpm run tauri build
 
+      - name: Make GUI tarball
+        run: |
+          tar czf slimevr-gui-dist.tar.gz -C gui/dist/ .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SlimeVR-GUI-Dist
+          path: ./slimevr-gui-dist.tar.gz
+
       - uses: actions/upload-artifact@v3.1.0
         with:
           name: SlimeVR-GUI-Deb
@@ -223,6 +232,7 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
+            ./slimevr-gui-dist.tar.gz
             ./SlimeVR-amd64.appimage
             ./SlimeVR-amd64.deb
 


### PR DESCRIPTION
This works to simplify packaging in other places as the HTML/CSS/JS code is portable and works everywhere, it doesn't need to be edited.