### PR TITLE
Disabled the HID service

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/Main.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/Main.kt
@@ -125,11 +125,14 @@ fun main(args: Array<String>) {
 			configDir,
 		)
 		vrServer.start()
-		
+
 		// Start service for USB HID trackers
+		// Because of a bug with the hid4java library, this is currently disabled
+		/*
 		TrackersHID(
 			"Sensors HID service",
 		) { tracker: Tracker -> vrServer.registerTracker(tracker) }
+		 */
 
 		Keybinding(vrServer)
 		val scanner = thread {


### PR DESCRIPTION
This fix solves an issue with the current server version (0.12.0), that causes certain USB devices to act weirdly because of a bug in the hid4java library: https://github.com/gary-rowe/hid4java/wiki/Troubleshooting#the-mouse-pointer-freezes-every-so-often