### PR TITLE
GUI - Fix condition for promise detection in a11y

### DIFF
--- a/gui/src/utils/a11y.ts
+++ b/gui/src/utils/a11y.ts
@@ -15,7 +15,7 @@ export function waitUntil(
   tries?: number
 ): Promise<void> {
   return new Promise((resolve, rej) => {
-    const isPromise = typeof condition() === 'boolean';
+    const isPromise = typeof condition() !== 'boolean';
     const interval = setInterval(() => {
       if (tries && --tries === 0) {
         error(new Error('waitUntil ran out of tries'));


### PR DESCRIPTION
Small fix to properly detect if condition's result is promise<boolean> or just boolean.
This will fix tons of errors from gui (and dev. console).

![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/6f40422f-ed02-4462-b92f-a36898850d85)
