### PR TITLE
De-duplicate repeated HID packets

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
@@ -205,6 +205,15 @@ class TrackersHID(name: String, private val trackersConsumer: Consumer<Tracker>)
 					val packetCount = dataReceived.size / 20
 					var i = 0
 					while (i < packetCount * 20) {
+						if (i > 0) {
+							val currSlice: Array<Byte> = dataReceived.copyOfRange(i, (i + 19))
+							val prevSlice: Array<Byte> = dataReceived.copyOfRange((i - 20), (i - 1))
+							if (currSlice contentEquals prevSlice) {
+								i += 20
+								continue
+							}
+						}
+
 						// dataReceived[i] //for later
 						val idCombination = dataReceived[i + 1].toInt()
 						val rssi = -dataReceived[i + 2].toInt()


### PR DESCRIPTION
Current implementation of slimenrf-receiver fills empty space with repeated duplication of the last packet to fulfill HID packet length requirement. The duplicated packets would interfere with TPS count and filtering etc.. This PR filters out duplicated packets on the server-side.