### PR TITLE
Add VMC toggle to mirror tracking 

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -553,6 +553,9 @@ settings-osc-vmc-vrm-file_select = Drag & drop a model to use, or <u>browse</u>
 settings-osc-vmc-anchor_hip = Anchor at hips
 settings-osc-vmc-anchor_hip-description = Anchor the tracking at the hips, useful for seated VTubing. If disabling, load a VRM model.
 settings-osc-vmc-anchor_hip-label = Anchor at hips
+settings-osc-vmc-mirror_tracking = Mirror tracking
+settings-osc-vmc-mirror_tracking-description = Mirror the tracking horizontally.
+settings-osc-vmc-mirror_tracking-label = Mirror tracking
 
 ## Setup/onboarding menu
 onboarding-skip = Skip setup

--- a/gui/src/components/settings/pages/VMCSettings.tsx
+++ b/gui/src/components/settings/pages/VMCSettings.tsx
@@ -32,6 +32,7 @@ interface VMCSettingsForm {
     };
     vrmJson?: FileList;
     anchorHip: boolean;
+    mirrorTracking: boolean;
   };
 }
 
@@ -44,6 +45,7 @@ const defaultValues = {
       address: '127.0.0.1',
     },
     anchorHip: true,
+    mirrorTracking: true,
   },
 };
 
@@ -80,6 +82,7 @@ export function VMCSettings() {
         }
       }
       vmcOsc.anchorHip = values.vmc.anchorHip;
+      vmcOsc.mirrorTracking = values.vmc.mirrorTracking;
 
       settings.vmcOsc = vmcOsc;
     }
@@ -115,6 +118,7 @@ export function VMCSettings() {
       }
 
       formData.vmc.anchorHip = settings.vmcOsc.anchorHip;
+      formData.vmc.mirrorTracking = settings.vmcOsc.mirrorTracking;
     }
 
     reset(formData);
@@ -272,6 +276,23 @@ export function VMCSettings() {
                 label={l10n.getString('settings-osc-vmc-anchor_hip-label')}
               />
             </div>
+            <Typography bold>
+              {l10n.getString('settings-osc-vmc-mirror_tracking')}
+            </Typography>
+            <div className="flex flex-col pb-2">
+              <Typography color="secondary">
+                {l10n.getString('settings-osc-vmc-mirror_tracking-description')}
+              </Typography>
+            </div>
+            <div className="grid grid-cols-2 gap-3 pb-5">
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="vmc.mirrorTracking"
+                label={l10n.getString('settings-osc-vmc-mirror_tracking-label')}
+              />
+            </div>
           </>
         </SettingsPagePaneLayout>
       </form>
@@ -281,6 +302,7 @@ export function VMCSettings() {
 
 const gltfHeaderStart = 0;
 const gltfHeaderEnd = 20;
+
 async function parseVRMFile(vrm: File): Promise<string | null> {
   const headerView = new DataView(
     await vrm.slice(gltfHeaderStart, gltfHeaderEnd).arrayBuffer()

--- a/server/core/src/main/java/dev/slimevr/config/VMCConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/VMCConfig.kt
@@ -7,4 +7,7 @@ class VMCConfig : OSCConfig() {
 
 	// JSON part of the VRM to be used
 	var vrmJson: String? = null
+
+	// Mirror the tracking before sending it (turn left <=> turn right, left leg <=> right leg)
+	var mirrorTracking = false
 }

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
@@ -98,6 +98,7 @@ public class RPCSettingsBuilder {
 		if (vrmJson != null)
 			VMCOSCSettings.addVrmJson(fbb, vrmJsonOffset);
 		VMCOSCSettings.addAnchorHip(fbb, config.getAnchorHip());
+		VMCOSCSettings.addMirrorTracking(fbb, config.getMirrorTracking());
 
 		return VMCOSCSettings.endVMCOSCSettings(fbb);
 	}

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
@@ -151,6 +151,7 @@ class RPCSettingsHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) {
 			}
 			if (req.vmcOsc().vrmJson() != null) vmcConfig.vrmJson = req.vmcOsc().vrmJson()
 			vmcConfig.anchorHip = req.vmcOsc().anchorHip()
+			vmcConfig.mirrorTracking = req.vmcOsc().mirrorTracking()
 
 			vmcHandler.refreshSettings(true)
 		}


### PR DESCRIPTION
This adds toggle to mirror the tracking before sending it via VMC. It does not mirror the tracking inside the skeleton itself.

needs https://github.com/SlimeVR/SolarXR-Protocol/pull/140
closes https://github.com/SlimeVR/SlimeVR-Server/issues/952