### PR TITLE
Fix mocap mode breaking on startup

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -622,7 +622,11 @@ class HumanSkeleton(
 			val extendedPelvisRot = extendedPelvisYawRoll(leftLegRot, rightLegRot, hipRot)
 
 			// Interpolate between the hipRot and extendedPelvisRot
-			val newHipRot = hipRot.interpR(extendedPelvisRot, hipLegsAveraging)
+			val newHipRot = if (extendedPelvisRot.lenSq() != 0.0f) {
+				hipRot.interpR(extendedPelvisRot, hipLegsAveraging)
+			} else {
+				Quaternion.IDENTITY
+			}
 
 			// Set new hip rotation
 			hipBone.setRotation(newHipRot)


### PR DESCRIPTION
extendedPelvisYawRoll in HumanSkeleton could sometimes return an invalid rotation quaternion on startup. With mocap mode disabled this value gets overwritten on the next iteration. However, when mocap mode is enabled the invalid rotation is used on calculations involved in setting the next head position causing NaNs to propagate to the head position.

This PR replaces the invalid rotation with the identity quaternion preventing this from occurring.