### PR TITLE
Issue#1074 - Icon of the body part in correct color

### DIFF
--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -307,7 +307,7 @@ export function TrackerSettingsPage() {
               )}
             </Typography>
             <div className="flex justify-between bg-background-80 w-full p-3 rounded-lg">
-              <div className="flex gap-3 items-center">
+              <div className="flex gap-3 items-center fill-background-10">
                 {tracker?.tracker.info?.bodyPart !== BodyPart.NONE && (
                   <BodyPartIcon
                     bodyPart={tracker?.tracker.info?.bodyPart}


### PR DESCRIPTION
 Icon of the body part should be now correct color.
 FIX: added missing class fill-background-10 to parent div
 
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/9d512024-4e41-4544-ab6f-a911d87bbbbc)
