### PR TITLE
Issue#1078 - Make tracker assignment list use a dropdown on mobile

### DIFF
--- a/gui/src/components/commons/Dropdown.tsx
+++ b/gui/src/components/commons/Dropdown.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { Control, Controller, UseControllerProps } from 'react-hook-form';
 import { a11yClick } from '@/utils/a11y';
 import { createPortal } from 'react-dom';
@@ -30,7 +30,7 @@ type DropdownItemsProps = Pick<
 };
 
 export interface DropdownItem {
-  label: string;
+  label: string | ReactNode;
   value: string;
   fontName?: string;
 }
@@ -189,7 +189,7 @@ export function Dropdown({
             </div>
             <div
               className={classNames(
-                'ml-2 fill-background-10',
+                'flex flex-col ml-2 fill-background-10 justify-center',
                 direction == 'up' && 'rotate-180',
                 direction == 'down' && 'rotate-0'
               )}

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
@@ -35,6 +35,8 @@ import { AssignMode, defaultConfig, useConfig } from '@/hooks/config';
 import { playTapSetupSound } from '@/sounds/sounds';
 import { useBreakpoint } from '@/hooks/breakpoint';
 import { Radio } from '@/components/commons/Radio';
+import { Dropdown } from '@/components/commons/Dropdown';
+import { TrackersAssignOption } from './TrackerAssignmentOption';
 
 export type BodyPartError = {
   label: string | undefined;
@@ -326,46 +328,49 @@ export function TrackersAssignPage() {
                   </div>
                 </div>
               )}
-              <div className="flex flex-col md:gap-4 sm:gap-2 mobile:gap-4">
-                {Object.entries(ASSIGN_MODE_OPTIONS).map(
-                  ([mode, trackersCount]) => (
-                    <Radio
-                      key={mode}
-                      name="assignMode"
-                      control={control}
-                      value={mode}
-                      disabled={
-                        connectedIMUTrackers > trackersCount &&
-                        mode !== AssignMode.All
-                      }
-                      className="hidden"
-                    >
-                      <div className="flex flex-row md:gap-4 sm:gap-2 mobile:gap-2">
-                        <div style={{ width: '2.5rem', textAlign: 'right' }}>
-                          <Typography variant="mobile-title">
-                            {l10n.getString(
-                              'onboarding-assign_trackers-option-amount',
-                              { trackersCount }
-                            )}
-                          </Typography>
-                        </div>
-                        <div className="flex flex-col">
-                          <Typography>
-                            {l10n.getString(
-                              'onboarding-assign_trackers-option-label',
-                              { mode }
-                            )}
-                          </Typography>
-                          <Typography variant="standard" color="secondary">
-                            {l10n.getString(
-                              'onboarding-assign_trackers-option-description',
-                              { mode }
-                            )}
-                          </Typography>
-                        </div>
-                      </div>
-                    </Radio>
-                  )
+              <div className="flex flex-col sm:gap-2">
+                {!isMobile &&
+                  Object.entries(ASSIGN_MODE_OPTIONS).map(
+                    ([mode, trackersCount]) => (
+                      <Radio
+                        key={mode}
+                        name="assignMode"
+                        control={control}
+                        value={mode}
+                        disabled={
+                          connectedIMUTrackers > trackersCount &&
+                          mode !== AssignMode.All
+                        }
+                        className="hidden"
+                      >
+                        <TrackersAssignOption
+                          mode={mode}
+                          trackersCount={trackersCount}
+                        />
+                      </Radio>
+                    )
+                  )}
+                {isMobile && (
+                  <Dropdown
+                    control={control}
+                    name="assignMode"
+                    display="block"
+                    placeholder={l10n.getString(
+                      'settings-serial-serial_select'
+                    )}
+                    direction="down"
+                    items={Object.entries(ASSIGN_MODE_OPTIONS).map(
+                      ([mode, trackersCount]) => ({
+                        label: (
+                          <TrackersAssignOption
+                            mode={mode}
+                            trackersCount={trackersCount}
+                          />
+                        ),
+                        value: mode,
+                      })
+                    )}
+                  ></Dropdown>
                 )}
                 <CheckBox
                   control={control}

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignmentOption.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignmentOption.tsx
@@ -1,0 +1,34 @@
+import { useLocalization } from '@fluent/react';
+import { Typography } from '@/components/commons/Typography';
+
+export function TrackersAssignOption({
+  mode,
+  trackersCount,
+}: {
+  mode: string;
+  trackersCount: number;
+}) {
+  const { l10n } = useLocalization();
+
+  return (
+    <div className="flex flex-row md:gap-4 sm:gap-2 mobile:gap-4">
+      <div style={{ width: '2.5rem', textAlign: 'right' }}>
+        <Typography variant="main-title">
+          {l10n.getString('onboarding-assign_trackers-option-amount', {
+            trackersCount,
+          })}
+        </Typography>
+      </div>
+      <div className="flex flex-col text-left">
+        <Typography variant="standard">
+          {l10n.getString('onboarding-assign_trackers-option-label', { mode })}
+        </Typography>
+        <Typography variant="standard" color="secondary">
+          {l10n.getString('onboarding-assign_trackers-option-description', {
+            mode,
+          })}
+        </Typography>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #1078 - Make tracker assignment list use a dropdown on mobile.

**UI Change:** Replaced the tracker assignment list with a dropdown menu in the mobile view:
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/cfac4c39-952d-41ce-994a-7e6c9d9672b9)
... desktop view:
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/ff6cfd49-1b49-476e-aa08-8c7c7c1417a1)

NOTE: The arrow (expand/collapse button) of the dropdown is now vertically centered to support two-row options, enhancing the visual alignment.