### PR TITLE
Sync server constants with firmware

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -42,6 +42,8 @@ enum class BoardType(val id: UInt) {
 	WRANGLER(14u),
 	MOCOPI(15u),
 	WEMOSWROOM02(16u),
+	XIAO_ESP32C3(17u),
+	HARITORA(18u),
 	DEV_RESERVED(250u),
 	;
 
@@ -63,6 +65,8 @@ enum class BoardType(val id: UInt) {
 		WRANGLER -> "Wrangler Joycons"
 		MOCOPI -> "Sony Mocopi"
 		WEMOSWROOM02 -> "Wemos Wroom-02 D1 Mini"
+		XIAO_ESP32C3 -> "Seeed Studio XIAO ESP32C3"
+		HARITORA -> "Haritora"
 		DEV_RESERVED -> "Prototype"
 	}
 
@@ -83,6 +87,7 @@ enum class MCUType(val id: UInt) {
 	OWOTRACK_IOS(5u),
 	ESP32_C3(6u),
 	MOCOPI(7u),
+	HARITORA(8u),
 	DEV_RESERVED(250u),
 	;
 


### PR DESCRIPTION
Adds XIAO ESP32C3 and Haritora to server's firmware constants
See https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/333