### PR TITLE
Fix Quaternion biAlign

### DIFF
--- a/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
@@ -352,7 +352,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 
 	/**
 	 * Produces angles such that
-	 * Quaternion.fromRotationVector(angles[0]*axisA) * Quaternion.fromRotationVector(angles[1]*axisB)
+	 * Quaternion.fromRotationVector(angles[0]*axisA.unit()) * Quaternion.fromRotationVector(angles[1]*axisB.unit())
 	 * is as close to rot as possible
 	 */
 	fun biAlign(rot: Quaternion, axisA: Vector3, axisB: Vector3): FloatArray {
@@ -361,10 +361,10 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 
 		val aQ = a.dot(rot.xyz)
 		val bQ = b.dot(rot.xyz)
-		val abQ = a.cross(b).dot(rot.xyz) - a.dot(b)*rot.w
+		val abQ = a.cross(b).dot(rot.xyz) - a.dot(b) * rot.w
 
-		val angleA = atan2(2f*(abQ*bQ + aQ*rot.w), rot.w*rot.w - aQ*aQ + bQ*bQ - abQ*abQ)
-		val angleB = atan2(2f*(abQ*aQ + bQ*rot.w), rot.w*rot.w + aQ*aQ - bQ*bQ - abQ*abQ)
+		val angleA = atan2(2f * (abQ * bQ + aQ * rot.w), rot.w * rot.w - aQ * aQ + bQ * bQ - abQ * abQ)
+		val angleB = atan2(2f * (abQ * aQ + bQ * rot.w), rot.w * rot.w + aQ * aQ - bQ * bQ - abQ * abQ)
 		
 		return floatArrayOf(angleA, angleB)
 	}

--- a/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
@@ -356,15 +356,16 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 	 * is as close to rot as possible
 	 */
 	fun biAlign(rot: Quaternion, axisA: Vector3, axisB: Vector3): FloatArray {
-		val aQ = axisA.dot(rot.xyz)
-		val bQ = axisA.dot(rot.xyz)
-		val abQ = axisA.cross(axisB).dot(rot.xyz)
+		val a = axisA.unit()
+		val b = axisB.unit()
 
-		val angleA = atan2(2 * (abQ * bQ + aQ * rot.w), abQ * abQ + aQ * aQ - bQ * bQ - rot.w * rot.w)
-		val cosA = cos(angleA / 2)
-		val sinA = sin(angleA / 2)
-		val angleB = 2 * atan2(aQ * cosA - rot.w * sinA, bQ * sinA - abQ * cosA)
+		val aQ = a.dot(rot.xyz)
+		val bQ = b.dot(rot.xyz)
+		val abQ = a.cross(b).dot(rot.xyz) - a.dot(b)*rot.w
 
+		val angleA = atan2(2f*(abQ*bQ + aQ*rot.w), rot.w*rot.w - aQ*aQ + bQ*bQ - abQ*abQ)
+		val angleB = atan2(2f*(abQ*aQ + bQ*rot.w), rot.w*rot.w + aQ*aQ - bQ*bQ - abQ*abQ)
+		
 		return floatArrayOf(angleA, angleB)
 	}
 


### PR DESCRIPTION
Fixed biAlign. (Syntax check and formatting needed)

Added: Safety unitization in case of non unit axes.
Fixed: Found bQ was evaluated as "a.dot(Q.xyz)" instead of "b.dot(Q.xyz)"
Fixed: abQ was missing term "- a.dot(b)*rot.w"
Fixed: angleA was maximizing error instead of minimizing
Fixed: angleB was not consistently giving a value between -pi and pi

I came back to this code to use it for some research, and turns out there were some severe mistakes or typos. This is re-derived from the ground up and the lua version is tested a fair bit. This is a translation of Lua to Kotlin, so there might be some syntax errors, but the math is correct now.