### PR TITLE
Issue#1092 - White theme has correct manual mounting colors

### DIFF
--- a/gui/src/components/onboarding/pages/mounting/MountingSelectionMenu.tsx
+++ b/gui/src/components/onboarding/pages/mounting/MountingSelectionMenu.tsx
@@ -187,7 +187,7 @@ export function MountingSelectionMenu({
       shouldCloseOnEsc
       onRequestClose={onClose}
       overlayClassName={classNames(
-        'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full bg-black bg-opacity-90 z-20'
+        'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full bg-background-90 bg-opacity-90 z-20'
       )}
       className={classNames(
         'focus:ring-transparent focus:ring-offset-transparent focus:outline-transparent outline-none mt-20 z-10'

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
@@ -265,7 +265,7 @@ export function TrackersAssignPage() {
       <NeckWarningModal
         isOpen={shouldShowChokerWarn}
         overlayClassName={classNames(
-          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-black bg-opacity-90 z-20'
+          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-background-90 bg-opacity-90 z-20'
         )}
         onClose={() => closeChokerWarning(true)}
         accept={() => closeChokerWarning(false)}

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerSelectionMenu.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerSelectionMenu.tsx
@@ -34,7 +34,7 @@ export function TrackerSelectionMenu({
         shouldCloseOnEsc
         onRequestClose={onClose}
         overlayClassName={classNames(
-          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full bg-black bg-opacity-90 z-20'
+          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full bg-background-90 bg-opacity-90 z-20'
         )}
         className={classNames(
           'focus:ring-transparent focus:ring-offset-transparent focus:outline-transparent outline-none z-10 h-full pt-10'

--- a/gui/src/components/tracker/SingleTrackerBodyAssignmentMenu.tsx
+++ b/gui/src/components/tracker/SingleTrackerBodyAssignmentMenu.tsx
@@ -37,7 +37,7 @@ export function SingleTrackerBodyAssignmentMenu({
         shouldCloseOnEsc
         onRequestClose={onClose}
         overlayClassName={classNames(
-          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-black bg-opacity-90 z-20'
+          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-background-90 bg-opacity-90 z-20'
         )}
         className={classNames(
           'focus:ring-transparent focus:ring-offset-transparent focus:outline-transparent outline-none mt-12 z-10 overflow-y-auto'
@@ -87,7 +87,7 @@ export function SingleTrackerBodyAssignmentMenu({
       <NeckWarningModal
         isOpen={shouldShowChokerWarn}
         overlayClassName={classNames(
-          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-black bg-opacity-90 z-20'
+          'fixed top-0 right-0 left-0 bottom-0 flex flex-col items-center w-full h-full justify-center bg-background-90 bg-opacity-90 z-20'
         )}
         onClose={() => closeChokerWarning(true)}
         accept={() => closeChokerWarning(false)}


### PR DESCRIPTION
Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/1092 - White theme has broken manual mounting text 

White theme was incorrectly applying a black background color as the shade overlay for pop-up windows. 
The fix ensures that the correct background color is applied to the shade overlay, respecting the selected theme (white or other).

**UI Change:**
- Use class names respecting the theme instead of constant "black" background color for the overlay.
- For the white theme, the overlay background color is now white with the specified opacity.
- For the dark theme(s), the overlay background color remains black with the specified opacity.
-
**Additional Change:**
- The background color for the overlay is fixed on more than just manual mounting page. For example assignment page when you navigate from tracker settings now have proper background color.

![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/592d3482-d13c-44f0-8703-fdba3861f9ed)
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/6ad778d2-13f0-426f-bc51-65857dc49423)

previous look:
![image](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/168dbc57-d362-453e-8b36-b30f6e3aea5c)
