### PR TITLE
Issue#1082 - The Exit Modals does not go on top of other

### DIFF
--- a/gui/src/components/TrackersStillOnModal.tsx
+++ b/gui/src/components/TrackersStillOnModal.tsx
@@ -24,7 +24,7 @@ export function TrackersStillOnModal({
   const { l10n } = useLocalization();
 
   return (
-    <BaseModal isOpen={isOpen} onRequestClose={cancel}>
+    <BaseModal isOpen={isOpen} onRequestClose={cancel} important>
       <div className="flex flex-col gap-3">
         <>
           <div className="flex flex-col items-center gap-3 fill-accent-background-20">

--- a/gui/src/components/TrayOrExitModal.tsx
+++ b/gui/src/components/TrayOrExitModal.tsx
@@ -36,7 +36,7 @@ export function TrayOrExitModal({
   });
 
   return (
-    <BaseModal isOpen={isOpen} onRequestClose={cancel}>
+    <BaseModal isOpen={isOpen} onRequestClose={cancel} important>
       <form
         className="flex flex-col gap-3 w-[27rem]"
         onSubmit={handleSubmit((form) => accept(form.exitType === '1'))}

--- a/gui/src/components/commons/BaseModal.tsx
+++ b/gui/src/components/commons/BaseModal.tsx
@@ -4,10 +4,12 @@ import ReactModal from 'react-modal';
 
 export function BaseModal({
   children,
+  important = false,
   ...props
 }: {
   isOpen: boolean;
   children: ReactNode;
+  important?: boolean;
 } & ReactModal.Props) {
   return (
     <ReactModal
@@ -18,7 +20,8 @@ export function BaseModal({
         props.overlayClassName ||
         classNames(
           'fixed top-0 right-0 left-0 bottom-0 flex flex-col justify-center',
-          'items-center w-full h-full bg-background-90 bg-opacity-60 z-20'
+          'items-center w-full h-full bg-background-90 bg-opacity-60',
+          important ? 'z-50' : 'z-40'
         )
       }
       className={


### PR DESCRIPTION
Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/1082 - The Exit Modal does not go on top of other.

The exit modal dialogs 'Trackers still on' and 'Tray or exit' are rendered behind the currently open overlays/modals, causing a poor user experience as the exit modals should always be on top.

**UI Changes:** Adjusted the z-index of the exit modals (TrackersStillOn and TrayOrExit), ensuring they appear on top of any other open overlays.
![obrazek](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/1ed520b7-8a44-4d59-a65f-1884e9c5eb74)
![obrazek](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/778b0805-ab3b-4b09-bd2b-4309106806ef)
![obrazek](https://github.com/SlimeVR/SlimeVR-Server/assets/11602729/d4fd3417-91e6-4198-9a3c-5cc89d33d81a)
