### PR TITLE
Issue#1079 - Add a background to the 3d preview skeleton

### DIFF
--- a/gui/src/components/widgets/SkeletonVisualizerWidget.tsx
+++ b/gui/src/components/widgets/SkeletonVisualizerWidget.tsx
@@ -110,9 +110,9 @@ export function ToggleableSkeletonVisualizerWidget(
         </Button>
       )}
       {enabled && (
-        <>
+        <div className="flex flex-col gap-2">
           <Button
-            className="w-full"
+            className="w-full "
             variant="secondary"
             onClick={() => {
               setEnabled(false);
@@ -121,9 +121,8 @@ export function ToggleableSkeletonVisualizerWidget(
           >
             {l10n.getString('widget-skeleton_visualizer-hide')}
           </Button>
-
           <SkeletonVisualizerWidget {...props} />
-        </>
+        </div>
       )}
     </>
   );
@@ -197,7 +196,7 @@ export function SkeletonVisualizerWidget({
 
   if (!skeleton.current) return <></>;
   return (
-    <div className="bg-background-70 flex flex-col p-3 rounded-lg gap-2">
+    <div className="bg-background-60 flex flex-col p-3 rounded-lg gap-2">
       <ErrorBoundary
         fallback={
           <Typography color="primary" textAlign="text-center">

--- a/gui/src/components/widgets/SkeletonVisualizerWidget.tsx
+++ b/gui/src/components/widgets/SkeletonVisualizerWidget.tsx
@@ -112,7 +112,7 @@ export function ToggleableSkeletonVisualizerWidget(
       {enabled && (
         <div className="flex flex-col gap-2">
           <Button
-            className="w-full "
+            className="w-full"
             variant="secondary"
             onClick={() => {
               setEnabled(false);


### PR DESCRIPTION
Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/1079 - Add a background or a border to the 3d preview so it does not merge with the page background.

**UI Changes:** Added a background to the 3D preview to ensure it stands out from the page background.
The 3D preview now does not blend into the page background and should work for all visual **themes** (see image).

**Implementation Note:** The background for the 3D preview has been applied universally across all pages, as per the feedback received.
![skell-anim](https://github.com/user-attachments/assets/0bf9b6f6-ac87-47a8-9348-1df99d282f2c)
