### PR TITLE
Update jSerialComm library

### DIFF
--- a/server/desktop/build.gradle.kts
+++ b/server/desktop/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 	implementation("com.google.protobuf:protobuf-java:3.21.12")
 	implementation("net.java.dev.jna:jna:5.+")
 	implementation("net.java.dev.jna:jna-platform:5.+")
-	implementation("com.fazecast:jSerialComm:2.10.2")
+	implementation("com.fazecast:jSerialComm:2.11.0")
 	implementation("org.hid4java:hid4java:0.8.0")
 }
 


### PR DESCRIPTION
Updating to jSerialComm v2.11.0 because v2.10.2 crashes on a user's computer with `STATUS_STACK_OVERFLOW` (0xc00000fd) on calls to `SerialPort.getCommPorts()`. May be related to https://github.com/Fazecast/jSerialComm/issues/515.

Do note, v2.11.0 has issues on 32 bit JVM on Windows, v2.11.1 is supposed to release soon to fix this, but I don't think we target 32 bit anyways. We could also just wait for v2.11.1 because it should be very soon.