### PR TITLE
Update flake nixpkgs revision

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1721562059,
+        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
               harfbuzz
               libffi
               libsoup_3
-              openssl.out
+              openssl
               pango
               pkg-config
               treefmt
@@ -138,6 +138,8 @@
             # Export a LD_LIBRARY_PATH without libudev-zero as libgudev not likey
             export SLIMEVR_RUST_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
             export LD_LIBRARY_PATH="${libudev-zero}/lib:$LD_LIBRARY_PATH"
+            # GStreamer plugins won't be found without this
+            export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
           '';
         };
       };


### PR DESCRIPTION
Newer nixpkgs revisions need GST_PLUGIN_SYSTEM_PATH_1_0 set. Keeping stuff working with the latest nixpkgs helps with packaging and getting mesa versions to match.