### PR TITLE
Change Android webserver port to 34536

### DIFF
--- a/server/android/src/main/java/dev/slimevr/android/Main.kt
+++ b/server/android/src/main/java/dev/slimevr/android/Main.kt
@@ -30,7 +30,7 @@ val vrServerInitialized: Boolean
 
 fun main(activity: AppCompatActivity) {
 	// Host the web GUI server
-	embeddedServer(Netty, port = 8080) {
+	embeddedServer(Netty, port = 34536) {
 		routing {
 			install(CachingHeaders) {
 				options { _, _ ->

--- a/server/android/src/main/java/dev/slimevr/android/MainActivity.kt
+++ b/server/android/src/main/java/dev/slimevr/android/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity() {
 		guiWebView.clearCache(true)
 
 		// Load GUI page
-		guiWebView.loadUrl("http://127.0.0.1:8080/")
+		guiWebView.loadUrl("http://127.0.0.1:34536/")
 		LogManager.info("[MainActivity] GUI WebView has been initialized and loaded.")
 	}
 }


### PR DESCRIPTION
Apparently Pico 4 reserves port 8080 and honestly it's a really common port, so let's just use something random. Ideally we could just use port 0 and have the OS choose an appropriate port? Maybe someone can figure that out instead, but this is a shrimple immediate workaround.