### PR TITLE
Fix Android build & OSC support

### DIFF
--- a/server/android/proguard-rules.pro
+++ b/server/android/proguard-rules.pro
@@ -24,6 +24,9 @@
 -dontwarn org.apache.logging.log4j.message.MessageFactory
 -dontwarn org.apache.logging.log4j.spi.ExtendedLogger
 -dontwarn org.apache.logging.log4j.spi.ExtendedLoggerWrapper
+-dontwarn org.apache.log4j.Level
+-dontwarn org.apache.log4j.Logger
+-dontwarn org.apache.log4j.Priority
 -dontwarn org.conscrypt.BufferAllocator
 -dontwarn org.conscrypt.Conscrypt
 -dontwarn org.conscrypt.HandshakeListener

--- a/server/core/build.gradle.kts
+++ b/server/core/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
 	implementation("org.apache.commons:commons-lang3:3.12.0")
 	implementation("org.apache.commons:commons-collections4:4.4")
 
-	implementation("com.illposed.osc:javaosc-core:0.9")
+	implementation("com.illposed.osc:javaosc-core:0.8")
 	implementation("org.java-websocket:Java-WebSocket:1.+")
 	implementation("com.melloware:jintellitype:1.+")
 	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")


### PR DESCRIPTION
JavaOSC 0.9 breaks Android support in this commit https://github.com/hoijui/JavaOSC/commit/2cbbc433a354fc0ba326b44826e1ae2b0a7f8350 by using `ClassLoader.getDefinedPackage()`, so we need to revert back to version 0.8.

Also it seems some dependency is using a different version of log4j so we need to add their classes to proguard rules to comply for minify on Android.