### PR TITLE
Reset upper chest tracker

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -1034,6 +1034,7 @@ class HumanSkeleton(
 	val trackersToReset: List<Tracker?>
 		get() = listOf(
 			neckTracker,
+			upperChestTracker,
 			chestTracker,
 			waistTracker,
 			hipTracker,


### PR DESCRIPTION
One of my PR made it so only trackers assigned in skeleton reset but existing code didn't account for the upper chest tracker.

We can also go back to resetting every trackers, but we have conditions such as checking if the tracker is on the head, feet, or arms, that require it to be assigned in the skeleton in some way so the user would have to re-reset anyways. 

Keeping it like that may be less confusing as tracking will either be 100% broken or working fine; no in-between.