### PR TITLE
Add small top padding to show highlighting on tracker assignment page

### DIFF
--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
@@ -334,7 +334,7 @@ export function TrackersAssignPage() {
                 )}
               </div>
             </div>
-            <div className="flex flex-col rounded-xl fill-background-50">
+            <div className="flex flex-col rounded-xl fill-background-50 pt-1">
               <BodyAssignment
                 width={isMobile ? 150 : undefined}
                 dotSize={isMobile ? 10 : undefined}


### PR DESCRIPTION
Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/1130 - Highlighting in tracker assignment cut off

This PR adds a small top padding to the tracker assignment page to ensure that the highlighting is not cut off when shaking the trackers.

![image](https://github.com/user-attachments/assets/f71bc68f-4661-438f-9f60-a674e2fbe72c)
