### PR TITLE
Fix tracker reset logic

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -323,7 +323,8 @@ class Tracker @JvmOverloads constructor(
 			_rotation
 		}
 
-		if (needsReset || (isComputed && !isInternal)) {
+		// Reset if needed and is not computed and internal
+		if (needsReset && !(isComputed && isInternal)) {
 			// Adjust to reset, mounting and drift compensation
 			rot = resetsHandler.getReferenceAdjustedDriftRotationFrom(rot)
 		}
@@ -354,7 +355,8 @@ class Tracker @JvmOverloads constructor(
 			_rotation
 		}
 
-		if (needsReset || (isComputed && trackerPosition == TrackerPosition.HEAD)) {
+		// Reset if needed or is a computed tracker besides head
+		if (needsReset && !(isComputed && trackerPosition != TrackerPosition.HEAD)) {
 			// Adjust to reset and mounting
 			rot = resetsHandler.getIdentityAdjustedDriftRotationFrom(rot)
 		}

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/SteamVRBridge.kt
@@ -155,16 +155,16 @@ abstract class SteamVRBridge(
 
 		// Display name, needsReset and isHmd
 		val displayName: String
-		val (needsReset, isHmd) = if (trackerAdded.trackerId == 0) {
+		val isHmd = if (trackerAdded.trackerId == 0) {
 			displayName = if (trackerAdded.trackerName == "HMD") {
 				"SteamVR Driver HMD"
 			} else {
 				"Feeder App HMD"
 			}
-			false to true
+			true
 		} else {
 			displayName = trackerAdded.trackerName
-			true to false
+			false
 		}
 
 		// trackerPosition
@@ -187,7 +187,7 @@ abstract class SteamVRBridge(
 			hasRotation = true,
 			userEditable = true,
 			isComputed = true,
-			needsReset = needsReset,
+			needsReset = true,
 			isHmd = isHmd,
 		)
 


### PR DESCRIPTION
The tracker reset logic was changed in #1057, this broke AutoBone by causing the recorded trackers to be reset. This PR should fix the logic, though I'm not exactly sure what was intended by the logic. I've also added comments because it's not super readable.