### PR TITLE
check flatpak runtime dir first

### DIFF
--- a/server/core/src/main/java/io/eiren/util/OperatingSystem.kt
+++ b/server/core/src/main/java/io/eiren/util/OperatingSystem.kt
@@ -39,6 +39,12 @@ enum class OperatingSystem(
 				if (dir != null) return dir
 				if (currentPlatform == LINUX) {
 					dir = System.getenv("XDG_RUNTIME_DIR")
+
+					// add /app/$FLATPAK_ID if running in flatpak
+					// see https://docs.flatpak.org/en/latest/sandbox-permissions.html
+					val flatpak_id = System.getenv("FLATPAK_ID")
+					if (flatpak_id != null) dir += "/app/" + flatpak_id
+
 					if (dir != null) return dir
 				}
 				return System.getProperty("java.io.tmpdir")


### PR DESCRIPTION
This change would allow SlimeVR to set up sockets on the host while running in a flatpak. In order to do this, we set the socket dir to `$XDG_RUNTIME_DIR/app/$FLATPAK_ID` if the `FLATPAK_ID` environment variable is set.

Flatpak's sandbox doesn't allow writes to the runtime root, for more details see: https://docs.flatpak.org/en/latest/sandbox-permissions.html

Related changes: https://github.com/SlimeVR/SlimeVR-OpenVR-Driver/pull/48 and https://github.com/SlimeVR/SlimeVR-Feeder-App/pull/22