### PR TITLE
Sleep HID dataRead with devices present

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
@@ -261,6 +261,8 @@ class TrackersHID(name: String, private val trackersConsumer: Consumer<Tracker>)
 			}
 			if (!devicesPresent) {
 				sleep(10) // No hid device, "empty loop" so sleep to save the poor cpu
+			} else {
+				sleep(1) // read has no timeout, no data also causes an "empty loop"
 			}
 		}
 	}

--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/TrackersHID.kt
@@ -186,6 +186,7 @@ class TrackersHID(name: String, private val trackersConsumer: Consumer<Tracker>)
 	private fun dataRead() {
 		synchronized(devicesByHID) {
 			var devicesPresent = false
+			var devicesDataReceived = false
 			val q = intArrayOf(0, 0, 0, 0)
 			val a = intArrayOf(0, 0, 0)
 			for ((hidDevice, deviceList) in devicesByHID) {
@@ -202,6 +203,7 @@ class TrackersHID(name: String, private val trackersConsumer: Consumer<Tracker>)
 						LogManager.info("[TrackerServer] Malformed HID packet, ignoring")
 						continue // Don't continue with this data
 					}
+					devicesDataReceived = true // Data is received and is valid (not malformed)
 					val packetCount = dataReceived.size / 20
 					var i = 0
 					while (i < packetCount * 20) {
@@ -261,7 +263,7 @@ class TrackersHID(name: String, private val trackersConsumer: Consumer<Tracker>)
 			}
 			if (!devicesPresent) {
 				sleep(10) // No hid device, "empty loop" so sleep to save the poor cpu
-			} else {
+			} else if (!devicesDataReceived) {
 				sleep(1) // read has no timeout, no data also causes an "empty loop"
 			}
 		}


### PR DESCRIPTION
In update to hid4java timeout for device read was removed since multiple devices could be connected, make the thread sleep at least once to save the cpu

Only affected if one or more HID devices are connected, if none are connected the thread already sleeps normally