### PR TITLE
Add settings profiles

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -280,6 +280,7 @@ settings-sidebar-utils = Utilities
 settings-sidebar-serial = Serial console
 settings-sidebar-appearance = Appearance
 settings-sidebar-notifications = Notifications
+settings-sidebar-profiles = Profiles
 settings-sidebar-advanced = Advanced
 
 ## SteamVR settings
@@ -603,6 +604,28 @@ settings-osc-vmc-anchor_hip-label = Anchor at hips
 settings-osc-vmc-mirror_tracking = Mirror tracking
 settings-osc-vmc-mirror_tracking-description = Mirror the tracking horizontally.
 settings-osc-vmc-mirror_tracking-label = Mirror tracking
+
+## Profile settings
+settings-utils-profiles = Profiles
+settings-utils-profiles-description = Manage your settings profiles to quickly switch between settings: GUI, tracking, body proportions, etc.
+
+settings-utils-profiles-default = Default profile
+
+settings-utils-profiles-profile = Current profile
+settings-utils-profiles-profile-description = Choose a profile to load or save your settings to.
+
+settings-utils-profiles-new = Create new profile
+settings-utils-profiles-new-description = Create a new profile with the current settings.
+settings-utils-profiles-new-label = Create
+
+settings-utils-profiles-delete = Delete profile
+settings-utils-profiles-delete-description = Delete the selected profile.
+settings-utils-profiles-delete-label = Delete profile
+settings-utils-profiles-delete-warning =
+    <b>Warning:</b> This will delete the selected profile ({ $name }).
+    Are you sure you want to do this?
+settings-utils-profiles-delete-warning-done = Yes
+settings-utils-profiles-delete-warning-cancel = Cancel
 
 ## Advanced settings
 settings-utils-advanced = Advanced

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -55,6 +55,7 @@ import { AppLayout } from './AppLayout';
 import { Preload } from './components/Preload';
 import { UnknownDeviceModal } from './components/UnknownDeviceModal';
 import { useDiscordPresence } from './hooks/discord-presence';
+import { ProfileSettings } from './components/settings/pages/Profiles';
 import { AdvancedSettings } from './components/settings/pages/AdvancedSettings';
 
 export const GH_REPO = 'SlimeVR/SlimeVR-Server';
@@ -111,6 +112,7 @@ function Layout() {
             <Route path="osc/vrchat" element={<VRCOSCSettings />} />
             <Route path="osc/vmc" element={<VMCSettings />} />
             <Route path="interface" element={<InterfaceSettings />} />
+            <Route path="profiles" element={<ProfileSettings />} />
             <Route path="advanced" element={<AdvancedSettings />} />
           </Route>
           <Route

--- a/gui/src/components/ProfilesDropdown.tsx
+++ b/gui/src/components/ProfilesDropdown.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useConfig } from '@/hooks/config';
+import { useWebsocketAPI as _ } from '@/hooks/websocket-api';
+import { useLocalization } from '@fluent/react';
+import { Dropdown } from './commons/Dropdown';
+import { log } from '@/utils/logging';
+
+export function ProfilesDropdown({
+  paddingX,
+  paddingY,
+  minHeight,
+}: {
+  // Used by the profile quick access in topbar, may be removed
+  paddingX?: number;
+  paddingY?: number;
+  minHeight?: string | number;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  const { l10n } = useLocalization();
+  const { config, setConfig } = useConfig();
+
+  const { control, watch, handleSubmit } = useForm<{ profile: string }>({
+    defaultValues: { profile: config?.profile || 'default' },
+  });
+
+  useEffect(() => {
+    const subscription = watch(() => handleSubmit(onSubmit)());
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const onSubmit = (values: { profile: string }) => {
+    log(`Setting profile to ${values.profile}`);
+    // TODO: get profile's settings and set them
+    /* setConfig({
+       debug: values.appearance.devmode,
+          watchNewDevices: values.notifications.watchNewDevices,
+          feedbackSound: values.notifications.feedbackSound,
+          feedbackSoundVolume: values.notifications.feedbackSoundVolume,
+          theme: values.appearance.theme,
+          showNavbarOnboarding: values.appearance.showNavbarOnboarding,
+          fonts: values.appearance.fonts.split(','),
+          textSize: values.appearance.textSize,
+          connectedTrackersWarning: values.notifications.connectedTrackersWarning,
+          useTray: values.notifications.useTray,
+          discordPresence: values.notifications.discordPresence,
+          decorations: values.appearance.decorations,
+    }); */
+  };
+
+  return (
+    <Dropdown
+      control={control}
+      name="profile"
+      display="block"
+      placeholder={l10n.getString('settings-utils-profiles-default')}
+      direction="down"
+      minHeight={minHeight}
+      paddingX={paddingX}
+      paddingY={paddingY}
+      items={[
+        {
+          label: l10n.getString('settings-utils-profiles-default'),
+          value: 'default',
+        },
+        { label: 'Lexend', value: 'Lexend' },
+        { label: 'Ubuntu', value: 'Ubuntu' },
+      ]}
+    ></Dropdown>
+  );
+}

--- a/gui/src/components/TopBar.tsx
+++ b/gui/src/components/TopBar.tsx
@@ -29,6 +29,7 @@ import { listen } from '@tauri-apps/api/event';
 import { TrayOrExitModal } from './TrayOrExitModal';
 import { error } from '@/utils/logging';
 import { useDoubleTap } from 'use-double-tap';
+import { ProfilesDropdown } from './ProfilesDropdown';
 
 export function VersionTag() {
   return (
@@ -168,6 +169,10 @@ export function TopBar({
                   )}
                 </>
               )}
+
+                <div className='flex items-center'>
+                  <ProfilesDropdown paddingX={2} paddingY={1} minHeight={'24px'}></ProfilesDropdown>
+                </div>
 
               {version && (
                 <div

--- a/gui/src/components/commons/Dropdown.tsx
+++ b/gui/src/components/commons/Dropdown.tsx
@@ -14,7 +14,10 @@ interface DropdownProps {
   control: Control<any>;
   name: string;
   items: DropdownItem[];
+  minHeight?: string | number;
   maxHeight?: string | number;
+  paddingX?: string | number;
+  paddingY?: string | number;
   rules?: UseControllerProps<any>['rules'];
 }
 
@@ -134,6 +137,10 @@ export function Dropdown({
   variant = 'primary',
   alignment = 'right',
   display = 'fit',
+  // Used by the profile quick access in topbar, may be removed
+  paddingX = '5',
+  paddingY = '3',
+  minHeight = '42px',
   maxHeight = '50vh',
   placeholder,
   control,
@@ -156,7 +163,7 @@ export function Dropdown({
     //    Works but have a slight delay when resizing, kinda looks laggy
     // 2 - We close the dropdown on resize.
     //     We could consider this as the same as clicking outside of the dropdown
-    //     This is the approach choosen RN
+    //     This is the approach chosen RN
     setOpen(false);
   };
 
@@ -182,7 +189,7 @@ export function Dropdown({
           <div
             ref={ref}
             className={classNames(
-              'min-h-[42px] text-background-10 px-5 py-3 rounded-md focus:ring-4 text-center dropdown',
+              `min-h-[${minHeight}] text-background-10 px-${paddingX} py-${paddingY} rounded-md focus:ring-4 text-center dropdown`,
               'flex cursor-pointer',
               variant == 'primary' && 'bg-background-60 hover:bg-background-50',
               variant == 'secondary' &&

--- a/gui/src/components/settings/DeleteProfileModal.tsx
+++ b/gui/src/components/settings/DeleteProfileModal.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@/components/commons/Button';
+import { WarningBox } from '@/components/commons/TipBox';
+import { Localized, useLocalization } from '@fluent/react';
+import { BaseModal } from '@/components/commons/BaseModal';
+import ReactModal from 'react-modal';
+
+export function DeleteProfileModal({
+  isOpen = true,
+  onClose,
+  accept,
+  profile,
+  ...props
+}: {
+  /**
+   * Is the parent/sibling component opened?
+   */
+  isOpen: boolean;
+  /**
+   * Function to trigger when the warning hasn't been accepted
+   */
+  onClose: () => void;
+  /**
+   * Function when accepting the modal
+   */
+  accept: () => void;
+  profile: string;
+} & ReactModal.Props) {
+  const { l10n } = useLocalization();
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      shouldCloseOnOverlayClick
+      onRequestClose={onClose}
+      className={props.className}
+      overlayClassName={props.overlayClassName}
+    >
+      <div className="flex w-full h-full flex-col ">
+        <div className="flex flex-col flex-grow items-center gap-3">
+          <Localized
+            id="settings-utils-profiles-delete-warning"
+            elems={{ b: <b></b> }}
+            vars={{ name: profile }}
+          >
+            <WarningBox>
+            <b>Warning:</b> This will delete the selected profile ({ profile }).
+            Are you sure you want to do this?
+            </WarningBox>
+          </Localized>
+
+          <div className="flex flex-row gap-3 pt-5 place-content-center">
+            <Button variant="primary" onClick={onClose}>
+              {l10n.getString(
+                'settings-utils-profiles-delete-warning-cancel'
+              )}
+            </Button>
+            <Button
+              variant="tertiary"
+              onClick={() => {
+                accept();
+              }}
+            >
+              {l10n.getString(
+                'settings-utils-profiles-delete-warning-done'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/gui/src/components/settings/SettingsLayout.tsx
+++ b/gui/src/components/settings/SettingsLayout.tsx
@@ -41,6 +41,10 @@ export function SettingSelectorMobile() {
         value: { url: '/settings/serial' },
       },
       {
+        label: l10n.getString('settings-sidebar-profiles'),
+        value: { url: '/settings/profiles' },
+      },
+      {
         label: l10n.getString('settings-sidebar-advanced'),
         value: { url: '/settings/advanced' },
       },
@@ -53,7 +57,7 @@ export function SettingSelectorMobile() {
   });
 
   useEffect(() => {
-    // This works because the component gets mounted/unmounted when switching beween desktop or mobile layout
+    // This works because the component gets mounted/unmounted when switching between desktop or mobile layout
     setValue('link', pathname, { shouldDirty: false, shouldTouch: false });
   }, []);
 
@@ -80,7 +84,7 @@ export function SettingSelectorMobile() {
         }))}
         variant="tertiary"
         direction="down"
-        // There is always an option selected placholder is not used
+        // There is always an option selected placeholder is not used
         placeholder=""
         name="link"
       ></Dropdown>

--- a/gui/src/components/settings/SettingsSidebar.tsx
+++ b/gui/src/components/settings/SettingsSidebar.tsx
@@ -102,6 +102,11 @@ export function SettingsSidebar() {
             </SettingsLink>
           </div>
           <div className="flex flex-col gap-2">
+            <SettingsLink to="/settings/profiles">
+              {l10n.getString('settings-sidebar-profiles')}
+            </SettingsLink>
+          </div>
+          <div className="flex flex-col gap-2">
             <SettingsLink to="/settings/advanced">
               {l10n.getString('settings-sidebar-advanced')}
             </SettingsLink>

--- a/gui/src/components/settings/pages/Profiles.tsx
+++ b/gui/src/components/settings/pages/Profiles.tsx
@@ -1,0 +1,156 @@
+import { useLocalization } from '@fluent/react';
+import { useState } from 'react';
+import { Typography } from '@/components/commons/Typography';
+import {
+  SettingsPageLayout,
+  SettingsPagePaneLayout,
+} from '@/components/settings/SettingsPageLayout';
+import { WrenchIcon } from '@/components/commons/icon/WrenchIcons';
+import { Button } from '@/components/commons/Button';
+
+import { error, log } from '@/utils/logging';
+import { defaultConfig as defaultGUIConfig, useConfig } from '@/hooks/config';
+import {
+  defaultValues as defaultDevConfig,
+  defaultValues,
+} from '@/components/widgets/DeveloperModeWidget';
+import { useWebsocketAPI } from '@/hooks/websocket-api';
+import { ProfilesDropdown } from '@/components/ProfilesDropdown';
+import { DeleteProfileModal } from '../DeleteProfileModal';
+import { Input } from '@/components/commons/Input';
+import { useForm } from 'react-hook-form';
+import { BugIcon } from '@/components/commons/icon/BugIcon';
+
+interface NewProfileForm {
+  name: string;
+}
+
+export function ProfileSettings() {
+  const { l10n } = useLocalization();
+  const { setConfig } = useConfig();
+
+  const [showWarning, setShowWarning] = useState(false);
+
+  const { reset, control, watch, handleSubmit } = useForm<NewProfileForm>({
+    defaultValues: { name: '' },
+  });
+
+  return (
+    <SettingsPageLayout>
+      <form className="flex flex-col gap-2 w-full">
+        <SettingsPagePaneLayout icon={<WrenchIcon></WrenchIcon>} id="advanced">
+          <>
+            <Typography variant="main-title">
+              {l10n.getString('settings-utils-profiles')}
+            </Typography>
+            <div className="flex flex-col pt-2 pb-4">
+              <>
+                {l10n
+                  .getString('settings-utils-profiles-description')
+                  .split('\n')
+                  .map((line, i) => (
+                    <Typography color="secondary" key={i}>
+                      {line}
+                    </Typography>
+                  ))}
+              </>
+            </div>
+
+            <div>
+              <Typography bold>
+                {l10n.getString('settings-utils-profiles-profile')}
+              </Typography>
+              <div className="flex flex-col pt-1 pb-2">
+                <Typography color="secondary">
+                  {l10n.getString(
+                    'settings-utils-profiles-profile-description'
+                  )}
+                </Typography>
+              </div>
+              <div className="grid sm:grid-cols-1 pb-4">
+                <ProfilesDropdown></ProfilesDropdown>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 mobile:grid-cols-1">
+              <div>
+                <Typography bold>
+                  {l10n.getString('settings-utils-profiles-new')}
+                </Typography>
+                <div className="flex flex-col pt-1 pb-2">
+                  <Typography color="secondary">
+                    {l10n.getString('settings-utils-profiles-new-description')}
+                  </Typography>
+                </div>
+                <div className="flex gap-2 mobile:flex-col">
+                  <div style={{ flexBasis: '65%' }}>
+                    <Input
+                      control={control}
+                      rules={{ required: true }}
+                      name="new-profile"
+                      type="text"
+                      placeholder="Enter name"
+                      variant="secondary"
+                      className="flex-grow"
+                    />
+                  </div>
+
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      // TODO: ask for name, then create a new profile
+                      /* setConfig({
+                        ...defaultGUIConfig,
+                        devSettings: defaultDevConfig,
+                      });*/
+                      log('Creating new profile');
+                    }}
+                    className="flex-grow"
+                    style={{ flexBasis: '35%' }}
+                  >
+                    {l10n.getString('settings-utils-profiles-new-label')}
+                  </Button>
+                </div>
+              </div>
+
+              <div>
+                <Typography bold>
+                  {l10n.getString('settings-utils-profiles-delete')}
+                </Typography>
+                <div className="flex flex-col pt-1 pb-2">
+                  <Typography color="secondary">
+                    {l10n.getString(
+                      'settings-utils-profiles-delete-description'
+                    )}
+                  </Typography>
+                </div>
+                <div className="flex gap-2 mobile:flex-col">
+                  <div style={{ flexBasis: '65%' }}>
+                    <ProfilesDropdown></ProfilesDropdown>
+                  </div>
+                    <Button
+                      variant="secondary"
+                      onClick={() => setShowWarning(true)}
+                      style={{ flexBasis: '35%' }}
+                    >
+                      {l10n.getString('settings-utils-profiles-delete-label')}
+                    </Button>
+                    <DeleteProfileModal
+                      accept={() => {
+                        log('Deleting profile');
+                        // TODO: actually delete profile
+                        setShowWarning(false);
+                      }}
+                      onClose={() => setShowWarning(false)}
+                      isOpen={showWarning}
+                      profile="default"
+                    ></DeleteProfileModal>
+                </div>
+              </div>
+            </div>
+          </>
+        </SettingsPagePaneLayout>
+      </form>
+    </SettingsPageLayout>
+  );
+}

--- a/gui/src/hooks/config.ts
+++ b/gui/src/hooks/config.ts
@@ -39,6 +39,7 @@ export interface Config {
   discordPresence: boolean;
   decorations: boolean;
   showNavbarOnboarding: boolean;
+  profile: string;
 }
 
 export interface ConfigContext {
@@ -66,6 +67,7 @@ export const defaultConfig: Omit<Config, 'devSettings'> = {
   discordPresence: false,
   decorations: false,
   showNavbarOnboarding: true,
+  profile: 'default',
 };
 
 interface CrossStorage {


### PR DESCRIPTION
Draft PR to add settings profiles so users can create different profiles for different settings, including body proportions.

Current plan is to have a `profiles` folder in SlimeVR's data folder which will have folders with the names of the profiles, each of them containing their own `vrsettings.yml` and `gui-settings.dat` (e.g. `dev.slimevr.SlimeVR/profiles/Bingus`).

Fixes #38.