### PR TITLE
Fix style for tracker "shadow" & add to all cases

### DIFF
--- a/gui/src/components/tracker/TrackerCard.tsx
+++ b/gui/src/components/tracker/TrackerCard.tsx
@@ -150,7 +150,7 @@ export function TrackerCard({
           ? {
               boxShadow: `0px 0px ${Math.floor(velocity * 8)}px ${Math.floor(
                 velocity * 8
-              )}px var(--accent-background-30)`,
+              )}px rgb(var(--accent-background-30))`,
             }
           : {}
       }

--- a/gui/src/components/tracker/TrackerPartCard.tsx
+++ b/gui/src/components/tracker/TrackerPartCard.tsx
@@ -86,7 +86,7 @@ export function TrackerPartCard({
         style={{
           boxShadow: `0px 0px ${globalVelocity * 3}px ${
             globalVelocity * 3
-          }px  #BB8AE5`,
+          }px rgb(var(--accent-background-30))`,
         }}
       >
         {roleError && (

--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -315,11 +315,11 @@ export function TrackerSettingsPage() {
                   ></BodyPartIcon>
                 )}
                 {tracker?.tracker.info?.bodyPart === BodyPart.NONE && (
-                  <WarningIcon className="text-yellow-300" />
+                  <WarningIcon className="fill-status-warning" />
                 )}
                 <Typography
                   color={classNames({
-                    'text-yellow-300':
+                    'text-status-warning':
                       tracker?.tracker.info?.bodyPart === BodyPart.NONE,
                   })}
                 >

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -137,7 +137,7 @@ export function RowContainer({
         style={{
           boxShadow: `0px 0px ${Math.floor(velocity * 8)}px ${Math.floor(
             velocity * 8
-          )}px  #BB8AE5`,
+          )}px rgb(var(--accent-background-30))`,
         }}
         className={classNames(
           'h-[50px]  flex flex-col justify-center px-3',


### PR DESCRIPTION
#1170 broke the tracker shadow when not in dev mode, the style should have `rgb` around `var`. This PR also applies the same change to all cases of the tracker shadow.