### PR TITLE
Fix vmc head shift for lock head

### DIFF
--- a/server/core/src/main/java/dev/slimevr/osc/VMCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/osc/VMCHandler.kt
@@ -368,7 +368,7 @@ class VMCHandler(
 						// Anchor from head
 						outputUnityArmature?.let { unityArmature ->
 							// Scale the SlimeVR head position with the VRM model
-							val slimevrScaledHeadPos = humanPoseManager.getBone(BoneType.HEAD).getPosition() *
+							val slimevrScaledHeadPos = humanPoseManager.getBone(BoneType.HEAD).getTailPosition() *
 								(vrmHeight / humanPoseManager.userHeightFromConfig)
 
 							// Get the VRM head and hip positions


### PR DESCRIPTION
When using a vive tracker or HMD, this makes it so the head shift is accounted for when using VMC with lock-head.