### PR TITLE
Clarify AutoBone error after #1185

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -970,7 +970,7 @@ onboarding-automatic_proportions-done-title = Body measured and saved.
 onboarding-automatic_proportions-done-description = Your body proportions' calibration is complete!
 onboarding-automatic_proportions-error_modal-v2 =
     <b>Warning:</b> There was an error while estimating proportions!
-    This is likely a mounting calibration issue, make sure your tracking works first.
+    This is likely a mounting calibration issue. Make sure your tracking works properly before trying again.
     Please <docs>check the docs</docs> or join our <discord>Discord</discord> for help ^_^
 onboarding-automatic_proportions-error_modal-confirm = Understood!
 

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -969,7 +969,8 @@ onboarding-automatic_proportions-verify_results-confirm = They're correct
 onboarding-automatic_proportions-done-title = Body measured and saved.
 onboarding-automatic_proportions-done-description = Your body proportions' calibration is complete!
 onboarding-automatic_proportions-error_modal =
-    <b>Warning:</b> An error was found while estimating proportions!
+    <b>Warning:</b> There was an error while estimating proportions!
+    This is likely a mounting calibration issue, make sure your tracking works first.
     Please <docs>check the docs</docs> or join our <discord>Discord</discord> for help ^_^
 onboarding-automatic_proportions-error_modal-confirm = Understood!
 

--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -968,7 +968,7 @@ onboarding-automatic_proportions-verify_results-redo = Redo recording
 onboarding-automatic_proportions-verify_results-confirm = They're correct
 onboarding-automatic_proportions-done-title = Body measured and saved.
 onboarding-automatic_proportions-done-description = Your body proportions' calibration is complete!
-onboarding-automatic_proportions-error_modal =
+onboarding-automatic_proportions-error_modal-v2 =
     <b>Warning:</b> There was an error while estimating proportions!
     This is likely a mounting calibration issue, make sure your tracking works first.
     Please <docs>check the docs</docs> or join our <discord>Discord</discord> for help ^_^

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/AutoboneErrorModal.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/AutoboneErrorModal.tsx
@@ -34,7 +34,7 @@ export function AutoboneErrorModal({
       <div className="flex w-full h-full flex-col ">
         <div className="flex w-full flex-col flex-grow items-center gap-3">
           <Localized
-            id="onboarding-automatic_proportions-error_modal"
+            id="onboarding-automatic_proportions-error_modal-v2"
             elems={{
               b: <b></b>,
               docs: (


### PR DESCRIPTION
The current error message doesn't really convey the issue as the error limit was just patched in. Let's make it say something more useful.

I don't think this is the best message possible since it doesn't really mention anything about an error value limit, though the end user knows nothing about this supposed error value, so maybe it would just be more confusing? I'd love thoughts and suggestions here.