### PR TITLE
Potentially fix weird hip issues

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -879,7 +879,7 @@ class HumanSkeleton(
 			// Interpolate between the hipRot and extendedPelvisRot
 			val newHipRot = hipRot.interpR(
 				if (extendedPelvisRot.lenSq() != 0.0f) extendedPelvisRot else IDENTITY,
-				hipLegsAveraging
+				hipLegsAveraging,
 			)
 
 			// Set new hip rotation

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -877,11 +877,10 @@ class HumanSkeleton(
 			val extendedPelvisRot = extendedPelvisYawRoll(leftLegRot, rightLegRot, hipRot)
 
 			// Interpolate between the hipRot and extendedPelvisRot
-			val newHipRot = if (extendedPelvisRot.lenSq() != 0.0f) {
-				hipRot.interpR(extendedPelvisRot, hipLegsAveraging)
-			} else {
-				Quaternion.IDENTITY
-			}
+			val newHipRot = hipRot.interpR(
+				if (extendedPelvisRot.lenSq() != 0.0f) extendedPelvisRot else IDENTITY,
+				hipLegsAveraging
+			)
 
 			// Set new hip rotation
 			hipBone.setRotation(newHipRot)


### PR DESCRIPTION
Instead of defaulting the hip rotation to IDENTITY when extendedPelvisRot is an invalid rotation interpolate from hipRot to IDENTITY.