### PR TITLE
Attempt to fix moving average quaternions not resetting properly

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -329,13 +329,7 @@ class Tracker @JvmOverloads constructor(
 	}
 
 	private fun getFilteredRotation(): Quaternion = if (trackRotDirection) {
-		if (filteringHandler.filteringEnabled) {
-			// Get filtered rotation
-			filteringHandler.getFilteredRotation()
-		} else {
-			// Get unfiltered rotation
-			filteringHandler.getTrackedRotation()
-		}
+		filteringHandler.getFilteredRotation()
 	} else {
 		// Get raw rotation
 		_rotation
@@ -433,6 +427,6 @@ class Tracker @JvmOverloads constructor(
 	 * Call when doing a full reset to reset the tracking of rotations >180 degrees
 	 */
 	fun resetFilteringQuats() {
-		filteringHandler.resetQuats(_rotation)
+		filteringHandler.resetMovingAverage(_rotation)
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
@@ -11,8 +11,8 @@ import io.github.axisangles.ktmath.Quaternion
  * See QuaternionMovingAverage.kt for the quaternion math.
  */
 class TrackerFilteringHandler {
-
-	private var movingAverage: QuaternionMovingAverage? = null
+	// Instantiated by default in case config doesn't get read (if tracker doesn't support filtering)
+	private var movingAverage = QuaternionMovingAverage(TrackerFilters.NONE)
 	var filteringEnabled = false
 
 	/**
@@ -37,25 +37,25 @@ class TrackerFilteringHandler {
 	 * Update the moving average to make it smooth
 	 */
 	fun update() {
-		movingAverage?.update()
+		movingAverage.update()
 	}
 
 	/**
 	 * Updates the latest rotation
 	 */
 	fun dataTick(currentRawRotation: Quaternion) {
-		movingAverage?.addQuaternion(currentRawRotation)
+		movingAverage.addQuaternion(currentRawRotation)
 	}
 
 	/**
 	 * Call when doing a full reset to reset the tracking of rotations >180 degrees
 	 */
 	fun resetMovingAverage(currentRawRotation: Quaternion) {
-		movingAverage?.resetQuats(currentRawRotation)
+		movingAverage.resetQuats(currentRawRotation)
 	}
 
 	/**
 	 * Get the filtered rotation from the moving average (either prediction/smoothing or just >180 degs)
 	 */
-	fun getFilteredRotation() = movingAverage?.filteredQuaternion ?: Quaternion.IDENTITY
+	fun getFilteredRotation() = movingAverage.filteredQuaternion
 }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
@@ -12,8 +12,7 @@ import io.github.axisangles.ktmath.Quaternion
  */
 class TrackerFilteringHandler {
 
-	private var filteringMovingAverage: QuaternionMovingAverage? = null
-	private var trackingMovingAverage = QuaternionMovingAverage(TrackerFilters.NONE)
+	private var movingAverage: QuaternionMovingAverage? = null
 	var filteringEnabled = false
 
 	/**
@@ -22,14 +21,14 @@ class TrackerFilteringHandler {
 	fun readFilteringConfig(config: FiltersConfig, currentRawRotation: Quaternion) {
 		val type = TrackerFilters.getByConfigkey(config.type)
 		if (type == TrackerFilters.SMOOTHING || type == TrackerFilters.PREDICTION) {
-			filteringMovingAverage = QuaternionMovingAverage(
+			movingAverage = QuaternionMovingAverage(
 				type,
 				config.amount,
 				currentRawRotation,
 			)
 			filteringEnabled = true
 		} else {
-			filteringMovingAverage = null
+			movingAverage = QuaternionMovingAverage(TrackerFilters.NONE)
 			filteringEnabled = false
 		}
 	}
@@ -38,33 +37,25 @@ class TrackerFilteringHandler {
 	 * Update the moving average to make it smooth
 	 */
 	fun update() {
-		trackingMovingAverage.update()
-		filteringMovingAverage?.update()
+		movingAverage?.update()
 	}
 
 	/**
 	 * Updates the latest rotation
 	 */
 	fun dataTick(currentRawRotation: Quaternion) {
-		trackingMovingAverage.addQuaternion(currentRawRotation)
-		filteringMovingAverage?.addQuaternion(currentRawRotation)
+		movingAverage?.addQuaternion(currentRawRotation)
 	}
 
 	/**
 	 * Call when doing a full reset to reset the tracking of rotations >180 degrees
 	 */
-	fun resetQuats(currentRawRotation: Quaternion) {
-		trackingMovingAverage.resetQuats(currentRawRotation)
-		filteringMovingAverage?.resetQuats(currentRawRotation)
+	fun resetMovingAverage(currentRawRotation: Quaternion) {
+		movingAverage?.resetQuats(currentRawRotation)
 	}
 
 	/**
-	 * Gets the tracked rotation from the moving average (allows >180 degrees)
+	 * Get the filtered rotation from the moving average (either prediction/smoothing or just >180 degs)
 	 */
-	fun getTrackedRotation() = trackingMovingAverage.filteredQuaternion
-
-	/**
-	 * Get the filtered rotation from the moving average
-	 */
-	fun getFilteredRotation() = filteringMovingAverage?.filteredQuaternion ?: Quaternion.IDENTITY
+	fun getFilteredRotation() = movingAverage?.filteredQuaternion ?: Quaternion.IDENTITY
 }


### PR DESCRIPTION
- Fixed the rotBuffer not being cleared in QuaternionMovingAverage:resetQuats
- Refactored and cleaned up old code since we don't need filtered and non-filtered rotation at the same time (should improve performance)