### PR TITLE
Update apt cache action to fix CI error

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -57,7 +57,7 @@ jobs:
 
       - if: matrix.os == 'ubuntu-22.04'
         name: Set up Linux dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: libgtk-3-dev webkit2gtk-4.1 libappindicator3-dev librsvg2-dev patchelf
           # Increment to invalidate the cache

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -158,7 +158,7 @@ jobs:
           path: server/desktop/build/libs/
 
       - name: Set up Linux dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: |
             build-essential curl wget file libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev


### PR DESCRIPTION
From what I see https://github.com/awalsh128/cache-apt-pkgs-action doesn't have up-to-date tags on `latest` and `v1` so we have to manually push it ourselves

https://github.com/awalsh128/cache-apt-pkgs-action/issues/145