### PR TITLE
[Stay Aligned] Add small yaw rotations to keep trackers aligned

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -185,6 +185,7 @@ widget-imu_visualizer-rotation_raw = Raw rotation
 widget-imu_visualizer-rotation_preview = Preview rotation
 widget-imu_visualizer-acceleration = Acceleration
 widget-imu_visualizer-position = Position
+widget-imu_visualizer-stay_aligned = Stay Aligned
 
 ## Widget: Skeleton Visualizer
 widget-skeleton_visualizer-preview = Skeleton preview
@@ -209,6 +210,7 @@ tracker-table-column-temperature = Temp. °C
 tracker-table-column-linear-acceleration = Accel. X/Y/Z
 tracker-table-column-rotation = Rotation X/Y/Z
 tracker-table-column-position = Position X/Y/Z
+tracker-table-column-stay_aligned = Stay Aligned
 tracker-table-column-url = URL
 
 ## Tracker rotation
@@ -338,6 +340,7 @@ mounting_selection_menu-close = Close
 settings-sidebar-title = Settings
 settings-sidebar-general = General
 settings-sidebar-tracker_mechanics = Tracker mechanics
+settings-sidebar-stay_aligned = Stay Aligned
 settings-sidebar-fk_settings = Tracking settings
 settings-sidebar-gesture_control = Gesture control
 settings-sidebar-interface = Interface
@@ -427,6 +430,23 @@ settings-general-tracker_mechanics-use_mag_on_all_trackers-description =
     Uses magnetometer on all trackers that have a compatible firmware for it, reducing drift in stable magnetic environments.
     Can be disabled per tracker in the tracker's settings. <b>Please don't shutdown any of the trackers while toggling this!</b>
 settings-general-tracker_mechanics-use_mag_on_all_trackers-label = Use magnetometer on trackers
+
+settings-general-stay_aligned = Stay Aligned
+settings-general-stay_aligned-description = Keeps your trackers aligned by slowly adjusting the yaw of your trackers.
+settings-general-stay_aligned-warnings-drift_compensation = ⚠ Please disable "Drift Compensation". Stay Aligned and Drift Compensation try to solve the same problem and only one should be enabled.
+settings-general-stay_aligned-enabled-label = Enabled
+settings-general-stay_aligned-amount-label = Maximum yaw adjustment rate
+settings-general-stay_aligned-amount-description = Pick a rate depending on how good your IMU is: 0.1 deg/s for ICM45686, LSM6DSV or BNO085; 0.2 deg/s for LSM6DSR or BMI270; and 0.4 deg/s for BMI160.
+settings-general-stay_aligned-relaxed_body_angles-label = Relaxed Body Angles
+settings-general-stay_aligned-relaxed_body_angles-description = Stay Aligned needs to know your pose when you are relaxed. These angles describe how much you twist your legs and feet outwards. Do a yaw reset, then stand in a relaxed position, and press "Auto detect angles". Repeat while relaxing in a chair, and lying on your back.
+settings-general-stay_aligned-relaxed_body_angles-standing-label = Standing
+settings-general-stay_aligned-relaxed_body_angles-sitting-label = Sitting in chair
+settings-general-stay_aligned-relaxed_body_angles-lying_on_back-label = Lying on back
+settings-general-stay_aligned-relaxed_body_angles-upper_leg_angle = Upper leg
+settings-general-stay_aligned-relaxed_body_angles-lower_leg_angle = Lower leg
+settings-general-stay_aligned-relaxed_body_angles-foot_angle = Foot
+settings-general-stay_aligned-relaxed_body_angles-auto_detect = Auto detect angles
+settings-general-stay_aligned-relaxed_body_angles-reset = Reset angles
 
 ## FK/Tracking settings
 settings-general-fk_settings = Tracking settings

--- a/gui/src/components/settings/SettingsSidebar.tsx
+++ b/gui/src/components/settings/SettingsSidebar.tsx
@@ -58,6 +58,9 @@ export function SettingsSidebar() {
           <SettingsLink to="/settings/trackers" scrollTo="mechanics">
             {l10n.getString('settings-sidebar-tracker_mechanics')}
           </SettingsLink>
+          <SettingsLink to="/settings/trackers" scrollTo="stayaligned">
+            {l10n.getString('settings-general-stay_aligned')}
+          </SettingsLink>
           <SettingsLink to="/settings/trackers" scrollTo="fksettings">
             {l10n.getString('settings-sidebar-fk_settings')}
           </SettingsLink>

--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -16,6 +16,7 @@ import {
   SettingsResponseT,
   SteamVRTrackersSettingT,
   TapDetectionSettingsT,
+  YawCorrectionSettingsT,
 } from 'solarxr-protocol';
 import { useConfig } from '@/hooks/config';
 import { useWebsocketAPI } from '@/hooks/websocket-api';
@@ -33,8 +34,9 @@ import {
 import { HandsWarningModal } from '@/components/settings/HandsWarningModal';
 import { MagnetometerToggleSetting } from './MagnetometerToggleSetting';
 import { DriftCompensationModal } from '@/components/settings/DriftCompensationModal';
+import { StayAlignedSettings } from './components/StayAlignedSettings';
 
-interface SettingsForm {
+export interface SettingsForm {
   trackers: {
     waist: boolean;
     chest: boolean;
@@ -104,6 +106,19 @@ interface SettingsForm {
     saveMountingReset: boolean;
     resetHmdPitch: boolean;
   };
+  yawCorrectionSettings: {
+    enabled: boolean;
+    amountInDegPerSec: number;
+    standingUpperLegAngle: number;
+    standingLowerLegAngle: number;
+    standingFootAngle: number;
+    sittingUpperLegAngle: number;
+    sittingLowerLegAngle: number;
+    sittingFootAngle: number;
+    lyingOnBackUpperLegAngle: number;
+    lyingOnBackLowerLegAngle: number;
+    hideYawCorrection: boolean;
+  };
 }
 
 const defaultValues: SettingsForm = {
@@ -170,6 +185,19 @@ const defaultValues: SettingsForm = {
     yawResetSmoothTime: 0.0,
     saveMountingReset: false,
     resetHmdPitch: false,
+  },
+  yawCorrectionSettings: {
+    enabled: true,
+    amountInDegPerSec: 0.2,
+    standingUpperLegAngle: 0.0,
+    standingLowerLegAngle: 0.0,
+    standingFootAngle: 0.0,
+    sittingUpperLegAngle: 0.0,
+    sittingLowerLegAngle: 0.0,
+    sittingFootAngle: 0.0,
+    lyingOnBackUpperLegAngle: 0.0,
+    lyingOnBackLowerLegAngle: 0.0,
+    hideYawCorrection: false,
   },
 };
 
@@ -300,6 +328,30 @@ export function GeneralSettings() {
     driftCompensation.maxResets = values.driftCompensation.maxResets;
     settings.driftCompensation = driftCompensation;
 
+    const yawCorrectionSettings = new YawCorrectionSettingsT();
+    yawCorrectionSettings.enabled = values.yawCorrectionSettings.enabled;
+    yawCorrectionSettings.amountInDegPerSec =
+      values.yawCorrectionSettings.amountInDegPerSec;
+    yawCorrectionSettings.standingUpperLegAngle =
+      values.yawCorrectionSettings.standingUpperLegAngle;
+    yawCorrectionSettings.standingLowerLegAngle =
+      values.yawCorrectionSettings.standingLowerLegAngle;
+    yawCorrectionSettings.standingFootAngle =
+      values.yawCorrectionSettings.standingFootAngle;
+    yawCorrectionSettings.sittingUpperLegAngle =
+      values.yawCorrectionSettings.sittingUpperLegAngle;
+    yawCorrectionSettings.sittingLowerLegAngle =
+      values.yawCorrectionSettings.sittingLowerLegAngle;
+    yawCorrectionSettings.sittingFootAngle =
+      values.yawCorrectionSettings.sittingFootAngle;
+    yawCorrectionSettings.lyingOnBackUpperLegAngle =
+      values.yawCorrectionSettings.lyingOnBackUpperLegAngle;
+    yawCorrectionSettings.lyingOnBackLowerLegAngle =
+      values.yawCorrectionSettings.lyingOnBackLowerLegAngle;
+    yawCorrectionSettings.hideYawCorrection =
+      values.yawCorrectionSettings.hideYawCorrection;
+    settings.yawCorrectionSettings = yawCorrectionSettings;
+
     if (values.resetsSettings) {
       const resetsSettings = new ResetsSettingsT();
       resetsSettings.resetMountingFeet =
@@ -421,6 +473,10 @@ export function GeneralSettings() {
 
     if (settings.resetsSettings) {
       formData.resetsSettings = settings.resetsSettings;
+    }
+
+    if (settings.yawCorrectionSettings) {
+      formData.yawCorrectionSettings = settings.yawCorrectionSettings;
     }
 
     reset({ ...getValues(), ...formData });
@@ -824,6 +880,11 @@ export function GeneralSettings() {
             />
           </>
         </SettingsPagePaneLayout>
+        <StayAlignedSettings
+          getValues={getValues}
+          setValue={setValue}
+          control={control}
+        />
         <SettingsPagePaneLayout
           icon={<WrenchIcon></WrenchIcon>}
           id="fksettings"

--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -117,7 +117,6 @@ export interface SettingsForm {
     sittingFootAngle: number;
     lyingOnBackUpperLegAngle: number;
     lyingOnBackLowerLegAngle: number;
-    hideYawCorrection: boolean;
   };
 }
 
@@ -197,7 +196,6 @@ const defaultValues: SettingsForm = {
     sittingFootAngle: 0.0,
     lyingOnBackUpperLegAngle: 0.0,
     lyingOnBackLowerLegAngle: 0.0,
-    hideYawCorrection: false,
   },
 };
 
@@ -348,8 +346,6 @@ export function GeneralSettings() {
       values.yawCorrectionSettings.lyingOnBackUpperLegAngle;
     yawCorrectionSettings.lyingOnBackLowerLegAngle =
       values.yawCorrectionSettings.lyingOnBackLowerLegAngle;
-    yawCorrectionSettings.hideYawCorrection =
-      values.yawCorrectionSettings.hideYawCorrection;
     settings.yawCorrectionSettings = yawCorrectionSettings;
 
     if (values.resetsSettings) {

--- a/gui/src/components/settings/pages/components/StayAlignedSettings.tsx
+++ b/gui/src/components/settings/pages/components/StayAlignedSettings.tsx
@@ -1,0 +1,381 @@
+import { FlatDeviceTracker } from '@/hooks/app';
+import { normalizeAngleAroundZero, RAD_TO_DEG } from '@/maths/angle';
+import { QuaternionFromQuatT } from '@/maths/quaternion';
+import { Control, FieldPath, UseFormSetValue } from 'react-hook-form';
+import { BodyPart } from 'solarxr-protocol';
+import { SettingsForm } from '@/components/settings/pages/GeneralSettings';
+import { Button } from '@/components/commons/Button';
+import { CheckBox } from '@/components/commons/Checkbox';
+import { WrenchIcon } from '@/components/commons/icon/WrenchIcons';
+import { NumberSelector } from '@/components/commons/NumberSelector';
+import { Typography } from '@/components/commons/Typography';
+import { SettingsPagePaneLayout } from '@/components/settings/SettingsPageLayout';
+import { useLocalization } from '@fluent/react';
+import { useTrackers } from '@/hooks/tracker';
+import { useLocaleConfig } from '@/i18n/config';
+import { Euler } from 'three';
+
+export function StayAlignedSettings({
+  getValues,
+  setValue,
+  control,
+}: {
+  getValues: () => SettingsForm;
+  setValue: UseFormSetValue<SettingsForm>;
+  control: Control<SettingsForm, any>;
+}) {
+  const { l10n } = useLocalization();
+  const { currentLocales } = useLocaleConfig();
+  const degreePerSecFormat = new Intl.NumberFormat(currentLocales, {
+    style: 'unit',
+    unit: 'degree-per-second',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const degreeFormat = new Intl.NumberFormat(currentLocales, {
+    style: 'unit',
+    unit: 'degree',
+    maximumFractionDigits: 0,
+  });
+
+  const { useConnectedIMUTrackers } = useTrackers();
+  const trackers = useConnectedIMUTrackers();
+
+  const values = getValues();
+
+  const yawBetweenInDeg = (
+    leftTracker: FlatDeviceTracker,
+    rightTracker: FlatDeviceTracker
+  ) => {
+    const leftTrackerYaw = new Euler().setFromQuaternion(
+      QuaternionFromQuatT(leftTracker.tracker.rotationReferenceAdjusted),
+      'YZX'
+    ).y;
+    const rightTrackerYaw = new Euler().setFromQuaternion(
+      QuaternionFromQuatT(rightTracker.tracker.rotationReferenceAdjusted),
+      'YZX'
+    ).y;
+    const yawDelta = normalizeAngleAroundZero(leftTrackerYaw - rightTrackerYaw);
+    return yawDelta * RAD_TO_DEG;
+  };
+
+  function findTracker(bodyPart: BodyPart): FlatDeviceTracker | undefined {
+    return trackers.find((t) => t.tracker.info?.bodyPart === bodyPart);
+  }
+
+  const detectAngles = (
+    upperLegKey: FieldPath<SettingsForm>,
+    lowerLegKey: FieldPath<SettingsForm>,
+    footKey?: FieldPath<SettingsForm>
+  ) => {
+    const leftUpperLegTracker = findTracker(BodyPart.LEFT_UPPER_LEG);
+    const rightUpperLegTracker = findTracker(BodyPart.RIGHT_UPPER_LEG);
+    if (leftUpperLegTracker && rightUpperLegTracker) {
+      const upperLegToBodyAngleInDeg =
+        yawBetweenInDeg(leftUpperLegTracker, rightUpperLegTracker) / 2.0;
+      setValue(upperLegKey, Math.round(upperLegToBodyAngleInDeg));
+    }
+
+    const leftLowerLegTracker = findTracker(BodyPart.LEFT_LOWER_LEG);
+    const rightLowerLegTracker = findTracker(BodyPart.RIGHT_LOWER_LEG);
+    if (leftLowerLegTracker && rightLowerLegTracker) {
+      const footToBodyAngleInDeg =
+        yawBetweenInDeg(leftLowerLegTracker, rightLowerLegTracker) / 2.0;
+      setValue(lowerLegKey, Math.round(footToBodyAngleInDeg));
+    }
+
+    if (footKey) {
+      const leftFootTracker = findTracker(BodyPart.LEFT_FOOT);
+      const rightFootTracker = findTracker(BodyPart.RIGHT_FOOT);
+      if (leftFootTracker && rightFootTracker) {
+        const footToBodyAngleInDeg =
+          yawBetweenInDeg(leftFootTracker, rightFootTracker) / 2.0;
+        setValue(footKey, Math.round(footToBodyAngleInDeg));
+      }
+    }
+  };
+
+  const resetAngles = (
+    upperLegKey: FieldPath<SettingsForm>,
+    lowerLegKey: FieldPath<SettingsForm>,
+    footKey?: FieldPath<SettingsForm>
+  ) => {
+    setValue(upperLegKey, 0.0);
+    setValue(lowerLegKey, 0.0);
+    if (footKey) {
+      setValue(footKey, 0.0);
+    }
+  };
+
+  return (
+    <SettingsPagePaneLayout icon={<WrenchIcon />} id="stayaligned">
+      <Typography variant="main-title">
+        {l10n.getString('settings-general-stay_aligned')}
+      </Typography>
+      <div className="flex flex-col pt-2 pb-4">
+        {l10n
+          .getString('settings-general-stay_aligned-description')
+          .split('\n')
+          .map((line, i) => (
+            <Typography color="secondary" key={i}>
+              {line}
+            </Typography>
+          ))}
+        {values.yawCorrectionSettings.enabled && (
+          <>
+            {!!values.driftCompensation.enabled && (
+              <div className="pt-2">
+                {l10n.getString(
+                  'settings-general-stay_aligned-warnings-drift_compensation'
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      <div className="grid sm:grid-cols-1 gap-3 pb-4">
+        <CheckBox
+          variant="toggle"
+          outlined
+          control={control}
+          name="yawCorrectionSettings.enabled"
+          label={l10n.getString('settings-general-stay_aligned-enabled-label')}
+        />
+        <div className="flex flex-col pt-2 pb-4">
+          <Typography bold>
+            {l10n.getString('settings-general-stay_aligned-amount-label')}
+          </Typography>
+          <Typography color="secondary">
+            {l10n.getString('settings-general-stay_aligned-amount-description')}
+          </Typography>
+          <NumberSelector
+            control={control}
+            name="yawCorrectionSettings.amountInDegPerSec"
+            valueLabelFormat={(value) => degreePerSecFormat.format(value)}
+            min={0.02}
+            max={2.0}
+            step={0.02}
+          />
+        </div>
+        <div className="flex flex-col pt-2">
+          <Typography bold>
+            {l10n.getString(
+              'settings-general-stay_aligned-relaxed_body_angles-label'
+            )}
+          </Typography>
+          <Typography color="secondary">
+            {l10n.getString(
+              'settings-general-stay_aligned-relaxed_body_angles-description'
+            )}
+          </Typography>
+        </div>
+        <div>
+          <Typography color="secondary">
+            {l10n.getString(
+              'settings-general-stay_aligned-relaxed_body_angles-standing-label'
+            )}
+          </Typography>
+          <div className="grid sm:grid-cols-5 gap-3 pb-3">
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.standingUpperLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-upper_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.standingLowerLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-lower_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.standingFootAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-foot_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <Button
+              variant="primary"
+              onClick={() =>
+                detectAngles(
+                  'yawCorrectionSettings.standingUpperLegAngle',
+                  'yawCorrectionSettings.standingLowerLegAngle',
+                  'yawCorrectionSettings.standingFootAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-auto_detect'
+              )}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() =>
+                resetAngles(
+                  'yawCorrectionSettings.standingUpperLegAngle',
+                  'yawCorrectionSettings.standingLowerLegAngle',
+                  'yawCorrectionSettings.standingFootAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-reset'
+              )}
+            </Button>
+          </div>
+        </div>
+        <div>
+          <Typography color="secondary">
+            {l10n.getString(
+              'settings-general-stay_aligned-relaxed_body_angles-sitting-label'
+            )}
+          </Typography>
+          <div className="grid sm:grid-cols-5 gap-3 pb-3">
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.sittingUpperLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-upper_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.sittingLowerLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-lower_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.sittingFootAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-foot_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <Button
+              variant="primary"
+              onClick={() =>
+                detectAngles(
+                  'yawCorrectionSettings.sittingUpperLegAngle',
+                  'yawCorrectionSettings.sittingLowerLegAngle',
+                  'yawCorrectionSettings.sittingFootAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-auto_detect'
+              )}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() =>
+                resetAngles(
+                  'yawCorrectionSettings.sittingUpperLegAngle',
+                  'yawCorrectionSettings.sittingLowerLegAngle',
+                  'yawCorrectionSettings.sittingFootAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-reset'
+              )}
+            </Button>
+          </div>
+        </div>
+        <div>
+          <Typography color="secondary">
+            {l10n.getString(
+              'settings-general-stay_aligned-relaxed_body_angles-lying_on_back-label'
+            )}
+          </Typography>
+          <div className="grid sm:grid-cols-5 gap-3 pb-3">
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.lyingOnBackUpperLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-upper_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <NumberSelector
+              control={control}
+              name="yawCorrectionSettings.lyingOnBackLowerLegAngle"
+              valueLabelFormat={(value) =>
+                `${l10n.getString(
+                  'settings-general-stay_aligned-relaxed_body_angles-lower_leg_angle'
+                )}: ${degreeFormat.format(value)}`
+              }
+              min={-90.0}
+              max={90.0}
+              step={1.0}
+            />
+            <div></div>
+            <Button
+              variant="primary"
+              onClick={() =>
+                detectAngles(
+                  'yawCorrectionSettings.lyingOnBackUpperLegAngle',
+                  'yawCorrectionSettings.lyingOnBackLowerLegAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-auto_detect'
+              )}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() =>
+                resetAngles(
+                  'yawCorrectionSettings.lyingOnBackUpperLegAngle',
+                  'yawCorrectionSettings.lyingOnBackLowerLegAngle'
+                )
+              }
+            >
+              {l10n.getString(
+                'settings-general-stay_aligned-relaxed_body_angles-reset'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </SettingsPagePaneLayout>
+  );
+}

--- a/gui/src/components/tracker/StayAlignedInfo.tsx
+++ b/gui/src/components/tracker/StayAlignedInfo.tsx
@@ -1,0 +1,50 @@
+import { Typography } from '@/components/commons/Typography';
+import { useLocaleConfig } from '@/i18n/config';
+import { angleIsNearZero } from '@/maths/angle';
+import { TrackerDataT } from 'solarxr-protocol';
+
+export function StayAlignedInfo({
+  color,
+  tracker,
+}: {
+  color: 'primary' | 'secondary';
+  tracker: TrackerDataT;
+}) {
+  const { currentLocales } = useLocaleConfig();
+  const degreeFormat = new Intl.NumberFormat(currentLocales, {
+    style: 'unit',
+    unit: 'degree',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+  const errorFormat = new Intl.NumberFormat(currentLocales, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+
+  const locked = tracker.stayAlignedLocked ? '🔒' : '';
+
+  const delta = `Δ=${degreeFormat.format(tracker.stayAlignedYawCorrectionInDeg)}`;
+
+  const errors = [];
+  const maxErrorToShow = 0.1;
+  if (!angleIsNearZero(tracker.stayAlignedLockedErrorInDeg, maxErrorToShow)) {
+    errors.push(`L=${errorFormat.format(tracker.stayAlignedLockedErrorInDeg)}`);
+  }
+  if (!angleIsNearZero(tracker.stayAlignedCenterErrorInDeg, maxErrorToShow)) {
+    errors.push(`C=${errorFormat.format(tracker.stayAlignedCenterErrorInDeg)}`);
+  }
+  if (!angleIsNearZero(tracker.stayAlignedNeighborErrorInDeg, maxErrorToShow)) {
+    errors.push(
+      `N=${errorFormat.format(tracker.stayAlignedNeighborErrorInDeg)}`
+    );
+  }
+
+  const error = errors.length > 0 ? `(${errors.join(', ')})` : '';
+
+  return (
+    <Typography color={color} whitespace="whitespace-nowrap">
+      {locked} {delta} {error}
+    </Typography>
+  );
+}

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -17,6 +17,7 @@ import { TrackerBattery } from './TrackerBattery';
 import { TrackerStatus } from './TrackerStatus';
 import { TrackerWifi } from './TrackerWifi';
 import { trackerStatusRelated, useStatusContext } from '@/hooks/status-system';
+import { StayAlignedInfo } from './StayAlignedInfo';
 
 enum DisplayColumn {
   NAME,
@@ -28,6 +29,7 @@ enum DisplayColumn {
   TEMPERATURE,
   LINEAR_ACCELERATION,
   POSITION,
+  STAY_ALIGNED,
   URL,
 }
 
@@ -41,6 +43,7 @@ const displayColumns: { [k: string]: boolean } = {
   [DisplayColumn.TEMPERATURE]: true,
   [DisplayColumn.LINEAR_ACCELERATION]: true,
   [DisplayColumn.POSITION]: true,
+  [DisplayColumn.STAY_ALIGNED]: true,
   [DisplayColumn.URL]: true,
 };
 
@@ -196,6 +199,7 @@ export function TrackersTable({
   displayColumns[DisplayColumn.TEMPERATURE] = hasTemperature || false;
   displayColumns[DisplayColumn.POSITION] = moreInfo || false;
   displayColumns[DisplayColumn.LINEAR_ACCELERATION] = moreInfo || false;
+  displayColumns[DisplayColumn.STAY_ALIGNED] = moreInfo || false;
   displayColumns[DisplayColumn.URL] = moreInfo || false;
   const displayColumnsKeys = Object.keys(displayColumns).filter(
     (k) => displayColumns[k]
@@ -360,6 +364,15 @@ export function TrackersTable({
               {formatVector3(tracker.position, 2)}
             </Typography>
           ),
+      })}
+
+      {column({
+        id: DisplayColumn.STAY_ALIGNED,
+        label: l10n.getString('tracker-table-column-stay_aligned'),
+        labelClassName: 'w-36',
+        row: ({ tracker }) => (
+          <StayAlignedInfo color={fontColor} tracker={tracker} />
+        ),
       })}
 
       {column({

--- a/gui/src/components/widgets/IMUVisualizerWidget.tsx
+++ b/gui/src/components/widgets/IMUVisualizerWidget.tsx
@@ -12,6 +12,7 @@ import { useLocalization } from '@fluent/react';
 import { Vector3Object } from '@/maths/vector3';
 import { Gltf } from '@react-three/drei';
 import { ErrorBoundary } from 'react-error-boundary';
+import { StayAlignedInfo } from '@/components/tracker/StayAlignedInfo';
 
 const groundColor = '#4444aa';
 
@@ -154,6 +155,15 @@ export function IMUVisualizerWidget({ tracker }: { tracker: TrackerDataT }) {
           <Typography>
             {formatVector3(tracker.linearAcceleration, 1)}
           </Typography>
+        </div>
+      )}
+
+      {!!tracker.stayAlignedYawCorrectionInDeg && (
+        <div className="flex justify-between">
+          <Typography color="secondary">
+            {l10n.getString('widget-imu_visualizer-stay_aligned')}
+          </Typography>
+          <StayAlignedInfo color="primary" tracker={tracker} />
         </div>
       )}
 

--- a/gui/src/hooks/datafeed-config.ts
+++ b/gui/src/hooks/datafeed-config.ts
@@ -17,6 +17,7 @@ export function useDataFeedConfig() {
   trackerData.rotationReferenceAdjusted = true;
   trackerData.rotationIdentityAdjusted = true;
   trackerData.tps = true;
+  trackerData.stayAligned = true;
 
   const dataMask = new DeviceDataMaskT();
   dataMask.deviceData = true;

--- a/gui/src/maths/angle.ts
+++ b/gui/src/maths/angle.ts
@@ -1,3 +1,24 @@
 export const DEG_TO_RAD = Math.PI / 180.0;
 
 export const RAD_TO_DEG = 180.0 / Math.PI;
+
+export const TWO_PI = 2.0 * Math.PI;
+
+export function normalizeAngle(angle: number): number {
+  if (angle < 0.0 || angle >= TWO_PI) {
+    angle -= Math.floor(angle / TWO_PI) * TWO_PI;
+  }
+  return angle;
+}
+
+export function normalizeAngleAroundZero(angle: number): number {
+  angle = normalizeAngle(angle);
+  if (angle > Math.PI) {
+    angle -= TWO_PI;
+  }
+  return angle;
+}
+
+export function angleIsNearZero(angle: number, maxError?: number): boolean {
+  return Math.abs(angle) < (maxError || 1e-6);
+}

--- a/server/core/src/main/java/dev/slimevr/config/StayAlignedConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/StayAlignedConfig.kt
@@ -8,7 +8,7 @@ import dev.slimevr.math.Angle
 class StayAlignedConfig {
 
 	// Apply yaw correction
-	var enabled = true
+	var enabled = false
 
 	// Amount of yaw correction
 	@JsonSerialize(using = AngleInDegConversions.Serializer::class)

--- a/server/core/src/main/java/dev/slimevr/config/StayAlignedConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/StayAlignedConfig.kt
@@ -1,0 +1,49 @@
+package dev.slimevr.config
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import dev.slimevr.config.serializers.AngleInDegConversions
+import dev.slimevr.math.Angle
+
+class StayAlignedConfig {
+
+	// Apply yaw correction
+	var enabled = true
+
+	// Amount of yaw correction
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var yawCorrectionPerSec = Angle.ofDeg(0.2f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var standingUpperLegAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var standingLowerLegAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var standingFootAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var sittingUpperLegAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var sittingLowerLegAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var sittingFootAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var lyingOnBackUpperLegAngle = Angle.ofDeg(0.0f)
+
+	@JsonSerialize(using = AngleInDegConversions.Serializer::class)
+	@JsonDeserialize(using = AngleInDegConversions.Deserializer::class)
+	var lyingOnBackLowerLegAngle = Angle.ofDeg(0.0f)
+}

--- a/server/core/src/main/java/dev/slimevr/config/VRConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/VRConfig.kt
@@ -40,6 +40,8 @@ class VRConfig {
 
 	val resetsConfig: ResetsConfig = ResetsConfig()
 
+	val stayAlignedConfig = StayAlignedConfig()
+
 	@JsonDeserialize(using = TrackerConfigMapDeserializer::class)
 	@JsonSerialize(keyUsing = StdKeySerializers.StringKeySerializer::class)
 	private val trackers: MutableMap<String, TrackerConfig> = HashMap()

--- a/server/core/src/main/java/dev/slimevr/config/serializers/AngleInDegConversions.kt
+++ b/server/core/src/main/java/dev/slimevr/config/serializers/AngleInDegConversions.kt
@@ -1,0 +1,27 @@
+package dev.slimevr.config.serializers
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import dev.slimevr.math.Angle
+
+object AngleInDegConversions {
+
+	object Serializer : JsonSerializer<Angle>() {
+		override fun serialize(
+			value: Angle,
+			generator: JsonGenerator,
+			serializer: SerializerProvider,
+		) {
+			generator.writeNumber(value.toDeg())
+		}
+	}
+
+	object Deserializer : JsonDeserializer<Angle>() {
+		override fun deserialize(parser: JsonParser, context: DeserializationContext): Angle =
+			Angle.ofDeg(parser.numberValue.toFloat())
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/math/Angle.kt
+++ b/server/core/src/main/java/dev/slimevr/math/Angle.kt
@@ -1,0 +1,92 @@
+package dev.slimevr.math
+
+import com.jme3.math.FastMath
+import io.github.axisangles.ktmath.Quaternion
+import io.github.axisangles.ktmath.Vector3
+import kotlin.math.*
+
+class Angle {
+
+	private val rad: Float
+	private val deg: Float?
+
+	private constructor() {
+		rad = 0.0f
+		deg = null
+	}
+
+	private constructor(rad: Float) {
+		this.rad = rad
+		this.deg = null
+	}
+
+	/**
+	 * Constructor that preserves the degrees, so that we don't have angles like
+	 * 0.999999 deg.
+	 */
+	private constructor(rad: Float, deg: Float) {
+		this.rad = rad
+		this.deg = deg
+	}
+
+	fun toRad() = rad
+	fun toDeg() = deg ?: (rad * FastMath.RAD_TO_DEG)
+
+	/**
+	 * Normalizes the angle to between [0, 2*PI)
+	 */
+	fun normalized() =
+		if (rad < 0.0f || rad >= FastMath.TWO_PI) {
+			Angle(rad - floor(rad * FastMath.INV_TWO_PI) * FastMath.TWO_PI)
+		} else {
+			this
+		}
+
+	/**
+	 * Normalizes the angle to between [-PI, PI)
+	 */
+	fun normalizedAroundZero() =
+		normalized().let {
+			if (it.rad > FastMath.PI) {
+				Angle(it.rad - FastMath.TWO_PI)
+			} else {
+				it
+			}
+		}
+
+	fun nearZero(error: Angle = DEFAULT_NEAR_ANGLE) =
+		abs(this) < error
+
+	operator fun unaryPlus() = Angle(rad)
+	operator fun unaryMinus() = Angle(-rad)
+	operator fun plus(other: Angle) = Angle(rad + other.rad)
+	operator fun minus(other: Angle) = Angle(rad - other.rad)
+	operator fun times(scale: Float) = Angle(rad * scale)
+	operator fun div(scale: Float) = Angle(rad / scale)
+
+	operator fun compareTo(other: Angle): Int = rad.compareTo(other.rad)
+	override fun toString(): String = "${toDeg()} deg"
+
+	companion object {
+		val ZERO = Angle()
+
+		fun ofRad(rad: Float) = Angle(rad)
+		fun ofDeg(deg: Float) = Angle(deg * FastMath.DEG_TO_RAD, deg)
+
+		fun abs(angle: Angle) = ofRad(abs(angle.rad))
+
+		// Signed angle between two angles
+		fun signedBetween(a: Angle, b: Angle) =
+			ofRad(a.rad - b.rad).normalizedAroundZero()
+
+		// Angle between two vectors
+		fun absBetween(a: Vector3, b: Vector3) =
+			ofRad(a.angleTo(b))
+
+		// Angle between two rotations in rotation space
+		fun absBetween(a: Quaternion, b: Quaternion) =
+			ofRad(a.angleToR(b))
+
+		private val DEFAULT_NEAR_ANGLE = ofRad(1e-6f)
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/math/AngleAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/math/AngleAverage.kt
@@ -1,0 +1,22 @@
+package dev.slimevr.math
+
+import kotlin.math.*
+
+/**
+ * Averages angles by summing vectors.
+ *
+ * See https://www.themathdoctors.org/averaging-angles/
+ */
+class AngleAverage {
+
+	private var sumX = 0.0f
+	private var sumY = 0.0f
+
+	fun add(angle: Angle, weight: Float = 1.0f) {
+		sumX += cos(angle.toRad()) * weight
+		sumY += sin(angle.toRad()) * weight
+	}
+
+	fun toAngle(): Angle =
+		Angle.ofRad(atan2(sumY, sumX))
+}

--- a/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -2,6 +2,7 @@ package dev.slimevr.protocol.datafeed;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 import dev.slimevr.tracking.trackers.Device;
+import dev.slimevr.tracking.processor.stayaligned.state.StayAlignedTrackerState;
 import dev.slimevr.tracking.trackers.Tracker;
 import dev.slimevr.tracking.trackers.udp.UDPDevice;
 import io.github.axisangles.ktmath.Quaternion;
@@ -232,6 +233,34 @@ public class DataFeedBuilder {
 		}
 		if (mask.getTps()) {
 			TrackerData.addTps(fbb, (int) tracker.getTps());
+		}
+		if (mask.getStayAligned()) {
+			StayAlignedTrackerState state = tracker.getStayAligned();
+			TrackerData
+				.addStayAlignedYawCorrectionInDeg(
+					fbb,
+					state.getYawCorrection().getYaw().toDeg()
+				);
+			TrackerData
+				.addStayAlignedLockedErrorInDeg(
+					fbb,
+					state.getYawErrors().getLockedError().toDeg()
+				);
+			TrackerData
+				.addStayAlignedCenterErrorInDeg(
+					fbb,
+					state.getYawErrors().getCenterError().toDeg()
+				);
+			TrackerData
+				.addStayAlignedNeighborErrorInDeg(
+					fbb,
+					state.getYawErrors().getNeighborError().toDeg()
+				);
+			TrackerData
+				.addStayAlignedLocked(
+					fbb,
+					state.getLockedRotation() != null
+				);
 		}
 
 		return TrackerData.endTrackerData(fbb);

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
@@ -354,6 +354,26 @@ public class RPCSettingsBuilder {
 			);
 	}
 
+	public static int createYawCorrectionSettings(
+		FlatBufferBuilder fbb,
+		StayAlignedConfig config
+	) {
+		return YawCorrectionSettings
+			.createYawCorrectionSettings(
+				fbb,
+				config.getEnabled(),
+				config.getYawCorrectionPerSec().toDeg(),
+				config.getStandingUpperLegAngle().toDeg(),
+				config.getStandingLowerLegAngle().toDeg(),
+				config.getStandingFootAngle().toDeg(),
+				config.getSittingUpperLegAngle().toDeg(),
+				config.getSittingLowerLegAngle().toDeg(),
+				config.getSittingFootAngle().toDeg(),
+				config.getLyingOnBackUpperLegAngle().toDeg(),
+				config.getLyingOnBackLowerLegAngle().toDeg()
+			);
+	}
+
 	public static int createSettingsResponse(FlatBufferBuilder fbb, VRServer server) {
 		ISteamVRBridge bridge = server.getVRBridge(ISteamVRBridge.class);
 
@@ -408,7 +428,11 @@ public class RPCSettingsBuilder {
 						fbb,
 						server.configManager.getVrConfig().getResetsConfig()
 					),
-				0
+				RPCSettingsBuilder
+					.createYawCorrectionSettings(
+						fbb,
+						server.configManager.getVrConfig().getStayAlignedConfig()
+					)
 			);
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
@@ -4,6 +4,7 @@ import com.google.flatbuffers.FlatBufferBuilder
 import dev.slimevr.bridge.ISteamVRBridge
 import dev.slimevr.config.ArmsResetModes
 import dev.slimevr.filtering.TrackerFilters
+import dev.slimevr.math.Angle
 import dev.slimevr.protocol.GenericConnection
 import dev.slimevr.protocol.ProtocolAPI
 import dev.slimevr.protocol.rpc.RPCHandler
@@ -352,6 +353,21 @@ class RPCSettingsHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) {
 			resetsConfig.yawResetSmoothTime = req.resetsSettings().yawResetSmoothTime()
 			resetsConfig.resetHmdPitch = req.resetsSettings().resetHmdPitch()
 			resetsConfig.updateTrackersResetsSettings()
+		}
+
+		if (req.yawCorrectionSettings() != null) {
+			val config = api.server.configManager.vrConfig.stayAlignedConfig
+			config.enabled = req.yawCorrectionSettings().enabled()
+			config.yawCorrectionPerSec = Angle.ofDeg(req.yawCorrectionSettings().amountInDegPerSec())
+			config.standingUpperLegAngle = Angle.ofDeg(req.yawCorrectionSettings().standingUpperLegAngle())
+			config.standingLowerLegAngle = Angle.ofDeg(req.yawCorrectionSettings().standingLowerLegAngle())
+			config.standingFootAngle = Angle.ofDeg(req.yawCorrectionSettings().standingFootAngle())
+			config.sittingUpperLegAngle = Angle.ofDeg(req.yawCorrectionSettings().sittingUpperLegAngle())
+			config.sittingLowerLegAngle = Angle.ofDeg(req.yawCorrectionSettings().sittingLowerLegAngle())
+			config.sittingFootAngle = Angle.ofDeg(req.yawCorrectionSettings().sittingFootAngle())
+			config.lyingOnBackUpperLegAngle = Angle.ofDeg(req.yawCorrectionSettings().lyingOnBackUpperLegAngle())
+			config.lyingOnBackLowerLegAngle = Angle.ofDeg(req.yawCorrectionSettings().lyingOnBackLowerLegAngle())
+			api.server.humanPoseManager.setStayAlignedConfig(config)
 		}
 
 		api.server.configManager.saveConfig()

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -2,6 +2,7 @@ package dev.slimevr.tracking.processor.skeleton
 
 import com.jme3.math.FastMath
 import dev.slimevr.VRServer
+import dev.slimevr.config.StayAlignedConfig
 import dev.slimevr.tracking.processor.Bone
 import dev.slimevr.tracking.processor.BoneType
 import dev.slimevr.tracking.processor.Constraint
@@ -9,6 +10,8 @@ import dev.slimevr.tracking.processor.Constraint.Companion.ConstraintType
 import dev.slimevr.tracking.processor.HumanPoseManager
 import dev.slimevr.tracking.processor.config.SkeletonConfigToggles
 import dev.slimevr.tracking.processor.config.SkeletonConfigValues
+import dev.slimevr.tracking.processor.stayaligned.StayAligned
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
 import dev.slimevr.tracking.trackers.TrackerRole
@@ -214,6 +217,8 @@ class HumanSkeleton(
 	var tapDetectionManager = TapDetectionManager(this)
 	var viveEmulation = ViveEmulation(this)
 	var localizer = Localizer(this)
+	private var trackerSkeleton = TrackerSkeleton(this)
+	var stayAlignedConfig = StayAlignedConfig().also { it.enabled = false }
 
 	// Constructors
 	init {
@@ -236,6 +241,7 @@ class HumanSkeleton(
 		)
 		legTweaks.setConfig(server.configManager.vrConfig.legTweaks)
 		localizer.setEnabled(humanPoseManager.getToggle(SkeletonConfigToggles.SELF_LOCALIZATION))
+		stayAlignedConfig = server.configManager.vrConfig.stayAlignedConfig
 	}
 
 	constructor(
@@ -453,6 +459,9 @@ class HumanSkeleton(
 
 		// Update bones tracker field
 		refreshBoneTracker()
+
+		// Update tracker skeleton
+		trackerSkeleton = TrackerSkeleton(this)
 	}
 
 	/**
@@ -508,6 +517,8 @@ class HumanSkeleton(
 	@VRServerThread
 	fun updatePose() {
 		tapDetectionManager.update()
+
+		StayAligned.adjustNextTracker(trackerSkeleton, stayAlignedConfig)
 
 		updateTransforms()
 		updateBones()

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAligned.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAligned.kt
@@ -1,0 +1,51 @@
+package dev.slimevr.tracking.processor.stayaligned
+
+import dev.slimevr.VRServer
+import dev.slimevr.config.StayAlignedConfig
+import dev.slimevr.tracking.processor.stayaligned.adjust.AdjustTrackerYaw
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
+
+/**
+ * Manager to keep the trackers aligned.
+ */
+object StayAligned {
+
+	private var nextTrackerIndex = 0
+
+	/**
+	 * Adjusts the yaw of the next tracker.
+	 *
+	 * We only adjust one tracker per tick to minimize CPU usage. When the server is
+	 * running at 1000 Hz and there are 20 trackers, each tracker is still updated 50
+	 * times a second. (It is possible to reduce CPU usage even further, e.g. by
+	 * updating every 5 ticks, so that each tracker is updated 10 times a second).
+	 */
+	fun adjustNextTracker(
+		trackers: TrackerSkeleton,
+		config: StayAlignedConfig,
+	) {
+		if (!config.enabled) {
+			return
+		}
+
+		val numTrackers = trackers.allTrackers.size
+		if (numTrackers == 0) {
+			return
+		}
+
+		val tracker = trackers.allTrackers[nextTrackerIndex % numTrackers]
+		tracker.stayAligned.prepareForAdjustment()
+
+		AdjustTrackerYaw.adjust(
+			tracker,
+			trackers,
+			// Scale yaw correction since we're only updating one tracker per tick
+			config.yawCorrectionPerSec *
+				VRServer.instance.fpsTimer.timePerFrame *
+				numTrackers.toFloat(),
+			config,
+		)
+
+		++nextTrackerIndex
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAlignedDefaults.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAlignedDefaults.kt
@@ -1,0 +1,59 @@
+package dev.slimevr.tracking.processor.stayaligned
+
+import dev.slimevr.math.Angle
+import dev.slimevr.tracking.processor.stayaligned.skeleton.RelaxedBodyAngles
+import dev.slimevr.tracking.processor.stayaligned.state.RestDetector
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * All non-user-configurable defaults used by Stay Aligned, so that we can tune the
+ * algorithm from a single place.
+ */
+object StayAlignedDefaults {
+
+	fun restDetector() =
+		RestDetector(
+			maxRotation = Angle.ofDeg(3.0f),
+			minDuration = 2.seconds,
+		)
+
+	val RELAXED_BODY_ANGLES_STANDING =
+		RelaxedBodyAngles(
+			upperLeg = Angle.ofDeg(6.0f),
+			lowerLeg = Angle.ofDeg(9.0f),
+			foot = Angle.ofDeg(10.0f),
+		)
+
+	val RELAXED_BODY_ANGLES_SITTING_IN_CHAIR =
+		RelaxedBodyAngles(
+			upperLeg = Angle.ofDeg(6.0f),
+			lowerLeg = Angle.ofDeg(9.0f),
+			foot = Angle.ofDeg(10.0f),
+		)
+
+	val RELAXED_BODY_ANGLES_LYING_ON_BACK =
+		RelaxedBodyAngles(
+			upperLeg = Angle.ofDeg(4.0f),
+			lowerLeg = Angle.ofDeg(4.0f),
+			foot = null,
+		)
+
+	val RELAXED_BODY_ANGLES_KNEELING =
+		RelaxedBodyAngles(
+			upperLeg = Angle.ofDeg(4.0f),
+			lowerLeg = Angle.ofDeg(4.0f),
+			foot = null,
+		)
+
+	const val NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT = 0.7f
+	const val NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT = 0.3f
+
+	const val CENTER_ERROR_HEAD_WEIGHT = 1.0f
+	const val CENTER_ERROR_UPPER_BODY_WEIGHT = 1.0f
+	const val CENTER_ERROR_UPPER_LEG_WEIGHT = 0.4f
+	const val CENTER_ERROR_LOWER_LEG_WEIGHT = 0.3f
+
+	const val YAW_ERRORS_LOCKED_ERROR_WEIGHT = 10.0f
+	const val YAW_ERRORS_CENTER_ERROR_WEIGHT = 2.0f
+	const val YAW_ERRORS_NEIGHBOR_ERROR_WEIGHT = 1.0f
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/AdjustTrackerYaw.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/AdjustTrackerYaw.kt
@@ -1,0 +1,178 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.config.StayAlignedConfig
+import dev.slimevr.math.Angle
+import dev.slimevr.math.Angle.Companion.abs
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults
+import dev.slimevr.tracking.processor.stayaligned.skeleton.RelaxedBodyAngles
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeletonPose
+import dev.slimevr.tracking.processor.stayaligned.state.YawErrors
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.udp.MagnetometerStatus
+
+object AdjustTrackerYaw {
+
+	/**
+	 * Adjusts the yaw of a tracker.
+	 *
+	 * We apply 3 forces to the tracker which help keep it balanced with the
+	 * rest of the trackers in the skeleton. Hopefully, this leads to a
+	 * reasonable alignment which closely matches the player's real alignment.
+	 *
+	 * Locked Trackers
+	 * ---------------
+	 * When a tracker is at rest, we lock it and save its yaw. We assume that
+	 * locked trackers really are at rest, and that any rotation is due to yaw
+	 * drift. We add an error term that is the difference between the tracker's
+	 * yaw and its locked yaw. This works very well when the player is leaning
+	 * against something, e.g. a chair or couch. But when the player is
+	 * standing still, they tend to sway back toward the neutral position, which
+	 * causes us to adjust the tracker a bit too much outwards. Luckily, this is
+	 * balanced by the centering force.
+	 *
+	 * Centering Force
+	 * ---------------
+	 * We have a centering force which nudges the trackers into a relaxed pose
+	 * for the player. For example, we know that a standing player tends to be
+	 * facing forward with their legs slightly spread apart. We calculate the
+	 * average yaw of the skeleton and nudge the trackers into the expected
+	 * position centered around this average yaw.
+	 *
+	 * Neighbor Trackers
+	 * -----------------
+	 * The player is often not in a relaxed pose. If we only had the above
+	 * forces, a moving tracker next to a locked tracker can rotate into
+	 * unnatural positions. For example, consider a lower leg tracker that is
+	 * moving, next to a foot tracker that is locked, but stretched out
+	 * in-front of the player. The centering force will try to adjust the
+	 * lower leg tracker back to the relaxed position, which could be very far
+	 * away from the foot tracker. To address this, we nudge the tracker into
+	 * the midpoint between its neighbors, after accounting for the relaxed
+	 * pose.
+	 *
+	 * After we calculate all these error terms, we weight them, and use
+	 * gradient descent to find the direction to apply a yaw correction. By
+	 * applying this 50 times a second, the whole body is nudged into a
+	 * reasonable alignment.
+	 */
+	fun adjust(
+		tracker: Tracker,
+		trackers: TrackerSkeleton,
+		yawCorrection: Angle,
+		config: StayAlignedConfig,
+	) {
+		if (tracker.stayAligned.lockedRotation != null) {
+			adjustLockedTracker(tracker, trackers, yawCorrection)
+		} else {
+			adjustMovingTracker(tracker, trackers, yawCorrection, config)
+		}
+	}
+
+	/**
+	 * Adjusts a locked tracker.
+	 */
+	private fun adjustLockedTracker(
+		tracker: Tracker,
+		trackers: TrackerSkeleton,
+		yawCorrection: Angle,
+	) {
+		adjustByError(tracker, yawCorrection) {
+			val yawErrors = YawErrors()
+
+			yawErrors.lockedError =
+				trackers.visit(tracker, LockedErrorVisitor())
+					?: Angle.ZERO
+
+			yawErrors
+		}
+	}
+
+	/**
+	 * Adjusts a tracker that is moving.
+	 */
+	private fun adjustMovingTracker(
+		tracker: Tracker,
+		trackers: TrackerSkeleton,
+		yawCorrection: Angle,
+		config: StayAlignedConfig,
+	) {
+		val pose = TrackerSkeletonPose.ofTrackers(trackers)
+		val relaxedBodyAngles = RelaxedBodyAngles.forPose(pose, config) ?: return
+		val centerYaw = CenterErrorVisitor.trackersCenterYaw(trackers) ?: return
+
+		adjustByError(tracker, yawCorrection) {
+			val yawErrors = YawErrors()
+
+			yawErrors.centerError =
+				trackers.visit(
+					tracker,
+					CenterErrorVisitor(centerYaw, relaxedBodyAngles),
+				) ?: Angle.ZERO
+
+			yawErrors.neighborError =
+				trackers.visit(
+					tracker,
+					NeighborErrorVisitor(relaxedBodyAngles),
+				) ?: Angle.ZERO
+
+			yawErrors
+		}
+	}
+
+	/**
+	 * Adjusts the yaw by applying gradient descent.
+	 */
+	private fun adjustByError(
+		tracker: Tracker,
+		yawCorrection: Angle,
+		errorFn: (tracker: Tracker) -> YawErrors,
+	) {
+		// Only IMUs have yaw drift
+		if (!tracker.isImu()) {
+			return
+		}
+
+		// Magnetometer directly determines the yaw
+		if (tracker.magStatus == MagnetometerStatus.ENABLED) {
+			return
+		}
+
+		val state = tracker.stayAligned
+
+		val curYaw = state.yawCorrection.yaw
+		val curError = errorFn(tracker)
+
+		val posYaw = curYaw + yawCorrection
+		state.yawCorrection.yaw = posYaw
+		val posError = errorFn(tracker)
+
+		val negYaw = curYaw - yawCorrection
+		state.yawCorrection.yaw = negYaw
+		val negError = errorFn(tracker)
+
+		val posYawDelta = gradient(posError, curError)
+		val negYawDelta = gradient(negError, curError)
+
+		// Pick the yaw that minimizes the error
+		if ((posYawDelta < Angle.ZERO) && (posYawDelta < negYawDelta)) {
+			state.yawCorrection.yaw = posYaw
+			state.yawErrors = posError
+		} else if (negYawDelta < Angle.ZERO) {
+			state.yawCorrection.yaw = negYaw
+			state.yawErrors = negError
+		} else {
+			state.yawCorrection.yaw = curYaw
+			state.yawErrors = curError
+		}
+	}
+
+	/**
+	 * Calculates the gradient between two errors. A negative gradient means that there
+	 * is less error in that direction.
+	 */
+	private fun gradient(errors: YawErrors, base: YawErrors) =
+		(abs(errors.lockedError) - abs(base.lockedError)) * StayAlignedDefaults.YAW_ERRORS_LOCKED_ERROR_WEIGHT +
+			(abs(errors.centerError) - abs(base.centerError)) * StayAlignedDefaults.YAW_ERRORS_CENTER_ERROR_WEIGHT +
+			(abs(errors.neighborError) - abs(base.neighborError)) * StayAlignedDefaults.YAW_ERRORS_NEIGHBOR_ERROR_WEIGHT
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/AngleErrors.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/AngleErrors.kt
@@ -1,0 +1,31 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.math.Angle
+import kotlin.math.*
+
+/**
+ * Aggregator for angle errors.
+ */
+class AngleErrors {
+
+	private var sumSqrError = 0.0f
+
+	/**
+	 * Adds an angle error.
+	 */
+	fun add(error: Angle, weight: Float = 1.0f) {
+		val weightedError = error.normalizedAroundZero().toRad() * weight
+		sumSqrError += weightedError * weightedError
+	}
+
+	/**
+	 * Gets the L2-norm of the angle errors.
+	 *
+	 * We use the L2 norm of the errors so that big errors are much worse than
+	 * small errors. For example, when balancing an upper body tracker in
+	 * between two leg trackers, we want the error to be minimized when the
+	 * upper body tracker is midway between the two leg trackers.
+	 */
+	fun toL2Norm() =
+		Angle.ofRad(sqrt(sumSqrError))
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/CenterErrorVisitor.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/CenterErrorVisitor.kt
@@ -1,0 +1,151 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.math.Angle
+import dev.slimevr.math.AngleAverage
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.CENTER_ERROR_HEAD_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.CENTER_ERROR_LOWER_LEG_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.CENTER_ERROR_UPPER_BODY_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.CENTER_ERROR_UPPER_LEG_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.adjust.TrackerYaw.extraYaw
+import dev.slimevr.tracking.processor.stayaligned.adjust.TrackerYaw.hasTrackerYaw
+import dev.slimevr.tracking.processor.stayaligned.adjust.TrackerYaw.trackerYaw
+import dev.slimevr.tracking.processor.stayaligned.skeleton.RelaxedBodyAngles
+import dev.slimevr.tracking.processor.stayaligned.skeleton.Side
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
+import dev.slimevr.tracking.trackers.Tracker
+
+/**
+ * Error between a tracker's yaw, and its expected yaw. Assumes that the body is in a
+ * relaxed position centered around an average yaw.
+ */
+class CenterErrorVisitor(
+	private val averageYaw: Angle,
+	private val relaxedBodyAngles: RelaxedBodyAngles,
+) : TrackerSkeleton.TrackerVisitor<Angle> {
+
+	override fun visitHeadTracker(
+		tracker: Tracker,
+		belowUpperBody: Tracker?,
+	): Angle =
+		error(tracker, averageYaw)
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowUpperBody: Tracker?,
+	): Angle =
+		error(tracker, averageYaw)
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowLeftUpperLeg: Tracker?,
+		belowRightUpperLeg: Tracker?,
+	): Angle =
+		error(tracker, averageYaw)
+
+	override fun visitArmTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBodyOrArm: Tracker?,
+		belowHandOrArm: Tracker?,
+	): Angle =
+		// Arms can go anywhere
+		Angle.ZERO
+
+	override fun visitHandTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveArm: Tracker?,
+	): Angle =
+		// Hands can go anywhere
+		Angle.ZERO
+
+	override fun visitUpperLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBody: Tracker?,
+		belowLowerLeg: Tracker?,
+	): Angle =
+		error(tracker, averageYaw + extraYaw(side, relaxedBodyAngles.upperLeg))
+
+	override fun visitLowerLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperLeg: Tracker?,
+		belowFoot: Tracker?,
+	): Angle =
+		error(tracker, averageYaw + extraYaw(side, relaxedBodyAngles.lowerLeg))
+
+	override fun visitFootTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveLowerLeg: Tracker?,
+	): Angle =
+		if (relaxedBodyAngles.foot != null) {
+			error(tracker, averageYaw + extraYaw(side, relaxedBodyAngles.foot))
+		} else {
+			Angle.ZERO
+		}
+
+	private fun error(tracker: Tracker, expectedYaw: Angle) =
+		Angle.signedBetween(trackerYaw(tracker), expectedYaw)
+
+	companion object {
+
+		/**
+		 * Finds the center yaw of the skeleton.
+		 */
+		fun trackersCenterYaw(
+			trackers: TrackerSkeleton,
+		): Angle? {
+			val head = trackers.head
+			val upperBody = trackers.upperBody
+			val leftUpperLeg = trackers.leftUpperLeg
+			val rightUpperLeg = trackers.rightUpperLeg
+			val leftLowerLeg = trackers.leftLowerLeg
+			val rightLowerLeg = trackers.rightLowerLeg
+
+			if (
+				// Head is optional
+				upperBody.isEmpty() ||
+				leftUpperLeg == null ||
+				rightUpperLeg == null ||
+				leftLowerLeg == null ||
+				rightLowerLeg == null
+			) {
+				return null
+			}
+
+			// Check whether we can calculate a center yaw
+			val hasCenterYaw =
+				upperBody.all(::hasTrackerYaw) &&
+					hasTrackerYaw(leftUpperLeg) &&
+					hasTrackerYaw(rightUpperLeg) &&
+					hasTrackerYaw(leftLowerLeg) &&
+					hasTrackerYaw(rightLowerLeg)
+			if (!hasCenterYaw) {
+				return null
+			}
+
+			// Calculate average yaw of the body
+			val averageYaw = AngleAverage()
+
+			if (head != null && hasTrackerYaw(head)) {
+				averageYaw.add(trackerYaw(head), CENTER_ERROR_HEAD_WEIGHT)
+			}
+
+			upperBody.forEach {
+				averageYaw.add(trackerYaw(it), CENTER_ERROR_UPPER_BODY_WEIGHT)
+			}
+
+			averageYaw.add(trackerYaw(leftUpperLeg), CENTER_ERROR_UPPER_LEG_WEIGHT)
+			averageYaw.add(trackerYaw(rightUpperLeg), CENTER_ERROR_UPPER_LEG_WEIGHT)
+
+			averageYaw.add(trackerYaw(leftLowerLeg), CENTER_ERROR_LOWER_LEG_WEIGHT)
+			averageYaw.add(trackerYaw(rightLowerLeg), CENTER_ERROR_LOWER_LEG_WEIGHT)
+
+			return averageYaw.toAngle()
+		}
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/LockedErrorVisitor.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/LockedErrorVisitor.kt
@@ -1,0 +1,126 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.math.Angle
+import dev.slimevr.tracking.processor.stayaligned.skeleton.Side
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
+import dev.slimevr.tracking.trackers.Tracker
+import io.github.axisangles.ktmath.Quaternion
+import io.github.axisangles.ktmath.Vector3
+import kotlin.math.*
+
+/**
+ * Error between a locked tracker's yaw and its yaw when it was initially locked.
+ */
+class LockedErrorVisitor : TrackerSkeleton.TrackerVisitor<Angle> {
+
+	override fun visitHeadTracker(
+		tracker: Tracker,
+		belowUpperBody: Tracker?,
+	): Angle =
+		// The head tracker is usually a headset and does not need to be aligned
+		Angle.ZERO
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowUpperBody: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowLeftUpperLeg: Tracker?,
+		belowRightUpperLeg: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitArmTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBodyOrArm: Tracker?,
+		belowHandOrArm: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitHandTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveArm: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitUpperLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBody: Tracker?,
+		belowLowerLeg: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitLowerLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperLeg: Tracker?,
+		belowFoot: Tracker?,
+	): Angle =
+		error(tracker)
+
+	override fun visitFootTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveLowerLeg: Tracker?,
+	): Angle =
+		error(tracker)
+
+	private fun error(tracker: Tracker): Angle {
+		val lockedRotation = tracker.stayAligned.lockedRotation
+			?: return Angle.ZERO
+
+		return yawDifference(tracker.getRotation(), lockedRotation)
+	}
+
+	/**
+	 * Gets the yaw between two rotations, for small rotations.
+	 *
+	 * A locked tracker can be in any rotation, so we cannot use TrackerYaw::trackerYaw,
+	 * which doesn't work for a tracker that is on its side.
+	 *
+	 * WARNING: DO NOT USE for large rotations because the chosen axis might have a very
+	 * small projection on the yaw plane, which yields a low confidence yaw.
+	 *
+	 * TODO: It might be possible to pick a different EulerOrder when we encounter
+	 * 		singularities, but I wasn't able to get this working correctly.
+	 */
+	private fun yawDifference(rotation: Quaternion, targetRotation: Quaternion): Angle {
+		val targetX = targetRotation.sandwichUnitX()
+		val targetY = targetRotation.sandwichUnitY()
+		val targetZ = targetRotation.sandwichUnitZ()
+
+		// Find the axis that is closest to the yaw plane
+		val axis: Vector3
+		val targetAxis: Vector3
+
+		val targetXScore = abs(targetX.dot(Vector3.POS_Y))
+		val targetYScore = abs(targetY.dot(Vector3.POS_Y))
+		val targetZScore = abs(targetZ.dot(Vector3.POS_Y))
+
+		// The axis that is closest to the yaw plane has the smallest absolute dot
+		// product with the Y axis
+		if ((targetXScore <= targetYScore) && (targetXScore <= targetZScore)) {
+			axis = rotation.sandwichUnitX()
+			targetAxis = targetX
+		} else if ((targetYScore <= targetXScore) && (targetYScore <= targetZScore)) {
+			axis = rotation.sandwichUnitY()
+			targetAxis = targetY
+		} else {
+			axis = rotation.sandwichUnitZ()
+			targetAxis = targetZ
+		}
+
+		val yaw = atan2(axis.z, axis.x)
+		val targetYaw = atan2(targetAxis.z, targetAxis.x)
+
+		return Angle.ofRad(yaw - targetYaw)
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/NeighborErrorVisitor.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/NeighborErrorVisitor.kt
@@ -1,0 +1,190 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.math.Angle
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults.NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT
+import dev.slimevr.tracking.processor.stayaligned.adjust.TrackerYaw.extraYaw
+import dev.slimevr.tracking.processor.stayaligned.adjust.TrackerYaw.trackerYaw
+import dev.slimevr.tracking.processor.stayaligned.skeleton.RelaxedBodyAngles
+import dev.slimevr.tracking.processor.stayaligned.skeleton.Side
+import dev.slimevr.tracking.processor.stayaligned.skeleton.TrackerSkeleton
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.TrackerPosition
+
+/**
+ * Error between a tracker's yaw and its neighbors' yaws.
+ */
+class NeighborErrorVisitor(
+	private val relaxedBodyAngles: RelaxedBodyAngles,
+) : TrackerSkeleton.TrackerVisitor<Angle> {
+
+	override fun visitHeadTracker(
+		tracker: Tracker,
+		belowUpperBody: Tracker?,
+	): Angle =
+		// The head tracker is often off to the side, and we should not force it to
+		// align to the upper body
+		Angle.ZERO
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowUpperBody: Tracker?,
+	): Angle {
+		val errors = AngleErrors()
+
+		if (aboveHeadOrUpperBody != null) {
+			// Head often drags the upper body trackers off to the side, so we ignore it
+			if (aboveHeadOrUpperBody.trackerPosition != TrackerPosition.HEAD) {
+				errors.add(error(tracker, aboveHeadOrUpperBody), NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT)
+			}
+		}
+
+		if (belowUpperBody != null) {
+			errors.add(error(tracker, belowUpperBody), NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT)
+		}
+
+		return errors.toL2Norm()
+	}
+
+	override fun visitUpperBodyTracker(
+		tracker: Tracker,
+		aboveHeadOrUpperBody: Tracker?,
+		belowLeftUpperLeg: Tracker?,
+		belowRightUpperLeg: Tracker?,
+	): Angle {
+		val errors = AngleErrors()
+
+		if (aboveHeadOrUpperBody != null) {
+			// Head often drags the upper body trackers off to the side, so we ignore it
+			if (aboveHeadOrUpperBody.trackerPosition != TrackerPosition.HEAD) {
+				errors.add(error(tracker, aboveHeadOrUpperBody), NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT)
+			}
+		}
+
+		// Only consider upper leg trackers if both are available, so that the upper
+		// body tracker can be balanced between both
+		if (belowLeftUpperLeg != null && belowRightUpperLeg != null) {
+			errors.add(
+				error(
+					tracker,
+					belowLeftUpperLeg,
+					// Upper body tracker is on the RIGHT side of the left upper leg tracker
+					extraYaw(Side.RIGHT, relaxedBodyAngles.upperLeg),
+				),
+				NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT * 0.5f,
+			)
+
+			errors.add(
+				error(
+					tracker,
+					belowRightUpperLeg,
+					// Upper body tracker is on the LEFT side of the right upper leg tracker
+					extraYaw(Side.LEFT, relaxedBodyAngles.upperLeg),
+				),
+				NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT * 0.5f,
+			)
+		}
+
+		return errors.toL2Norm()
+	}
+
+	override fun visitArmTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBodyOrArm: Tracker?,
+		belowHandOrArm: Tracker?,
+	): Angle =
+		// Arms can go anywhere
+		Angle.ZERO
+
+	override fun visitHandTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveArm: Tracker?,
+	): Angle =
+		// Hands can go anywhere
+		Angle.ZERO
+
+	override fun visitUpperLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperBody: Tracker?,
+		belowLowerLeg: Tracker?,
+	): Angle {
+		val errors = AngleErrors()
+
+		if (aboveUpperBody != null) {
+			errors.add(
+				error(tracker, aboveUpperBody, extraYaw(side, relaxedBodyAngles.upperLeg)),
+				NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT,
+			)
+		}
+
+		if (belowLowerLeg != null) {
+			errors.add(
+				// Negative extra yaw because we are on the opposite side of the lower leg
+				error(tracker, belowLowerLeg, -extraYaw(side, relaxedBodyAngles.lowerLeg - relaxedBodyAngles.upperLeg)),
+				NEIGHBOR_ERROR_BELOW_TRACKER_WEIGHT,
+			)
+		}
+
+		return errors.toL2Norm()
+	}
+
+	override fun visitLowerLegTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveUpperLeg: Tracker?,
+		belowFoot: Tracker?,
+	): Angle {
+		val errors = AngleErrors()
+
+		if (aboveUpperLeg != null) {
+			errors.add(
+				error(tracker, aboveUpperLeg, extraYaw(side, relaxedBodyAngles.lowerLeg - relaxedBodyAngles.upperLeg)),
+				NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT,
+			)
+		}
+
+		if (belowFoot != null && relaxedBodyAngles.foot != null) {
+			errors.add(
+				// Negative extra yaw because we are on the opposite side of the foot
+				error(tracker, belowFoot, -extraYaw(side, relaxedBodyAngles.foot - relaxedBodyAngles.lowerLeg)),
+			)
+		}
+
+		return errors.toL2Norm()
+	}
+
+	override fun visitFootTracker(
+		side: Side,
+		tracker: Tracker,
+		aboveLowerLeg: Tracker?,
+	): Angle {
+		val errors = AngleErrors()
+
+		if (aboveLowerLeg != null && relaxedBodyAngles.foot != null) {
+			errors.add(
+				error(
+					tracker,
+					aboveLowerLeg,
+					extraYaw(side, relaxedBodyAngles.foot - relaxedBodyAngles.lowerLeg),
+				),
+				NEIGHBOR_ERROR_ABOVE_TRACKER_WEIGHT,
+			)
+		}
+
+		return errors.toL2Norm()
+	}
+
+	private fun error(
+		tracker: Tracker,
+		neighborTracker: Tracker,
+		extraYawRelativeToNeighbor: Angle = Angle.ZERO,
+	) =
+		Angle.signedBetween(
+			trackerYaw(tracker),
+			trackerYaw(neighborTracker) + extraYawRelativeToNeighbor,
+		)
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/TrackerYaw.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/adjust/TrackerYaw.kt
@@ -1,0 +1,59 @@
+package dev.slimevr.tracking.processor.stayaligned.adjust
+
+import dev.slimevr.math.Angle
+import dev.slimevr.tracking.processor.stayaligned.skeleton.Side
+import dev.slimevr.tracking.trackers.Tracker
+import io.github.axisangles.ktmath.EulerOrder
+import io.github.axisangles.ktmath.Vector3
+
+/**
+ * Utilities for tracker yaw.
+ *
+ * The SlimeVR coordinate system is x-right, y-up, z-back, which is a right-handed
+ * coordinate system.
+ *
+ * Rotations follow the right-hand rule, for example, a positive rotation around the
+ * y-axis is a counter-clockwise rotation from z to x. From the perspective of a player,
+ * left is positive yaw, right is negative yaw.
+ */
+object TrackerYaw {
+
+	/**
+	 * Whether we can get the yaw of a tracker.
+	 */
+	fun hasTrackerYaw(tracker: Tracker) =
+		Angle.absBetween(
+			tracker.getRotation().sandwichUnitX(),
+			Vector3.POS_Y,
+		) > MIN_ON_SIDE_ANGLE
+
+	/**
+	 * Gets the yaw of the tracker, for trackers that are not on its side.
+	 *
+	 * WARNING: DO NOT USE for a tracker that is on its side. Euler YZX angles have a
+	 * singularity for a tracker that is on its side, and can yield arbitrary yaws.
+	 * For example, the Euler YZX angles (Y=0°, Z=90°, X=30°) and (Y=30°, Z=90°, X=0°)
+	 * are equivalent but yield completely different yaws.
+	 *
+	 * WARNING: It is possible to use another EulerOrder which does not have a
+	 * singularity for this rotation to get "some" yaw, but this yaw will be very
+	 * different from the from YZX. DO NOT ATTEMPT!
+	 */
+	fun trackerYaw(tracker: Tracker) =
+		Angle.ofRad(
+			tracker.getRotation()
+				.toEulerAngles(EulerOrder.YZX)
+				.y,
+		)
+
+	/**
+	 * Applies an extra yaw in the specified direction.
+	 */
+	fun extraYaw(direction: Side, angle: Angle) =
+		when (direction) {
+			Side.LEFT -> angle
+			Side.RIGHT -> -angle
+		}
+
+	private val MIN_ON_SIDE_ANGLE = Angle.ofDeg(30.0f)
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/RelaxedBodyAngles.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/RelaxedBodyAngles.kt
@@ -1,0 +1,69 @@
+package dev.slimevr.tracking.processor.stayaligned.skeleton
+
+import dev.slimevr.config.StayAlignedConfig
+import dev.slimevr.math.Angle
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults
+
+class RelaxedBodyAngles(
+	val upperLeg: Angle,
+	val lowerLeg: Angle,
+	val foot: Angle?,
+) {
+	companion object {
+
+		/**
+		 * Gets the relaxed angles for a particular pose. May provide defaults if the
+		 * angles aren't configured for the pose.
+		 */
+		fun forPose(
+			pose: TrackerSkeletonPose,
+			config: StayAlignedConfig,
+		) =
+			when (pose) {
+				TrackerSkeletonPose.STANDING ->
+					fromConfig(
+						config.standingUpperLegAngle,
+						config.standingLowerLegAngle,
+						config.standingFootAngle,
+					) ?: StayAlignedDefaults.RELAXED_BODY_ANGLES_STANDING
+
+				TrackerSkeletonPose.SITTING_IN_CHAIR ->
+					fromConfig(
+						config.sittingUpperLegAngle,
+						config.sittingLowerLegAngle,
+						config.sittingFootAngle,
+					) ?: StayAlignedDefaults.RELAXED_BODY_ANGLES_SITTING_IN_CHAIR
+
+				TrackerSkeletonPose.SITTING_ON_GROUND,
+				TrackerSkeletonPose.LYING_ON_BACK,
+				->
+					fromConfig(
+						config.lyingOnBackUpperLegAngle,
+						config.lyingOnBackLowerLegAngle,
+						null,
+					) ?: StayAlignedDefaults.RELAXED_BODY_ANGLES_LYING_ON_BACK
+
+				TrackerSkeletonPose.KNEELING ->
+					StayAlignedDefaults.RELAXED_BODY_ANGLES_KNEELING
+
+				else ->
+					null
+			}
+
+		private fun fromConfig(
+			upperLegAngle: Angle,
+			lowerLegAngle: Angle,
+			footAngle: Angle?,
+		): RelaxedBodyAngles? {
+			if (
+				upperLegAngle.nearZero() &&
+				lowerLegAngle.nearZero() &&
+				(footAngle == null || footAngle.nearZero())
+			) {
+				return null
+			}
+
+			return RelaxedBodyAngles(upperLegAngle, lowerLegAngle, footAngle)
+		}
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/Side.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/Side.kt
@@ -1,0 +1,6 @@
+package dev.slimevr.tracking.processor.stayaligned.skeleton
+
+enum class Side {
+	LEFT,
+	RIGHT,
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerPose.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerPose.kt
@@ -1,0 +1,54 @@
+package dev.slimevr.tracking.processor.stayaligned.skeleton
+
+import dev.slimevr.tracking.trackers.Tracker
+import io.github.axisangles.ktmath.Vector3
+import kotlin.math.*
+
+enum class TrackerPose {
+	NONE,
+	TOP_FACING_UP,
+	TOP_FACING_DOWN,
+	FRONT_FACING_UP,
+	FRONT_FACING_DOWN,
+	ON_SIDE,
+	;
+
+	companion object {
+
+		fun ofTracker(tracker: Tracker): TrackerPose {
+			val rotation = tracker.getRotation()
+
+			val x = rotation.sandwichUnitX()
+			val y = rotation.sandwichUnitY()
+			val z = rotation.sandwichUnitZ()
+
+			val xDot = x.dot(Vector3.POS_Y)
+			val yDot = y.dot(Vector3.POS_Y)
+			val zDot = z.dot(Vector3.POS_Y)
+
+			val xAbsDot = abs(xDot)
+			val yAbsDot = abs(yDot)
+			val zAbsDot = abs(zDot)
+
+			val pose =
+				if ((xAbsDot >= yAbsDot) && (xAbsDot >= zAbsDot)) {
+					ON_SIDE
+				} else if ((yAbsDot >= xDot) && (yAbsDot >= zAbsDot)) {
+					if (yDot >= 0) {
+						TOP_FACING_UP
+					} else {
+						TOP_FACING_DOWN
+					}
+				} else {
+					// Tracker local POS_Z is behind
+					if (zDot >= 0) {
+						FRONT_FACING_DOWN
+					} else {
+						FRONT_FACING_UP
+					}
+				}
+
+			return pose
+		}
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeleton.kt
@@ -297,7 +297,7 @@ class TrackerSkeleton(skeleton: HumanSkeleton) {
 		arm: List<Tracker>,
 		hand: Tracker?,
 	): V? {
-		val index = this.upperBody.indexOf(tracker)
+		val index = arm.indexOf(tracker)
 		if (index < 0) {
 			return null
 		}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeleton.kt
@@ -1,0 +1,419 @@
+package dev.slimevr.tracking.processor.stayaligned.skeleton
+
+import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.TrackerPosition
+
+/**
+ * Represents a skeleton of trackers.
+ *
+ * The skeleton consists of:
+ * - An upper body group
+ * - A head tracker, connected to the top of the upper body group
+ * - Two arm groups, connected to the top of the upper body group
+ * - Two hands connected to the bottom of the corresponding arm group
+ * - Two upper legs, connected to the bottom of the upper body group
+ * - Two lower legs, connected to the bottom of each corresponding upper leg
+ * - Two feet, connected to the bottom of each corresponding lower leg
+ */
+class TrackerSkeleton(skeleton: HumanSkeleton) {
+
+	val allTrackers = with(skeleton) {
+		listOfNotNull(
+			headTracker,
+			// Upper body
+			neckTracker,
+			upperChestTracker,
+			chestTracker,
+			waistTracker,
+			hipTracker,
+			// Left arm
+			leftShoulderTracker,
+			leftUpperArmTracker,
+			leftLowerArmTracker,
+			leftHandTracker,
+			// Right arm
+			rightShoulderTracker,
+			rightUpperArmTracker,
+			rightLowerArmTracker,
+			rightHandTracker,
+			// Left leg
+			leftUpperLegTracker,
+			leftLowerLegTracker,
+			leftFootTracker,
+			// Right leg
+			rightUpperLegTracker,
+			rightLowerLegTracker,
+			rightFootTracker,
+		)
+	}
+
+	// Tracker groups
+	val upperBody = with(skeleton) {
+		listOfNotNull(
+			neckTracker,
+			upperChestTracker,
+			chestTracker,
+			waistTracker,
+			hipTracker,
+		)
+	}
+
+	val leftArm = with(skeleton) {
+		listOfNotNull(
+			leftShoulderTracker,
+			leftUpperArmTracker,
+			leftLowerArmTracker,
+		)
+	}
+
+	val rightArm = with(skeleton) {
+		listOfNotNull(
+			rightShoulderTracker,
+			rightUpperArmTracker,
+			rightLowerArmTracker,
+		)
+	}
+
+	// Individual trackers
+	val head = skeleton.headTracker
+	val leftHand = skeleton.leftHandTracker
+	val rightHand = skeleton.rightHandTracker
+	val leftUpperLeg = skeleton.leftUpperLegTracker
+	val leftLowerLeg = skeleton.leftLowerLegTracker
+	val leftFoot = skeleton.leftFootTracker
+	val rightUpperLeg = skeleton.rightUpperLegTracker
+	val rightLowerLeg = skeleton.rightLowerLegTracker
+	val rightFoot = skeleton.rightFootTracker
+
+	/**
+	 * Visits a tracker within the skeleton.
+	 */
+	fun <V> visit(
+		tracker: Tracker,
+		visitor: TrackerVisitor<V>,
+	): V? =
+		when (tracker.trackerPosition) {
+			TrackerPosition.HEAD ->
+				if (tracker == head) {
+					visitor.visitHeadTracker(tracker, upperBody.firstOrNull())
+				} else {
+					null
+				}
+
+			// Upper body
+			TrackerPosition.NECK,
+			TrackerPosition.UPPER_CHEST,
+			TrackerPosition.CHEST,
+			TrackerPosition.WAIST,
+			TrackerPosition.HIP,
+			->
+				visitUpperBodyTrackers(
+					tracker,
+					visitor,
+					head,
+					upperBody,
+					leftUpperLeg,
+					rightUpperLeg,
+				)
+
+			// Left arm
+			TrackerPosition.LEFT_SHOULDER,
+			TrackerPosition.LEFT_UPPER_ARM,
+			TrackerPosition.LEFT_LOWER_ARM,
+			->
+				visitArmTrackers(
+					tracker,
+					visitor,
+					Side.LEFT,
+					upperBody.firstOrNull(),
+					leftArm,
+					leftHand,
+				)
+
+			// Right arm
+			TrackerPosition.RIGHT_SHOULDER,
+			TrackerPosition.RIGHT_UPPER_ARM,
+			TrackerPosition.RIGHT_LOWER_ARM,
+			->
+				visitArmTrackers(
+					tracker,
+					visitor,
+					Side.RIGHT,
+					upperBody.firstOrNull(),
+					rightArm,
+					rightHand,
+				)
+
+			TrackerPosition.LEFT_HAND ->
+				if (tracker == leftHand) {
+					visitor.visitHandTracker(
+						Side.LEFT,
+						tracker,
+						leftArm.lastOrNull(),
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.RIGHT_HAND ->
+				if (tracker == rightHand) {
+					visitor.visitHandTracker(
+						Side.RIGHT,
+						tracker,
+						rightArm.lastOrNull(),
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.LEFT_UPPER_LEG ->
+				if (tracker == leftUpperLeg) {
+					visitor.visitUpperLegTracker(
+						Side.LEFT,
+						tracker,
+						upperBody.lastOrNull(),
+						leftLowerLeg,
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.RIGHT_UPPER_LEG ->
+				if (tracker == rightUpperLeg) {
+					visitor.visitUpperLegTracker(
+						Side.RIGHT,
+						tracker,
+						upperBody.lastOrNull(),
+						rightLowerLeg,
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.LEFT_LOWER_LEG ->
+				if (tracker == leftLowerLeg) {
+					visitor.visitLowerLegTracker(
+						Side.LEFT,
+						tracker,
+						leftUpperLeg,
+						leftFoot,
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.RIGHT_LOWER_LEG ->
+				if (tracker == rightLowerLeg) {
+					visitor.visitLowerLegTracker(
+						Side.RIGHT,
+						tracker,
+						rightUpperLeg,
+						rightFoot,
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.LEFT_FOOT ->
+				if (tracker == leftFoot) {
+					visitor.visitFootTracker(
+						Side.LEFT,
+						tracker,
+						leftLowerLeg,
+					)
+				} else {
+					null
+				}
+
+			TrackerPosition.RIGHT_FOOT ->
+				if (tracker == rightFoot) {
+					visitor.visitFootTracker(
+						Side.RIGHT,
+						tracker,
+						rightLowerLeg,
+					)
+				} else {
+					null
+				}
+
+			else ->
+				null
+		}
+
+	private fun <V> visitUpperBodyTrackers(
+		tracker: Tracker,
+		visitor: TrackerVisitor<V>,
+		head: Tracker?,
+		upperBody: List<Tracker>,
+		leftUpperLeg: Tracker?,
+		rightUpperLeg: Tracker?,
+	): V? {
+		val index = upperBody.indexOf(tracker)
+		if (index < 0) {
+			return null
+		}
+
+		return if (index == 0) {
+			if (upperBody.size == 1) {
+				// Only upper body tracker
+				visitor.visitUpperBodyTracker(
+					tracker,
+					head,
+					leftUpperLeg,
+					rightUpperLeg,
+				)
+			} else {
+				// First upper body tracker
+				visitor.visitUpperBodyTracker(
+					tracker,
+					head,
+					upperBody[1],
+				)
+			}
+		} else if (index < upperBody.size - 1) {
+			// Middle upper body tracker
+			visitor.visitUpperBodyTracker(
+				tracker,
+				upperBody[index - 1],
+				upperBody[index + 1],
+			)
+		} else {
+			// Last upper body tracker
+			visitor.visitUpperBodyTracker(
+				tracker,
+				upperBody[index - 1],
+				leftUpperLeg,
+				rightUpperLeg,
+			)
+		}
+	}
+
+	private fun <V> visitArmTrackers(
+		tracker: Tracker,
+		visitor: TrackerVisitor<V>,
+		side: Side,
+		upperBody: Tracker?,
+		arm: List<Tracker>,
+		hand: Tracker?,
+	): V? {
+		val index = this.upperBody.indexOf(tracker)
+		if (index < 0) {
+			return null
+		}
+
+		return if (index == 0) {
+			if (arm.size == 1) {
+				// Only arm tracker
+				visitor.visitArmTracker(
+					side,
+					tracker,
+					upperBody,
+					hand,
+				)
+			} else {
+				// First arm tracker
+				visitor.visitArmTracker(
+					side,
+					tracker,
+					upperBody,
+					arm[1],
+				)
+			}
+		} else if (index < arm.size - 1) {
+			// Middle arm tracker
+			visitor.visitArmTracker(
+				side,
+				tracker,
+				arm[index - 1],
+				arm[index + 1],
+			)
+		} else {
+			// Last arm tracker
+			visitor.visitArmTracker(
+				side,
+				tracker,
+				arm[index - 1],
+				hand,
+			)
+		}
+	}
+
+	interface TrackerVisitor<V> {
+
+		/**
+		 * Visits the head tracker.
+		 */
+		fun visitHeadTracker(
+			tracker: Tracker,
+			belowUpperBody: Tracker?,
+		): V
+
+		/**
+		 * Visits an upper body tracker (except for the bottom-most tracker).
+		 */
+		fun visitUpperBodyTracker(
+			tracker: Tracker,
+			aboveHeadOrUpperBody: Tracker?,
+			belowUpperBody: Tracker?,
+		): V
+
+		/**
+		 * Visits the bottom-most upper body tracker.
+		 */
+		fun visitUpperBodyTracker(
+			tracker: Tracker,
+			aboveHeadOrUpperBody: Tracker?,
+			belowLeftUpperLeg: Tracker?,
+			belowRightUpperLeg: Tracker?,
+		): V
+
+		/**
+		 * Visits an arm tracker.
+		 */
+		fun visitArmTracker(
+			side: Side,
+			tracker: Tracker,
+			aboveUpperBodyOrArm: Tracker?,
+			belowHandOrArm: Tracker?,
+		): V
+
+		/**
+		 * Visits a hand tracker.
+		 */
+		fun visitHandTracker(
+			side: Side,
+			tracker: Tracker,
+			aboveArm: Tracker?,
+		): V
+
+		/**
+		 * Visits an upper leg tracker.
+		 */
+		fun visitUpperLegTracker(
+			side: Side,
+			tracker: Tracker,
+			aboveUpperBody: Tracker?,
+			belowLowerLeg: Tracker?,
+		): V
+
+		/**
+		 * Visits a lower leg tracker.
+		 */
+		fun visitLowerLegTracker(
+			side: Side,
+			tracker: Tracker,
+			aboveUpperLeg: Tracker?,
+			belowFoot: Tracker?,
+		): V
+
+		/**
+		 * Visits a foot tracker.
+		 */
+		fun visitFootTracker(
+			side: Side,
+			tracker: Tracker,
+			aboveLowerLeg: Tracker?,
+		): V
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeletonPose.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/skeleton/TrackerSkeletonPose.kt
@@ -1,0 +1,93 @@
+package dev.slimevr.tracking.processor.stayaligned.skeleton
+
+import kotlin.math.*
+
+/**
+ * Detects the pose of trackers in a skeleton.
+ */
+enum class TrackerSkeletonPose {
+	UNKNOWN,
+	STANDING,
+	SITTING_IN_CHAIR,
+	SITTING_ON_GROUND,
+	LYING_ON_BACK,
+	KNEELING,
+	;
+
+	companion object {
+
+		fun ofTrackers(trackers: TrackerSkeleton): TrackerSkeletonPose {
+			val poses = TrackerPoses(
+				trackers.upperBody.map(TrackerPose::ofTracker),
+				trackers.leftUpperLeg?.let(TrackerPose::ofTracker) ?: TrackerPose.NONE,
+				trackers.rightUpperLeg?.let(TrackerPose::ofTracker) ?: TrackerPose.NONE,
+				trackers.leftLowerLeg?.let(TrackerPose::ofTracker) ?: TrackerPose.NONE,
+				trackers.rightLowerLeg?.let(TrackerPose::ofTracker) ?: TrackerPose.NONE,
+			)
+
+			return if (isStanding(poses)) {
+				STANDING
+			} else if (isSittingInChair(poses)) {
+				SITTING_IN_CHAIR
+			} else if (isSittingOnGround(poses)) {
+				SITTING_ON_GROUND
+			} else if (isLyingOnBack(poses)) {
+				LYING_ON_BACK
+			} else if (isKneeling(poses)) {
+				KNEELING
+			} else {
+				UNKNOWN
+			}
+		}
+
+		private class TrackerPoses(
+			val upperBody: List<TrackerPose>,
+			val leftUpperLeg: TrackerPose,
+			val rightUpperLeg: TrackerPose,
+			val leftLowerLeg: TrackerPose,
+			val rightLowerLeg: TrackerPose,
+		)
+
+		private fun isStanding(pose: TrackerPoses) =
+			pose.upperBody.all(::topFacingUp) &&
+				topFacingUp(pose.leftUpperLeg) &&
+				topFacingUp(pose.rightUpperLeg) &&
+				topFacingUp(pose.leftLowerLeg) &&
+				topFacingUp(pose.rightLowerLeg)
+
+		private fun isSittingInChair(pose: TrackerPoses) =
+			pose.upperBody.isNotEmpty() && topFacingUp(pose.upperBody[0]) &&
+				pose.upperBody.all { topFacingUp(it) || frontFacingUp(it) } &&
+				frontFacingUp(pose.leftUpperLeg) &&
+				frontFacingUp(pose.rightUpperLeg) &&
+				topFacingUp(pose.leftLowerLeg) &&
+				topFacingUp(pose.rightLowerLeg)
+
+		private fun isSittingOnGround(pose: TrackerPoses) =
+			pose.upperBody.isNotEmpty() && topFacingUp(pose.upperBody[0]) &&
+				pose.upperBody.all { topFacingUp(it) || frontFacingUp(it) } &&
+				pose.leftUpperLeg.let { frontFacingUp(it) || topFacingDown(it) } &&
+				pose.rightUpperLeg.let { frontFacingUp(it) || topFacingDown(it) } &&
+				pose.leftLowerLeg.let { frontFacingUp(it) || topFacingUp(it) } &&
+				pose.rightLowerLeg.let { frontFacingUp(it) || topFacingUp(it) }
+
+		private fun isLyingOnBack(pose: TrackerPoses) =
+			pose.upperBody.all(::frontFacingUp) &&
+				pose.leftUpperLeg.let { frontFacingUp(it) || topFacingDown(it) } &&
+				pose.rightUpperLeg.let { frontFacingUp(it) || topFacingDown(it) } &&
+				pose.leftLowerLeg.let { frontFacingUp(it) || topFacingUp(it) } &&
+				pose.rightLowerLeg.let { frontFacingUp(it) || topFacingUp(it) }
+
+		private fun isKneeling(pose: TrackerPoses) =
+			pose.leftUpperLeg.let { topFacingUp(it) || frontFacingUp(it) } &&
+				pose.rightUpperLeg.let { topFacingUp(it) || frontFacingUp(it) } &&
+				frontFacingDown(pose.leftLowerLeg) &&
+				frontFacingDown(pose.rightLowerLeg)
+
+		// Helper functions to make checks more readable
+		private fun topFacingUp(pose: TrackerPose) = pose == TrackerPose.TOP_FACING_UP
+		private fun topFacingDown(pose: TrackerPose) = pose == TrackerPose.TOP_FACING_DOWN
+		private fun frontFacingUp(pose: TrackerPose) = pose == TrackerPose.FRONT_FACING_UP
+		private fun frontFacingDown(pose: TrackerPose) = pose == TrackerPose.FRONT_FACING_DOWN
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/RestDetector.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/RestDetector.kt
@@ -1,0 +1,55 @@
+package dev.slimevr.tracking.processor.stayaligned.state
+
+import dev.slimevr.math.Angle
+import io.github.axisangles.ktmath.Quaternion
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * Detects whether a tracker is at rest.
+ *
+ * A tracker is at rest when it stays within a certain rotational range for a given
+ * amount of time. If it rotates past that range, it is no longer at rest.
+ *
+ * TODO: In practice this is good enough for Stay Aligned, but we could also consider
+ * 		acceleration if we want to make this a general purpose rest detector.
+ */
+class RestDetector(
+	private val maxRotation: Angle,
+	private val minDuration: Duration,
+) {
+	private var startAt = TimeSource.Monotonic.markNow()
+	private var startRotation = Quaternion.IDENTITY
+	private var atRest = false
+
+	/**
+	 * Resets the detector so that the tracker is no longer at rest
+	 */
+	fun reset(rotation: Quaternion = Quaternion.IDENTITY) {
+		startAt = TimeSource.Monotonic.markNow()
+		startRotation = rotation
+		atRest = false
+	}
+
+	/**
+	 * Provides a new rotation sample to the detector.
+	 *
+	 * @return whether the tracker is at rest
+	 */
+	fun update(rotation: Quaternion): Boolean {
+		if (Angle.absBetween(startRotation, rotation) < maxRotation) {
+			// When we detect the tracker is at rest, use the current rotation as the
+			// new start rotation for continuing to detect the tracker is at rest
+			if (!atRest &&
+				TimeSource.Monotonic.markNow() > startAt.plus(minDuration)
+			) {
+				startRotation = rotation
+				atRest = true
+			}
+		} else {
+			reset(rotation)
+		}
+
+		return atRest
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/StayAlignedTrackerState.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/StayAlignedTrackerState.kt
@@ -1,0 +1,43 @@
+package dev.slimevr.tracking.processor.stayaligned.state
+
+import dev.slimevr.tracking.processor.stayaligned.StayAlignedDefaults
+import dev.slimevr.tracking.trackers.Tracker
+import io.github.axisangles.ktmath.Quaternion
+
+class StayAlignedTrackerState(
+	val tracker: Tracker,
+) {
+	// Detects whether the tracker is at rest
+	val restDetector = StayAlignedDefaults.restDetector()
+
+	// Yaw of the tracker when it was locked
+	var lockedRotation: Quaternion? = null
+
+	// Yaw correction to apply to tracker rotation
+	val yawCorrection = YawCorrection()
+
+	// Alignment error that yaw correction attempts to minimize
+	var yawErrors = YawErrors()
+
+	fun update() {
+		val atRest = restDetector.update(tracker.getRawRotation())
+		if (atRest) {
+			if (lockedRotation == null) {
+				lockedRotation = tracker.getRotation()
+			}
+		} else {
+			lockedRotation = null
+		}
+	}
+
+	fun prepareForAdjustment() {
+		yawErrors = YawErrors()
+	}
+
+	fun reset() {
+		restDetector.reset()
+		lockedRotation = null
+		yawCorrection.reset()
+		yawErrors = YawErrors()
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/YawCorrection.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/YawCorrection.kt
@@ -1,0 +1,31 @@
+package dev.slimevr.tracking.processor.stayaligned.state
+
+import dev.slimevr.math.Angle
+import io.github.axisangles.ktmath.EulerAngles
+import io.github.axisangles.ktmath.EulerOrder
+import io.github.axisangles.ktmath.Quaternion
+
+/**
+ * Tracks the yaw correction that should be applied to a tracker.
+ */
+class YawCorrection {
+
+	var yaw = Angle.ZERO
+		set(value) {
+			field = value
+			yawRotation = EulerAngles(EulerOrder.YZX, 0.0f, value.toRad(), 0.0f).toQuaternion()
+		}
+
+	var yawRotation = Quaternion.IDENTITY
+		private set
+
+	var yawAtLastReset = Angle.ZERO
+		private set
+
+	fun reset() {
+		yawAtLastReset = yaw
+
+		yaw = Angle.ZERO
+		yawRotation = Quaternion.IDENTITY
+	}
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/YawErrors.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/state/YawErrors.kt
@@ -1,0 +1,9 @@
+package dev.slimevr.tracking.processor.stayaligned.state
+
+import dev.slimevr.math.Angle
+
+class YawErrors {
+	var lockedError = Angle.ZERO
+	var centerError = Angle.ZERO
+	var neighborError = Angle.ZERO
+}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -2,6 +2,7 @@ package dev.slimevr.tracking.trackers
 
 import dev.slimevr.VRServer
 import dev.slimevr.config.TrackerConfig
+import dev.slimevr.tracking.processor.stayaligned.state.StayAlignedTrackerState
 import dev.slimevr.tracking.trackers.TrackerPosition.Companion.getByDesignation
 import dev.slimevr.tracking.trackers.udp.IMUType
 import dev.slimevr.tracking.trackers.udp.MagnetometerStatus
@@ -146,6 +147,8 @@ class Tracker @JvmOverloads constructor(
 	 * It's like the ID, but it should be local to the device if it has one
 	 */
 	val trackerNum: Int = trackerNum ?: id
+
+	val stayAligned = StayAlignedTrackerState(this)
 
 	init {
 		// IMPORTANT: Look here for the required states of inputs
@@ -308,6 +311,7 @@ class Tracker @JvmOverloads constructor(
 		}
 		filteringHandler.update()
 		resetsHandler.update()
+		stayAligned.update()
 	}
 
 	/**
@@ -351,6 +355,8 @@ class Tracker @JvmOverloads constructor(
 			rot = resetsHandler.getReferenceAdjustedDriftRotationFrom(rot)
 		}
 
+		rot = stayAligned.yawCorrection.yawRotation * rot
+
 		return rot
 	}
 
@@ -376,6 +382,8 @@ class Tracker @JvmOverloads constructor(
 			// Adjust to reset and mounting
 			rot = resetsHandler.getIdentityAdjustedDriftRotationFrom(rot)
 		}
+
+		rot = stayAligned.yawCorrection.yawRotation * rot
 
 		return rot
 	}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -289,6 +289,8 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			yawResetSmoothTimeRemain = 0.0f
 		}
 
+		tracker.stayAligned.reset()
+
 		calculateDrift(oldRot)
 
 		postProcessResetFull()
@@ -327,6 +329,8 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		yawResetSmoothTimeRemain = 0.0f
 
 		makeIdentityAdjustmentQuatsYaw()
+
+		tracker.stayAligned.reset()
 
 		calculateDrift(oldRot)
 

--- a/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
@@ -55,6 +55,33 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 		}
 
 		/**
+		 * Rotation around X-axis
+		 *
+		 * Derived from the axis-angle representation in
+		 * https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Unit_quaternions
+		 */
+		fun rotationAroundXAxis(angle: Float): Quaternion =
+			Quaternion(cos(angle / 2.0f), sin(angle / 2.0f), 0.0f, 0.0f)
+
+		/**
+		 * Rotation around Y-axis
+		 *
+		 * Derived from the axis-angle representation in
+		 * https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Unit_quaternions
+		 */
+		fun rotationAroundYAxis(angle: Float): Quaternion =
+			Quaternion(cos(angle / 2.0f), 0.0f, sin(angle / 2.0f), 0.0f)
+
+		/**
+		 * Rotation around Z-axis
+		 *
+		 * Derived from the axis-angle representation in
+		 * https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Unit_quaternions
+		 */
+		fun rotationAroundZAxis(angle: Float): Quaternion =
+			Quaternion(cos(angle / 2.0f), 0.0f, 0.0f, sin(angle / 2.0f))
+
+		/**
 		 * SlimeVR-specific constants and utils
 		 */
 		object SlimeVR {
@@ -365,7 +392,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 
 		val angleA = atan2(2f * (abQ * bQ + aQ * rot.w), rot.w * rot.w - aQ * aQ + bQ * bQ - abQ * abQ)
 		val angleB = atan2(2f * (abQ * aQ + bQ * rot.w), rot.w * rot.w + aQ * aQ - bQ * bQ - abQ * abQ)
-		
+
 		return floatArrayOf(angleA, angleB)
 	}
 
@@ -375,6 +402,45 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 	 * @return that vector transformed by this quaternion
 	 **/
 	fun sandwich(that: Vector3): Vector3 = (this * Quaternion(0f, that) / this).xyz
+
+	/**
+	 * Sandwiches the unit X vector
+	 *
+	 * First column of rotation matrix in
+	 * https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Conversion_to_and_from_the_matrix_representation
+	 */
+	fun sandwichUnitX(): Vector3 =
+		Vector3(
+			w * w + x * x - y * y - z * z,
+			2.0f * (x * y + w * z),
+			2.0f * (x * z - w * y),
+		)
+
+	/**
+	 * Sandwiches the unit Y vector
+	 *
+	 * Second column of rotation matrix in
+	 * https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Conversion_to_and_from_the_matrix_representation
+	 */
+	fun sandwichUnitY(): Vector3 =
+		Vector3(
+			2.0f * (x * y - w * z),
+			w * w - x * x + y * y - z * z,
+			2.0f * (y * z + w * x),
+		)
+
+	/**
+	 * Sandwiches the unit Z vector
+	 *
+	 * Third column of rotation matrix in
+	 * https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Conversion_to_and_from_the_matrix_representation
+	 */
+	fun sandwichUnitZ(): Vector3 =
+		Vector3(
+			2.0f * (x * z + w * y),
+			2.0f * (y * z - w * x),
+			w * w - x * x - y * y + z * z,
+		)
 
 	/**
 	 * computes this quaternion's unit length rotation axis

--- a/server/core/src/main/java/io/github/axisangles/ktmath/Vector3.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Vector3.kt
@@ -99,6 +99,9 @@ value class Vector3(val x: Float, val y: Float, val z: Float) {
 	 * @return the angle
 	 **/
 	fun angleTo(that: Vector3): Float = atan2(this.cross(that).len(), this.dot(that))
+
+	fun isNear(other: Vector3, maxError: Float = 1e-6f) =
+		abs(x - other.x) <= maxError && abs(y - other.y) <= maxError && abs(z - other.z) <= maxError
 }
 
 operator fun Float.times(that: Vector3): Vector3 = that * this

--- a/server/core/src/test/java/io/github/axisangles/ktmath/QuaternionTest.kt
+++ b/server/core/src/test/java/io/github/axisangles/ktmath/QuaternionTest.kt
@@ -181,6 +181,24 @@ class QuaternionTest {
 	}
 
 	@Test
+	fun sandwichUnitX() {
+		val q = Quaternion(0.34f, 0.223f, -0.8f, -0.7f).unit()
+		assertTrue(q.sandwichUnitX().isNear(q.sandwich(Vector3.POS_X)))
+	}
+
+	@Test
+	fun sandwichUnitY() {
+		val q = Quaternion(0.34f, 0.223f, -0.8f, -0.7f).unit()
+		assertTrue(q.sandwichUnitY().isNear(q.sandwich(Vector3.POS_Y)))
+	}
+
+	@Test
+	fun sandwichUnitZ() {
+		val q = Quaternion(0.34f, 0.223f, -0.8f, -0.7f).unit()
+		assertTrue(q.sandwichUnitZ().isNear(q.sandwich(Vector3.POS_Z)))
+	}
+
+	@Test
 	fun axis() {
 		val v1 = Quaternion(0f, Quaternion(1f, 2f, 3f, 4f).axis())
 		val v2 = Quaternion(0f, Vector3(0.37139067f, 0.557086f, 0.74278134f))


### PR DESCRIPTION
Add small yaw rotations to keep trackers aligned. Stay Aligned applies small yaw corrects every server tick. It can successfully keep the user aligned in many poses including standing, sitting and lying down.

This feature has two primary ideas:
1. If the player is not moving, the tracker yaws should not be changing.
2. If the player is moving, on average, the player will be in their relaxed pose.

Every server tick, Stay Aligned picked a tracker, calculates an error based on 3 forces (locked trackers, centering force, and neighbor trackers), and uses gradient descent to nudge the tracker's yaw.

Main classes:
1. `StayAligned`: Entry point of Stay Aligned that is called from `HumanSkeleton`
2. `AdjustTrackerYaw`: Performs the gradient descent
3. `LockedErrorVisitor`, `CenterErrorVisitor` and `NeighborErrorVisitor` calculates the errors for gradient descent
4. `StayAlignedTrackerState`: Tracks the Stay Aligned state per tracker

Supporting classes:
1. `TrackerSkeleton`: Visits trackers, while providing neighboring trackers
2. `TrackerPose` and `TrackerSkeletonPose`: Detects the pose of the player from tracker orientations
3. `RestDetector`: Detects when a tracker is at rest

![image](https://github.com/user-attachments/assets/b35c4c14-cca7-4208-8e4d-5ad6b3f95184)
![image](https://github.com/user-attachments/assets/1ffecb31-08c4-48da-9afc-11f671afaadf)

TODO: For the actual release, we should make a wizard for detecting the relaxed body angles.

https://github.com/SlimeVR/SolarXR-Protocol/pull/157