### PR TITLE
Use only auto calibarations during the onboarding

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -736,7 +736,7 @@ onboarding-wifi_creds-password =
 onboarding-reset_tutorial-back = Go Back to Mounting calibration
 onboarding-reset_tutorial = Reset tutorial
 onboarding-reset_tutorial-explanation = While you use your trackers they might get out of alignment because of IMU yaw drift, or because you might have moved them physically. You have several ways to fix this.
-onboarding-reset_tutorial-skip = Skip step
+onboarding-reset_tutorial-next = Got it!
 # Cares about multiline
 onboarding-reset_tutorial-0 = Tap { $taps } times the highlighted tracker for triggering yaw reset.
 

--- a/gui/src/components/onboarding/pages/ResetTutorial.tsx
+++ b/gui/src/components/onboarding/pages/ResetTutorial.tsx
@@ -143,12 +143,12 @@ export function ResetTutorialPage() {
                 setCurIndex(curIndex + 1);
               }}
             >
-              {l10n.getString('onboarding-reset_tutorial-skip')}
+              {l10n.getString('onboarding-reset_tutorial-next')}
             </Button>
 
             <Button
               variant="primary"
-              to="/onboarding/body-proportions/choose"
+              to="/onboarding/body-proportions/auto"
               className={classNames(
                 'ml-auto',
                 order.length > curIndex + 1 && 'hidden'

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/PutTrackersOn.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/PutTrackersOn.tsx
@@ -54,7 +54,11 @@ export function PutTrackersOnStep({
           <div className="flex gap-3 mobile:justify-between">
             <Button
               variant={variant === 'onboarding' ? 'secondary' : 'tertiary'}
-              to="/onboarding/body-proportions/choose"
+              to={
+                variant === 'alone'
+                  ? '/onboarding/body-proportions/choose'
+                  : '/onboarding/reset-tutorial'
+              }
               state={{ alonePage: variant === 'alone' }}
             >
               {l10n.getString('onboarding-automatic_proportions-prev_step')}

--- a/gui/src/components/onboarding/pages/mounting/mounting-steps/PutTrackersOn.tsx
+++ b/gui/src/components/onboarding/pages/mounting/mounting-steps/PutTrackersOn.tsx
@@ -54,7 +54,11 @@ export function PutTrackersOnStep({
           <div className="flex gap-3 mobile:justify-between">
             <Button
               variant={variant === 'onboarding' ? 'secondary' : 'tertiary'}
-              to="/onboarding/mounting/choose"
+              to={
+                variant === 'alone'
+                  ? '/onboarding/mounting/choose'
+                  : '/onboarding/trackers-assign'
+              }
               state={{ alonePage: variant === 'alone' }}
             >
               {l10n.getString('onboarding-automatic_mounting-prev_step')}

--- a/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
+++ b/gui/src/components/onboarding/pages/trackers-assign/TrackerAssignment.tsx
@@ -322,7 +322,7 @@ export function TrackersAssignPage() {
                     </Button>
                     <Button
                       variant="primary"
-                      to="/onboarding/mounting/choose"
+                      to="/onboarding/mounting/auto"
                       disabled={
                         assignedTrackers.length === 0 && trackers.length > 0
                       }


### PR DESCRIPTION
Both mounting and autobone are now pretty good.
This PR aim to reduce the amount of steps and simplify the onboarding process for new users.

This is done by removing the option to choose between manual or automatic during the onboarding, and now defaulting to automatic.
This is done while keeping the options to use manual proportions and mounting after the onboarding, like it was before.

