### PR TITLE
Updates nodeOffset when body proportions change

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
@@ -156,14 +156,8 @@ class SkeletonConfigManager(
 	}
 
 	protected fun setNodeOffset(nodeOffset: BoneType, x: Float, y: Float, z: Float) {
-		var offset = nodeOffsets[nodeOffset]
-
-		if (offset == null) {
-			offset = Vector3(x, y, z)
-			nodeOffsets[nodeOffset] = offset
-		} else {
-			offset = Vector3(x, y, z)
-		}
+		val offset = Vector3(x, y, z)
+		nodeOffsets[nodeOffset] = offset
 
 		// Updates in skeleton
 		humanPoseManager?.updateNodeOffset(nodeOffset, offset)


### PR DESCRIPTION
After a user changes the body proportions, when a tracker connects or disconnects, the skeleton reverts back to the original skeleton. This is because nodeOffset is not updated when the user changes the body proportions, and stores the value at startup. When a tracker connects or disconnects, updateNodeOffsetsInSkeleton overwrites the skeleton's node offsets using the original values. This causes the skeleton to revert back to the original skeleton.

Fixes https://github.com/SlimeVR/SlimeVR-Server/issues/1298