### PR TITLE
Use bones for AutoBone error calculation

### DIFF
--- a/server/core/src/main/java/dev/slimevr/autobone/errors/FootHeightOffsetError.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/errors/FootHeightOffsetError.kt
@@ -1,9 +1,9 @@
 package dev.slimevr.autobone.errors
 
 import dev.slimevr.autobone.AutoBoneStep
+import dev.slimevr.tracking.processor.BoneType
 import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
-import dev.slimevr.tracking.trackers.Tracker
-import dev.slimevr.tracking.trackers.TrackerRole
+import io.github.axisangles.ktmath.Vector3
 import kotlin.math.*
 
 // The offset between the height both feet at one instant and over time
@@ -15,32 +15,31 @@ class FootHeightOffsetError : IAutoBoneError {
 	)
 
 	companion object {
-		fun getSlideError(skeleton1: HumanSkeleton, skeleton2: HumanSkeleton): Float {
-			val leftTracker1: Tracker = skeleton1.getComputedTracker(TrackerRole.LEFT_FOOT)
-			val rightTracker1: Tracker = skeleton1.getComputedTracker(TrackerRole.RIGHT_FOOT)
-			val leftTracker2: Tracker = skeleton2.getComputedTracker(TrackerRole.LEFT_FOOT)
-			val rightTracker2: Tracker = skeleton2.getComputedTracker(TrackerRole.RIGHT_FOOT)
-			return getFootHeightError(leftTracker1, rightTracker1, leftTracker2, rightTracker2)
-		}
+		fun getSlideError(skeleton1: HumanSkeleton, skeleton2: HumanSkeleton): Float = getFootHeightError(
+			skeleton1.getBone(BoneType.LEFT_LOWER_LEG).getTailPosition(),
+			skeleton1.getBone(BoneType.RIGHT_LOWER_LEG).getTailPosition(),
+			skeleton2.getBone(BoneType.LEFT_LOWER_LEG).getTailPosition(),
+			skeleton2.getBone(BoneType.RIGHT_LOWER_LEG).getTailPosition(),
+		)
 
 		fun getFootHeightError(
-			leftTracker1: Tracker,
-			rightTracker1: Tracker,
-			leftTracker2: Tracker,
-			rightTracker2: Tracker,
+			leftFoot1: Vector3,
+			rightFoot1: Vector3,
+			leftFoot2: Vector3,
+			rightFoot2: Vector3,
 		): Float {
-			val leftFoot1 = leftTracker1.position.y
-			val rightFoot1 = rightTracker1.position.y
-			val leftFoot2 = leftTracker2.position.y
-			val rightFoot2 = rightTracker2.position.y
+			val lFoot1Y = leftFoot1.y
+			val rFoot1Y = rightFoot1.y
+			val lFoot2Y = leftFoot2.y
+			val rFoot2Y = rightFoot2.y
 
 			// Compute all combinations of heights
-			val dist1 = abs(leftFoot1 - rightFoot1)
-			val dist2 = abs(leftFoot1 - leftFoot2)
-			val dist3 = abs(leftFoot1 - rightFoot2)
-			val dist4 = abs(rightFoot1 - leftFoot2)
-			val dist5 = abs(rightFoot1 - rightFoot2)
-			val dist6 = abs(leftFoot2 - rightFoot2)
+			val dist1 = abs(lFoot1Y - rFoot1Y)
+			val dist2 = abs(lFoot1Y - lFoot2Y)
+			val dist3 = abs(lFoot1Y - rFoot2Y)
+			val dist4 = abs(rFoot1Y - lFoot2Y)
+			val dist5 = abs(rFoot1Y - rFoot2Y)
+			val dist6 = abs(lFoot2Y - rFoot2Y)
 
 			// Divide by 12 (6 values * 2 to halve) to halve and average, it's
 			// halved because you want to approach a midpoint, not the other point

--- a/server/core/src/main/java/dev/slimevr/autobone/errors/OffsetSlideError.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/errors/OffsetSlideError.kt
@@ -1,9 +1,9 @@
 package dev.slimevr.autobone.errors
 
 import dev.slimevr.autobone.AutoBoneStep
+import dev.slimevr.tracking.processor.BoneType
 import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
-import dev.slimevr.tracking.trackers.Tracker
-import dev.slimevr.tracking.trackers.TrackerRole
+import io.github.axisangles.ktmath.Vector3
 import kotlin.math.*
 
 // The change in distance between both of the ankles over time
@@ -15,24 +15,19 @@ class OffsetSlideError : IAutoBoneError {
 	)
 
 	companion object {
-		fun getSlideError(skeleton1: HumanSkeleton, skeleton2: HumanSkeleton): Float {
-			val leftTracker1: Tracker = skeleton1.getComputedTracker(TrackerRole.LEFT_FOOT)
-			val rightTracker1: Tracker = skeleton1.getComputedTracker(TrackerRole.RIGHT_FOOT)
-			val leftTracker2: Tracker = skeleton2.getComputedTracker(TrackerRole.LEFT_FOOT)
-			val rightTracker2: Tracker = skeleton2.getComputedTracker(TrackerRole.RIGHT_FOOT)
-			return getSlideError(leftTracker1, rightTracker1, leftTracker2, rightTracker2)
-		}
+		fun getSlideError(skeleton1: HumanSkeleton, skeleton2: HumanSkeleton): Float = getSlideError(
+			skeleton1.getBone(BoneType.LEFT_LOWER_LEG).getTailPosition(),
+			skeleton1.getBone(BoneType.RIGHT_LOWER_LEG).getTailPosition(),
+			skeleton2.getBone(BoneType.LEFT_LOWER_LEG).getTailPosition(),
+			skeleton2.getBone(BoneType.RIGHT_LOWER_LEG).getTailPosition(),
+		)
 
 		fun getSlideError(
-			leftTracker1: Tracker,
-			rightTracker1: Tracker,
-			leftTracker2: Tracker,
-			rightTracker2: Tracker,
+			leftFoot1: Vector3,
+			rightFoot1: Vector3,
+			leftFoot2: Vector3,
+			rightFoot2: Vector3,
 		): Float {
-			val leftFoot1 = leftTracker1.position
-			val rightFoot1 = rightTracker1.position
-			val leftFoot2 = leftTracker2.position
-			val rightFoot2 = rightTracker2.position
 			val slideDist1 = (rightFoot1 - leftFoot1).len()
 			val slideDist2 = (rightFoot2 - leftFoot2).len()
 			val slideDist3 = (rightFoot2 - leftFoot1).len()

--- a/server/core/src/main/java/dev/slimevr/autobone/errors/SlideError.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/errors/SlideError.kt
@@ -1,9 +1,9 @@
 package dev.slimevr.autobone.errors
 
 import dev.slimevr.autobone.AutoBoneStep
+import dev.slimevr.tracking.processor.Bone
+import dev.slimevr.tracking.processor.BoneType
 import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
-import dev.slimevr.tracking.trackers.Tracker
-import dev.slimevr.tracking.trackers.TrackerRole
 
 // The change in position of the ankle over time
 class SlideError : IAutoBoneError {
@@ -17,26 +17,26 @@ class SlideError : IAutoBoneError {
 		fun getSlideError(skeleton1: HumanSkeleton, skeleton2: HumanSkeleton): Float {
 			// Calculate and average between both feet
 			return (
-				getSlideError(skeleton1, skeleton2, TrackerRole.LEFT_FOOT) +
-					getSlideError(skeleton1, skeleton2, TrackerRole.RIGHT_FOOT)
+				getSlideError(skeleton1, skeleton2, BoneType.LEFT_LOWER_LEG) +
+					getSlideError(skeleton1, skeleton2, BoneType.RIGHT_LOWER_LEG)
 				) / 2f
 		}
 
 		fun getSlideError(
 			skeleton1: HumanSkeleton,
 			skeleton2: HumanSkeleton,
-			trackerRole: TrackerRole,
+			bone: BoneType,
 		): Float {
 			// Calculate and average between both feet
 			return getSlideError(
-				skeleton1.getComputedTracker(trackerRole),
-				skeleton2.getComputedTracker(trackerRole),
+				skeleton1.getBone(bone),
+				skeleton2.getBone(bone),
 			)
 		}
 
-		fun getSlideError(tracker1: Tracker, tracker2: Tracker): Float {
+		fun getSlideError(bone1: Bone, bone2: Bone): Float {
 			// Return the midpoint distance
-			return (tracker2.position - tracker1.position).len() / 2f
+			return (bone2.getTailPosition() - bone1.getTailPosition()).len() / 2f
 		}
 	}
 }


### PR DESCRIPTION
Currently it uses feet trackers, though it seems like those are at the tail node of the foot now. This will haunt me.