### PR TITLE
Accept rest calibration in sensor info packet

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
@@ -225,8 +225,9 @@ data class UDPPacket15SensorInfo(
 	var sensorStatus: Int = 0,
 	var sensorType: IMUType = IMUType.UNKNOWN,
 	var sensorConfig: SensorConfig? = null,
-	var trackerDataType: TrackerDataType = TrackerDataType.ROTATION,
+	var hasCompletedRestCalibration: Boolean? = null,
 	var trackerPosition: TrackerPosition? = null,
+	var trackerDataType: TrackerDataType = TrackerDataType.ROTATION,
 ) : UDPPacket(15),
 	SensorSpecificPacket {
 	override var sensorId = 0
@@ -239,6 +240,7 @@ data class UDPPacket15SensorInfo(
 		if (buf.remaining() > 1) {
 			sensorConfig = SensorConfig(buf.getShort().toUShort())
 		}
+		if (buf.remaining() > 0) hasCompletedRestCalibration = buf.get().toInt() and 0xFF != 0
 		if (buf.remaining() > 0) trackerPosition = TrackerPosition.getById(buf.get().toInt() and 0xFF)
 		if (buf.remaining() > 0) trackerDataType = TrackerDataType.getById(buf.get().toUInt() and 0xFFu) ?: TrackerDataType.ROTATION
 	}


### PR DESCRIPTION
This PR is to go with https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/394

From firmware v0.5.3 to v0.5.4, we use a byte order for the packet SensorInfo that has the rest calibration state included before the default tracker position and tracking type. I think we should go this route since it will keep all the already released firmware functional, though we will need to correct the main branch of firmware for it.

Fixes #1313