### PR TITLE
Fix erroneous sign extension in Protobuf IPC packet handling

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 	public final String socketPath;
 	public final UnixDomainSocketAddress socketAddress;
-	private final ByteBuffer dst = ByteBuffer.allocate(2048);
+	private final ByteBuffer dst = ByteBuffer.allocate(2048).order(ByteOrder.LITTLE_ENDIAN);
 	private final ByteBuffer src = ByteBuffer.allocate(2048).order(ByteOrder.LITTLE_ENDIAN);
 
 	private ServerSocketChannel server;
@@ -163,7 +163,7 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 		// if buffer has 4 bytes at least, we got the message size!
 		// processs all messages
 		while (dst.position() >= 4) {
-			int messageLength = dst.get(0) | dst.get(1) << 8 | dst.get(2) << 16 | dst.get(3) << 24;
+			int messageLength = dst.getInt(0);
 			if (messageLength > 1024) { // Overflow
 				LogManager
 					.severe(

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
@@ -181,10 +181,10 @@ public class WindowsNamedPipeBridge extends SteamVRBridge {
 			if (bytesAvailable.getValue() < 4) {
 				return readAnything; // Wait for more data
 			}
-			int messageLength = (buffArray[3] << 24)
-				| (buffArray[2] << 16)
-				| (buffArray[1] << 8)
-				| buffArray[0];
+			int messageLength = (Byte.toUnsignedInt(buffArray[3]) << 24)
+				| (Byte.toUnsignedInt(buffArray[2]) << 16)
+				| (Byte.toUnsignedInt(buffArray[1]) << 8)
+				| Byte.toUnsignedInt(buffArray[0]);
 			if (messageLength > 1024) { // Overflow
 				setPipeError("Pipe overflow. Message length: " + messageLength);
 				return readAnything;


### PR DESCRIPTION
The message length parsing used the signed `byte` datatype, which caused any packet with length containing a byte >=128 (`(length & 0x808080) != 0`) to extend into a negative number. This bug was present in both the Windows and Linux Protobuf bridges, but *not* the Linux SolarXR bridge.