### PR TITLE
Update firmware constants and translations

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -86,7 +86,15 @@ board_type-ESP01 = ESP-01
 board_type-SLIMEVR = SlimeVR
 board_type-LOLIN_C3_MINI = Lolin C3 Mini
 board_type-BEETLE32C3 = Beetle ESP32-C3
-board_type-ES32C3DEVKITM1 = Espressif ESP32-C3 DevKitM-1
+board_type-ESP32C3DEVKITM1 = Espressif ESP32-C3 DevKitM-1
+board_type-OWOTRACK = owoTrack
+board_type-WRANGLER = Wrangler Joycons
+board_type-MOCOPI = Sony Mocopi
+board_type-WEMOSWROOM02 = Wemos Wroom-02 D1 Mini
+board_type-XIAO_ESP32C3 = Seeed Studio XIAO ESP32C3
+board_type-HARITORA = Haritora
+board_type-ESP32C6DEVKITC1 = Espressif ESP32-C6 DevKitC-1
+board_type-GLOVE_IMU_SLIMEVR_DEV = SlimeVR Dev IMU Glove
 
 ## Proportions
 skeleton_bone-NONE = None

--- a/gui/src/components/firmware-tool/FlashingMethodStep.tsx
+++ b/gui/src/components/firmware-tool/FlashingMethodStep.tsx
@@ -199,7 +199,12 @@ function OTADevicesList({
       if (
         hardwareInfo?.officialBoardType === BoardType.SLIMEVR_LEGACY ||
         hardwareInfo?.officialBoardType === BoardType.SLIMEVR_DEV ||
-        hardwareInfo?.officialBoardType === BoardType.CUSTOM
+        hardwareInfo?.officialBoardType === BoardType.CUSTOM ||
+        hardwareInfo?.officialBoardType === BoardType.OWOTRACK ||
+        hardwareInfo?.officialBoardType === BoardType.WRANGLER ||
+        hardwareInfo?.officialBoardType === BoardType.MOCOPI ||
+        hardwareInfo?.officialBoardType === BoardType.HARITORA ||
+        hardwareInfo?.officialBoardType === BoardType.DEV_RESERVED
       )
         return false;
 

--- a/gui/src/hooks/firmware-tool.ts
+++ b/gui/src/hooks/firmware-tool.ts
@@ -52,7 +52,16 @@ export const boardTypeToFirmwareToolBoardType: Record<
   [BoardType.SLIMEVR]: 'BOARD_SLIMEVR',
   [BoardType.LOLIN_C3_MINI]: 'BOARD_LOLIN_C3_MINI',
   [BoardType.BEETLE32C3]: 'BOARD_BEETLE32C3',
-  [BoardType.ES32C3DEVKITM1]: 'BOARD_ES32C3DEVKITM1',
+  [BoardType.ESP32C3DEVKITM1]: 'BOARD_ES32C3DEVKITM1',
+  [BoardType.OWOTRACK]: null,
+  [BoardType.WRANGLER]: null,
+  [BoardType.MOCOPI]: null,
+  [BoardType.WEMOSWROOM02]: null,
+  [BoardType.XIAO_ESP32C3]: null,
+  [BoardType.HARITORA]: null,
+  [BoardType.ESP32C6DEVKITC1]: null,
+  [BoardType.GLOVE_IMU_SLIMEVR_DEV]: null,
+  [BoardType.DEV_RESERVED]: null,
 };
 
 export const firmwareToolToBoardType: Record<CreateBoardConfigDTO['type'], BoardType> =

--- a/gui/src/hooks/firmware-tool.ts
+++ b/gui/src/hooks/firmware-tool.ts
@@ -39,7 +39,14 @@ export const boardTypeToFirmwareToolBoardType: Record<
     BoardType,
     // This boards will not be handled by the firmware tool.
     // These are either impossible to compile automatically or deprecated
-    BoardType.CUSTOM | BoardType.SLIMEVR_DEV | BoardType.SLIMEVR_LEGACY
+    | BoardType.CUSTOM
+    | BoardType.SLIMEVR_DEV
+    | BoardType.SLIMEVR_LEGACY
+    | BoardType.OWOTRACK
+    | BoardType.WRANGLER
+    | BoardType.MOCOPI
+    | BoardType.HARITORA
+    | BoardType.DEV_RESERVED
   >,
   CreateBoardConfigDTO['type'] | null
 > = {
@@ -53,15 +60,10 @@ export const boardTypeToFirmwareToolBoardType: Record<
   [BoardType.LOLIN_C3_MINI]: 'BOARD_LOLIN_C3_MINI',
   [BoardType.BEETLE32C3]: 'BOARD_BEETLE32C3',
   [BoardType.ESP32C3DEVKITM1]: 'BOARD_ES32C3DEVKITM1',
-  [BoardType.OWOTRACK]: null,
-  [BoardType.WRANGLER]: null,
-  [BoardType.MOCOPI]: null,
   [BoardType.WEMOSWROOM02]: null,
   [BoardType.XIAO_ESP32C3]: null,
-  [BoardType.HARITORA]: null,
   [BoardType.ESP32C6DEVKITC1]: null,
   [BoardType.GLOVE_IMU_SLIMEVR_DEV]: null,
-  [BoardType.DEV_RESERVED]: null,
 };
 
 export const firmwareToolToBoardType: Record<CreateBoardConfigDTO['type'], BoardType> =

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -17,6 +17,9 @@ enum class IMUType(val id: UInt) {
 	LSM6DSV(13u),
 	LSM6DSO(14u),
 	LSM6DSR(15u),
+	ICM45686(16u),
+	ICM45605(17u),
+	ADC_RESISTANCE(18u),
 	DEV_RESERVED(250u),
 	;
 
@@ -43,13 +46,15 @@ enum class BoardType(val id: UInt) {
 	SLIMEVR(9u),
 	LOLIN_C3_MINI(10u),
 	BEETLE32C3(11u),
-	ES32C3DEVKITM1(12u),
+	ESP32C3DEVKITM1(12u),
 	OWOTRACK(13u),
 	WRANGLER(14u),
 	MOCOPI(15u),
 	WEMOSWROOM02(16u),
 	XIAO_ESP32C3(17u),
 	HARITORA(18u),
+	ESP32C6DEVKITC1(19u),
+	GLOVE_IMU_SLIMEVR_DEV(20u),
 	DEV_RESERVED(250u),
 	;
 
@@ -68,13 +73,15 @@ enum class BoardType(val id: UInt) {
 		SLIMEVR -> "SlimeVR"
 		LOLIN_C3_MINI -> "Lolin C3 Mini"
 		BEETLE32C3 -> "Beetle ESP32-C3"
-		ES32C3DEVKITM1 -> "Espressif ESP32-C3 DevKitM-1"
+		ESP32C3DEVKITM1 -> "Espressif ESP32-C3 DevKitM-1"
 		OWOTRACK -> "owoTrack"
 		WRANGLER -> "Wrangler Joycons"
 		MOCOPI -> "Sony Mocopi"
 		WEMOSWROOM02 -> "Wemos Wroom-02 D1 Mini"
 		XIAO_ESP32C3 -> "Seeed Studio XIAO ESP32C3"
 		HARITORA -> "Haritora"
+		ESP32C6DEVKITC1 -> "Espressif ESP32-C6 DevKitC-1"
+		GLOVE_IMU_SLIMEVR_DEV -> "SlimeVR Dev IMU Glove"
 		DEV_RESERVED -> "Prototype"
 	}
 


### PR DESCRIPTION
Updates definitions based on the latest [consts.h](https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/main/src/consts.h) from firmware.
https://github.com/SlimeVR/SolarXR-Protocol/pull/158
https://github.com/SlimeVR/SolarXR-Protocol/pull/159

The firmware tool API side needs to be updated for the board rename and additional entries, but this should suffice for now.
Relevant firmware tool PR: https://github.com/SlimeVR/SlimeVR-Firmware-WebBuilder/pull/26