### PR TITLE
Simplify reset code

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -58,7 +58,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		}
 
 	// Reference adjustment quats
-	private var gyroFix = Quaternion.IDENTITY
 	private var attachmentFix = Quaternion.IDENTITY
 	var mountRotFix = Quaternion.IDENTITY
 		private set
@@ -71,7 +70,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	private var yawResetSmoothTimeRemain = 0.0f
 
 	// Zero-reference/identity adjustment quats for IMU debugging
-	private var gyroFixNoMounting = Quaternion.IDENTITY
 	private var attachmentFixNoMounting = Quaternion.IDENTITY
 	private var yawFixZeroReference = Quaternion.IDENTITY
 	private var tposeDownFix = Quaternion.IDENTITY
@@ -164,7 +162,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		if (!tracker.isHmd || tracker.trackerPosition != TrackerPosition.HEAD) {
 			rot *= mountingOrientation
 		}
-		rot = gyroFix * rot
 		rot *= attachmentFix
 		rot = mountRotFix.inv() * (rot * mountRotFix)
 		rot *= tposeDownFix
@@ -179,7 +176,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	 */
 	private fun adjustToIdentity(rotation: Quaternion): Quaternion {
 		var rot = rotation
-		rot = gyroFixNoMounting * rot
 		rot *= attachmentFixNoMounting
 		rot = yawFixZeroReference * rot
 		rot = constraintFix * rot
@@ -244,22 +240,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		// Adjust raw rotation to mountingOrientation
 		val mountingAdjustedRotation = tracker.getRawRotation() * mountingOrientation
 
-		// Gyrofix
-		if (tracker.needsMounting || (tracker.trackerPosition == TrackerPosition.HEAD && !tracker.isHmd)) {
-			gyroFix = if (tracker.isComputed) {
-				fixGyroscope(tracker.getRawRotation())
-			} else {
-				fixGyroscope(mountingAdjustedRotation * tposeDownFix)
-			}
-		}
-
-		// Mounting for computed trackers
-		if (tracker.isComputed && tracker.trackerPosition != TrackerPosition.HEAD) {
-			// Set mounting to the reference's yaw so that a computed
-			// tracker goes forward according to the head tracker.
-			mountRotFix = getYawQuaternion(reference)
-		}
-
 		// Attachment fix
 		attachmentFix = if (tracker.trackerPosition == TrackerPosition.HEAD && tracker.isHmd) {
 			if (resetHmdPitch) {
@@ -272,16 +252,20 @@ class TrackerResetsHandler(val tracker: Tracker) {
 				// Don't reset the HMD at all
 				Quaternion.IDENTITY
 			}
+		} else if (!tracker.isComputed) {
+			// Align the pitch and roll axes with a zero reference-space
+			fixAttachment(mountingAdjustedRotation * tposeDownFix)
 		} else {
-			fixAttachment(mountingAdjustedRotation)
+			// If the tracker is computed, then we can assume a zero reference-space
+			Quaternion.IDENTITY
 		}
 
-		// Rotate attachmentFix by 180 degrees as a workaround for t-pose (down)
-		if (tposeDownFix != Quaternion.IDENTITY && tracker.needsMounting) {
-			attachmentFix *= HalfHorizontal
+		// Mounting for computed trackers
+		if (tracker.isComputed && tracker.trackerPosition != TrackerPosition.HEAD) {
+			// Set mounting to the reference's yaw so that a computed
+			// tracker goes forward according to the head tracker.
+			mountRotFix = getYawQuaternion(reference)
 		}
-
-		makeIdentityAdjustmentQuatsFull()
 
 		// Don't adjust yaw if head and computed
 		if (tracker.trackerPosition != TrackerPosition.HEAD || !tracker.isComputed) {
@@ -289,8 +273,10 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			yawResetSmoothTimeRemain = 0.0f
 		}
 
+		// Separate from any values computed here
+		makeIdentityAdjustmentQuatsFull()
+		// Compute the difference between the old rotation and new rotation
 		calculateDrift(oldRot)
-
 		postProcessResetFull()
 	}
 
@@ -366,7 +352,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 
 		// Get the current calibrated rotation
 		var rotBuf = adjustToDrift(tracker.getRawRotation() * mountingOrientation)
-		rotBuf = gyroFix * rotBuf
 		rotBuf *= attachmentFix
 		rotBuf = yawFix * rotBuf
 
@@ -425,11 +410,10 @@ class TrackerResetsHandler(val tracker: Tracker) {
 
 	private fun fixGyroscope(sensorRotation: Quaternion): Quaternion = getYawQuaternion(sensorRotation).inv()
 
-	private fun fixAttachment(sensorRotation: Quaternion): Quaternion = (gyroFix * sensorRotation).inv()
+	private fun fixAttachment(sensorRotation: Quaternion): Quaternion = (fixGyroscope(sensorRotation) * sensorRotation).inv()
 
 	private fun fixYaw(sensorRotation: Quaternion, reference: Quaternion): Quaternion {
-		var rot = gyroFix * sensorRotation
-		rot *= attachmentFix
+		var rot = sensorRotation * attachmentFix
 		rot = mountRotFix.inv() * (rot * mountRotFix)
 		rot = getYawQuaternion(rot)
 		return rot.inv() * reference.project(Vector3.POS_Y).unit()
@@ -444,14 +428,12 @@ class TrackerResetsHandler(val tracker: Tracker) {
 
 	private fun makeIdentityAdjustmentQuatsFull() {
 		val sensorRotation = tracker.getRawRotation()
-		gyroFixNoMounting = fixGyroscope(sensorRotation)
-		attachmentFixNoMounting = (gyroFixNoMounting * sensorRotation).inv()
+		attachmentFixNoMounting = fixAttachment(sensorRotation)
 		yawFixZeroReference = Quaternion.IDENTITY
 	}
 
 	private fun makeIdentityAdjustmentQuatsYaw() {
 		var sensorRotation = tracker.getRawRotation()
-		sensorRotation = gyroFixNoMounting * sensorRotation
 		sensorRotation *= attachmentFixNoMounting
 		yawFixZeroReference = fixGyroscope(sensorRotation)
 	}


### PR DESCRIPTION
Our current reset code is a mess, we can absolutely annihilate `gyroFix` and leave it to `yawFix` to handle the yaw offset. I also want to remove `tposeDownFix`, but haven't done so yet.

There's also some really confusing logic between computed trackers, the head tracker, and different reset poses. I tackled a lot of that already, but I think there's more that can be cleaned up.

Also see #1320 for explanations of the different fields.