### PR TITLE
Estimate full height and clarify height config translations

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -1027,10 +1027,10 @@ onboarding-automatic_proportions-requirements-descriptionv2 =
     Your tracking is working and is accurately representing your movements (ex. you have performed a full reset and they move the right direction when kicking, bending over, sitting, etc).
 onboarding-automatic_proportions-requirements-next = I have read the requirements
 
-onboarding-automatic_proportions-check_height-title-v2 = Measure your height
+onboarding-automatic_proportions-check_height-title-v3 = Measure your headset height
 onboarding-automatic_proportions-check_height-description-v2 = Your headset (HMD) height should be slightly less than your full height, as headsets measure your eye height. This measurement will be used as a baseline for your body proportions.
 # All the text is in bold!
-onboarding-automatic_proportions-check_height-calculation_warning-v2 = Start measuring while standing <u>upright</u> to calculate your height. Be careful to not raise your hands higher than your headset, as they may affect the measurement!
+onboarding-automatic_proportions-check_height-calculation_warning-v3 = Start measuring while standing <u>upright</u> to measure your height. Be careful to not raise your hands higher than your headset, as they may affect the measurement!
 onboarding-automatic_proportions-check_height-guardian_tip = If you are using a standalone VR headset, make sure to have your guardian /
     boundary turned on so that your height is correct!
 # Context is that the height is unknown
@@ -1045,9 +1045,10 @@ onboarding-automatic_proportions-check_height-next_step = Use headset height
 onboarding-automatic_proportions-check_floor_height-title = Measure your floor height (optional)
 onboarding-automatic_proportions-check_floor_height-description = In some cases, your floor height may not be set correctly by your headset, causing the headset height to be measured as higher than it should be. You can measure the "height" of your floor to correct your headset height.
 # All the text is in bold!
-onboarding-automatic_proportions-check_floor_height-calculation_warning = If you are sure that your floor height is correct, you can skip this step.
+onboarding-automatic_proportions-check_floor_height-calculation_warning-v2 = Start measuring and put a controller against your floor to measure its height. If you are sure that your floor height is correct, you can skip this step.
 # Shows an element below it
 onboarding-automatic_proportions-check_floor_height-floor_height = Your floor height is:
+onboarding-automatic_proportions-check_floor_height-full_height = Your estimated full height is:
 onboarding-automatic_proportions-check_floor_height-measure-start = Start measuring
 onboarding-automatic_proportions-check_floor_height-measure-stop = Stop measuring
 onboarding-automatic_proportions-check_floor_height-measure-reset = Retry measuring

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckFloorHeight.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckFloorHeight.tsx
@@ -75,7 +75,7 @@ export function CheckFloorHeightStep({
                 )}
               </Typography>
               <Localized
-                id="onboarding-automatic_proportions-check_floor_height-calculation_warning"
+                id="onboarding-automatic_proportions-check_floor_height-calculation_warning-v2"
                 elems={{ u: <span className="underline"></span> }}
               >
                 <Typography color="secondary" bold>
@@ -129,6 +129,16 @@ export function CheckFloorHeightStep({
                         'onboarding-automatic_proportions-check_height-unknown'
                       )
                     : mFormat.format(floorHeight)}
+                </Typography>
+                <Typography>
+                  {l10n.getString(
+                    'onboarding-automatic_proportions-check_floor_height-full_height'
+                  )}
+                </Typography>
+                <Typography>
+                  {mFormat.format(
+                    ((hmdHeight ?? 0) - (floorHeight ?? 0)) / 0.936
+                  )}
                 </Typography>
               </div>
             </div>

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckHeight.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckHeight.tsx
@@ -54,7 +54,7 @@ export function CheckHeightStep({
           <div className="flex flex-grow flex-col gap-4">
             <Typography variant="main-title" bold>
               {l10n.getString(
-                'onboarding-automatic_proportions-check_height-title-v2'
+                'onboarding-automatic_proportions-check_height-title-v3'
               )}
             </Typography>
             <div>
@@ -64,7 +64,7 @@ export function CheckHeightStep({
                 )}
               </Typography>
               <Localized
-                id="onboarding-automatic_proportions-check_height-calculation_warning-v2"
+                id="onboarding-automatic_proportions-check_height-calculation_warning-v3"
                 elems={{ u: <span className="underline"></span> }}
               >
                 <Typography color="secondary" bold>

--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/TooSmolModal.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/TooSmolModal.tsx
@@ -50,7 +50,7 @@ export function TooSmolModal({
             id="onboarding-automatic_proportions-smol_warning"
             elems={{ b: <b></b> }}
             vars={{
-              height: mFormat.format(hmdHeight ?? 0 - (floorHeight ?? 0)),
+              height: mFormat.format((hmdHeight ?? 0) - (floorHeight ?? 0)),
               minHeight: mFormat.format(MIN_HEIGHT),
             }}
           >


### PR DESCRIPTION
This should help make users feel more sure about the measured values and clarifies a few instances of vague wording. I think we should also have a "height config" button somewhere, probably on the manual proportions section next to the reset proportions button?