### PR TITLE
Fix moving average quaternions

### DIFF
--- a/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
@@ -29,7 +29,6 @@ class QuaternionMovingAverage(
 	private var latestQuaternion = IDENTITY
 	private var smoothingQuaternion = IDENTITY
 	private val fpsTimer = if (VRServer.instanceInitialized) VRServer.instance.fpsTimer else NanoTimer()
-	private var frameCounter = 0
 	private var lastAmt = 0f
 
 	init {
@@ -71,21 +70,11 @@ class QuaternionMovingAverage(
 				filteredQuaternion = filteredQuaternion.interpQ(quatBuf, amt)
 			}
 		} else if (type == TrackerFilters.SMOOTHING) {
-			// Increase every update for linear interpolation
-			frameCounter++
-
-			// Calculate the slerp factor based off the smoothFactor and smoothingCounter
-			var amt = smoothFactor * frameCounter
-
-			// Make it framerate-independent
-			amt *= fpsTimer.timePerFrame
-
-			// Be at least last amount to not rollback
-			amt = amt.coerceAtLeast(lastAmt)
-
+			// Calculate the slerp factor based off the last amount and smoothFactor
 			// limit to 1 to not overshoot
-			amt = amt.coerceAtMost(1f)
-
+			val amt = (
+				lastAmt + (smoothFactor * fpsTimer.timePerFrame)
+				).coerceAtMost(1f)
 			lastAmt = amt
 
 			// Smooth towards the target rotation by the slerp factor
@@ -108,7 +97,6 @@ class QuaternionMovingAverage(
 			// Gets and stores the rotation between the last 2 quaternions
 			rotBuffer?.add(latestQuaternion.inv().times(twinQ))
 		} else if (type == TrackerFilters.SMOOTHING) {
-			frameCounter = 0
 			lastAmt = 0f
 			smoothingQuaternion = filteredQuaternion
 		} else {

--- a/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
@@ -120,11 +120,12 @@ class QuaternionMovingAverage(
 
 	@Synchronized
 	fun resetQuats(q: Quaternion) {
-		if (type == TrackerFilters.PREDICTION) {
-			rotBuffer?.clear()
-			latestQuaternion = q
-		}
+		// Clear prediction buffer
+		rotBuffer?.clear()
+		// Reset tracked quaternions
+		latestQuaternion = q
 		filteredQuaternion = q
+		// Set the current quaternion
 		addQuaternion(q)
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
@@ -118,6 +118,7 @@ class QuaternionMovingAverage(
 		latestQuaternion = twinQ
 	}
 
+	@Synchronized
 	fun resetQuats(q: Quaternion) {
 		if (type == TrackerFilters.PREDICTION) {
 			rotBuffer?.clear()

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
@@ -124,160 +124,108 @@ class HumanPoseManager(val server: VRServer?) {
 
 	// #endregion
 	// #region private methods
+	private fun mkTrack(name: String, display: String, pos: TrackerPosition): Tracker = Tracker(
+		null,
+		getNextLocalTrackerId(),
+		name,
+		display,
+		pos,
+		hasPosition = true,
+		hasRotation = true,
+		isInternal = true,
+		isComputed = true,
+		allowFiltering = false,
+		trackRotDirection = false,
+	)
+
 	private fun initializeComputedHumanPoseTracker() {
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://HEAD",
 					"Computed head",
 					TrackerPosition.HEAD,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://CHEST",
 					"Computed chest",
 					TrackerPosition.UPPER_CHEST,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://WAIST",
 					"Computed hip",
 					TrackerPosition.HIP,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://LEFT_KNEE",
 					"Computed left knee",
 					TrackerPosition.LEFT_UPPER_LEG,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://RIGHT_KNEE",
 					"Computed right knee",
 					TrackerPosition.RIGHT_UPPER_LEG,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://LEFT_FOOT",
 					"Computed left foot",
 					TrackerPosition.LEFT_FOOT,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://RIGHT_FOOT",
 					"Computed right foot",
 					TrackerPosition.RIGHT_FOOT,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://LEFT_ELBOW",
 					"Computed left elbow",
 					TrackerPosition.LEFT_UPPER_ARM,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://RIGHT_ELBOW",
 					"Computed right elbow",
 					TrackerPosition.RIGHT_UPPER_ARM,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://LEFT_HAND",
 					"Computed left hand",
 					TrackerPosition.LEFT_HAND,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 
 				),
 			)
 		computedTrackers
 			.add(
-				Tracker(
-					null,
-					getNextLocalTrackerId(),
+				mkTrack(
 					"human://RIGHT_HAND",
 					"Computed right hand",
 					TrackerPosition.RIGHT_HAND,
-					hasPosition = true,
-					hasRotation = true,
-					isInternal = true,
-					isComputed = true,
 				),
 			)
 

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -810,11 +810,6 @@ class HumanSkeleton(
 						var hipRot = it.getRotation()
 						var chestRot = chest.getRotation()
 
-						// Get the rotation relative to where we expect the hip to be
-						if (chestRot.times(FORWARD_QUATERNION).dot(hipRot) < 0.0f) {
-							hipRot = hipRot.unaryMinus()
-						}
-
 						// Interpolate between the chest and the hip
 						chestRot = chestRot.interpQ(hipRot, waistFromChestHipAveraging)
 
@@ -826,15 +821,6 @@ class HumanSkeleton(
 							var leftLegRot = leftUpperLegTracker?.getRotation() ?: IDENTITY
 							var rightLegRot = rightUpperLegTracker?.getRotation() ?: IDENTITY
 							var chestRot = chest.getRotation()
-
-							// Get the rotation relative to where we expect the upper legs to be
-							val expectedUpperLegsRot = chestRot.times(FORWARD_QUATERNION)
-							if (expectedUpperLegsRot.dot(leftLegRot) < 0.0f) {
-								leftLegRot = leftLegRot.unaryMinus()
-							}
-							if (expectedUpperLegsRot.dot(rightLegRot) < 0.0f) {
-								rightLegRot = rightLegRot.unaryMinus()
-							}
 
 							// Interpolate between the pelvis, averaged from the legs, and the chest
 							chestRot = chestRot.interpQ(leftLegRot.lerpQ(rightLegRot, 0.5f), waistFromChestLegsAveraging).unit()
@@ -852,15 +838,6 @@ class HumanSkeleton(
 					var rightLegRot = rightUpperLegTracker?.getRotation() ?: IDENTITY
 					var waistRot = it.getRotation()
 
-					// Get the rotation relative to where we expect the upper legs to be
-					val expectedUpperLegsRot = waistRot.times(FORWARD_QUATERNION)
-					if (expectedUpperLegsRot.dot(leftLegRot) < 0.0f) {
-						leftLegRot = leftLegRot.unaryMinus()
-					}
-					if (expectedUpperLegsRot.dot(rightLegRot) < 0.0f) {
-						rightLegRot = rightLegRot.unaryMinus()
-					}
-
 					// Interpolate between the pelvis, averaged from the legs, and the chest
 					waistRot = waistRot.interpQ(leftLegRot.lerpQ(rightLegRot, 0.5f), hipFromWaistLegsAveraging).unit()
 
@@ -873,15 +850,6 @@ class HumanSkeleton(
 						var leftLegRot = leftUpperLegTracker?.getRotation() ?: IDENTITY
 						var rightLegRot = rightUpperLegTracker?.getRotation() ?: IDENTITY
 						var chestRot = it.getRotation()
-
-						// Get the rotation relative to where we expect the upper legs to be
-						val expectedUpperLegsRot = chestRot.times(FORWARD_QUATERNION)
-						if (expectedUpperLegsRot.dot(leftLegRot) < 0.0f) {
-							leftLegRot = leftLegRot.unaryMinus()
-						}
-						if (expectedUpperLegsRot.dot(rightLegRot) < 0.0f) {
-							rightLegRot = rightLegRot.unaryMinus()
-						}
 
 						// Interpolate between the pelvis, averaged from the legs, and the chest
 						chestRot = chestRot.interpQ(leftLegRot.lerpQ(rightLegRot, 0.5f), hipFromChestLegsAveraging).unit()
@@ -1137,24 +1105,11 @@ class HumanSkeleton(
 		rightKnee: Quaternion,
 		hip: Quaternion,
 	): Quaternion {
-		// Get the knees' rotation relative to where we expect them to be.
-		// The angle between your knees and hip can be over 180 degrees...
-		var leftKneeRot = leftKnee
-		var rightKneeRot = rightKnee
-
-		val kneeRot = hip.times(FORWARD_QUATERNION)
-		if (kneeRot.dot(leftKneeRot) < 0.0f) {
-			leftKneeRot = leftKneeRot.unaryMinus()
-		}
-		if (kneeRot.dot(rightKneeRot) < 0.0f) {
-			rightKneeRot = rightKneeRot.unaryMinus()
-		}
-
 		// R = InverseHip * (LeftLeft + RightLeg)
 		// C = Quaternion(R.w, -R.x, 0, 0)
 		// Pelvis = Hip * R * C
 		// normalize(Pelvis)
-		val r = hip.inv() * (leftKneeRot + rightKneeRot)
+		val r = hip.inv() * (leftKnee + rightKnee)
 		val c = Quaternion(r.w, -r.x, 0f, 0f)
 		return (hip * r * c).unit()
 	}


### PR DESCRIPTION
Synchronizes `resetQuats()` to prevent race conditions, tracks quaternion polarity in `addQuaternion()` to prevent tracker tick vs server tick race conditions, and no longer tracks the polarity of output trackers.

~~Not entirely sure why we track the polarity of the output trackers, pls let me know if there's a reason. To me, I don't see why they wouldn't just inherit the rotation of the bones, which inherit the rotation from the input trackers?~~