### PR TITLE
Remove tracker polarity tracking

### DIFF
--- a/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
@@ -50,7 +50,10 @@ class QuaternionMovingAverage(
 			predictFactor = PREDICT_MULTIPLIER * amount + PREDICT_MIN
 			rotBuffer = CircularArrayList(PREDICT_BUFFER)
 		}
-		resetQuats(initialRotation)
+
+		latestQuaternion = initialRotation
+		filteredQuaternion = initialRotation
+		addQuaternion(initialRotation)
 	}
 
 	// Runs at up to 1000hz. We use a timer to make it framerate-independent
@@ -91,8 +94,7 @@ class QuaternionMovingAverage(
 			// Smooth towards the target rotation by the slerp factor
 			filteredQuaternion = smoothingQuaternion.interpR(latestQuaternion, amt)
 		} else {
-			// No filtering; just keep track of rotations (for going over 180 degrees)
-			filteredQuaternion = latestQuaternion.twinNearest(smoothingQuaternion)
+			return
 		}
 
 		filteringImpact = latestQuaternion.angleToR(filteredQuaternion)
@@ -112,18 +114,9 @@ class QuaternionMovingAverage(
 			lastAmt = 0f
 			smoothingQuaternion = filteredQuaternion
 		} else {
-			smoothingQuaternion = filteredQuaternion
+			filteredQuaternion = q
 		}
 
 		latestQuaternion = q
-	}
-
-	fun resetQuats(q: Quaternion) {
-		if (type == TrackerFilters.PREDICTION) {
-			rotBuffer?.clear()
-			latestQuaternion = q
-		}
-		filteredQuaternion = q
-		addQuaternion(q)
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/poseframeformat/trackerdata/TrackerFrames.kt
+++ b/server/core/src/main/java/dev/slimevr/poseframeformat/trackerdata/TrackerFrames.kt
@@ -41,7 +41,6 @@ data class TrackerFrames(var name: String = "", val frames: FastList<TrackerFram
 			// Make sure this is false!! Otherwise HumanSkeleton ignores it
 			isInternal = false,
 			isComputed = true,
-			trackRotDirection = false,
 		)
 
 		tracker.status = TrackerStatus.OK

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -67,12 +67,6 @@ class Tracker @JvmOverloads constructor(
 	val needsReset: Boolean = false,
 	val needsMounting: Boolean = false,
 	val isHmd: Boolean = false,
-	/**
-	 * Whether to track the direction of the tracker's rotation
-	 * (positive vs negative rotation). This needs to be disabled for AutoBone and
-	 * unit tests, where the rotation is absolute and not temporal.
-	 */
-	val trackRotDirection: Boolean = true,
 	magStatus: MagnetometerStatus = MagnetometerStatus.NOT_SUPPORTED,
 	/**
 	 * Rotation by default.
@@ -306,7 +300,9 @@ class Tracker @JvmOverloads constructor(
 				status = TrackerStatus.TIMED_OUT
 			}
 		}
-		filteringHandler.update()
+		if (filteringHandler.filteringEnabled) {
+			filteringHandler.update()
+		}
 		resetsHandler.update()
 	}
 
@@ -316,7 +312,7 @@ class Tracker @JvmOverloads constructor(
 	fun dataTick() {
 		timer.update()
 		timeAtLastUpdate = System.currentTimeMillis()
-		if (trackRotDirection) {
+		if (filteringHandler.filteringEnabled) {
 			filteringHandler.dataTick(_rotation)
 		}
 	}
@@ -328,7 +324,7 @@ class Tracker @JvmOverloads constructor(
 		timeAtLastUpdate = System.currentTimeMillis()
 	}
 
-	private fun getFilteredRotation(): Quaternion = if (trackRotDirection) {
+	private fun getFilteredRotation(): Quaternion = if (filteringHandler.filteringEnabled) {
 		filteringHandler.getFilteredRotation()
 	} else {
 		// Get raw rotation
@@ -422,11 +418,4 @@ class Tracker @JvmOverloads constructor(
 	 */
 	val tps: Float
 		get() = timer.averageFPS
-
-	/**
-	 * Call when doing a full reset to reset the tracking of rotations >180 degrees
-	 */
-	fun resetFilteringQuats() {
-		filteringHandler.resetMovingAverage(_rotation)
-	}
 }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerFilteringHandler.kt
@@ -37,7 +37,9 @@ class TrackerFilteringHandler {
 	 * Update the moving average to make it smooth
 	 */
 	fun update() {
-		movingAverage.update()
+		if (filteringEnabled) {
+			movingAverage.update()
+		}
 	}
 
 	/**
@@ -45,13 +47,6 @@ class TrackerFilteringHandler {
 	 */
 	fun dataTick(currentRawRotation: Quaternion) {
 		movingAverage.addQuaternion(currentRawRotation)
-	}
-
-	/**
-	 * Call when doing a full reset to reset the tracking of rotations >180 degrees
-	 */
-	fun resetMovingAverage(currentRawRotation: Quaternion) {
-		movingAverage.resetQuats(currentRawRotation)
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -350,8 +350,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			VRServer.instance.statusSystem.removeStatus(this.tracker.lastResetStatus)
 			this.tracker.lastResetStatus = 0u
 		}
-
-		tracker.resetFilteringQuats()
 	}
 
 	/**
@@ -394,8 +392,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			this.tracker.statusResetRecently = false
 			this.tracker.lastResetStatus = 0u
 		}
-
-		tracker.resetFilteringQuats()
 	}
 
 	/**
@@ -405,7 +401,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	fun resetMounting(reference: Quaternion) {
 		if (tracker.trackerDataType == TrackerDataType.FLEX_RESISTANCE) {
 			tracker.trackerFlexHandler.resetMax()
-			tracker.resetFilteringQuats()
 			return
 		} else if (tracker.trackerDataType == TrackerDataType.FLEX_ANGLE) {
 			return
@@ -459,8 +454,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 
 		// save mounting reset
 		if (saveMountingReset) tracker.saveMountingResetOrientation(mountRotFix)
-
-		tracker.resetFilteringQuats()
 	}
 
 	/**

--- a/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
@@ -114,7 +114,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 	/**
 	 * computes the dot product of this quaternion with that quaternion
 	 * @param that the quaternion with which to be dotted
-	 * @return the inverse quaternion
+	 * @return the dot product between quaternions
 	 **/
 	fun dot(that: Quaternion): Float =
 		this.w * that.w + this.x * that.x + this.y * that.y + this.z * that.z
@@ -365,7 +365,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 
 		val angleA = atan2(2f * (abQ * bQ + aQ * rot.w), rot.w * rot.w - aQ * aQ + bQ * bQ - abQ * abQ)
 		val angleB = atan2(2f * (abQ * aQ + bQ * rot.w), rot.w * rot.w + aQ * aQ - bQ * bQ - abQ * abQ)
-		
+
 		return floatArrayOf(angleA, angleB)
 	}
 

--- a/server/core/src/test/java/dev/slimevr/unit/JointInterpTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/JointInterpTests.kt
@@ -1,0 +1,56 @@
+package dev.slimevr.unit
+
+import com.jme3.math.FastMath
+import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
+import io.github.axisangles.ktmath.EulerAngles
+import io.github.axisangles.ktmath.EulerOrder
+import io.github.axisangles.ktmath.Quaternion
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import kotlin.math.sign
+import kotlin.test.assertEquals
+
+class JointInterpTests {
+
+	// Bottom back quarter
+	val negRange = -269..-180
+
+	// Front two quarters and top back quarter
+	val posRange = -179..90
+
+	val pitchRange = negRange.map {
+		AngleTest(it.toFloat(), -1f)
+	}.plus(
+		posRange.map {
+			AngleTest(it.toFloat(), 1f)
+		},
+	)
+
+	@get:TestFactory
+	val pitchTests: List<DynamicTest>
+		get() = pitchRange
+			.map { a: AngleTest ->
+				DynamicTest.dynamicTest(
+					"Dot product test for ${if (a.sign > 0f) "positive" else "negative"} signs <$a>",
+				) {
+					testSign(
+						Quaternion.IDENTITY,
+						EulerAngles(
+							EulerOrder.YZX,
+							a.pitch * FastMath.DEG_TO_RAD,
+							0f,
+							0f,
+						).toQuaternion(),
+						a.sign,
+					)
+				}
+			}
+
+	fun testSign(ref: Quaternion, extended: Quaternion?, expectedSign: Float) {
+		val result = HumanSkeleton.signExtendedRot(ref, extended)
+		val dot = ref.dot(result)
+		assertEquals(expectedSign.sign, dot.sign, "Resulting dot ($dot) does not match the expected sign ($expectedSign)")
+	}
+
+	data class AngleTest(val pitch: Float, val sign: Float)
+}

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -4,9 +4,9 @@ import com.jme3.math.FastMath
 import dev.slimevr.VRServer.Companion.getNextLocalTrackerId
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.udp.IMUType
-import dev.slimevr.unit.TrackerUtils.assertAnglesApproxEqual
-import dev.slimevr.unit.TrackerUtils.deg
-import dev.slimevr.unit.TrackerUtils.yaw
+import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.deg
+import dev.slimevr.unit.TrackerTestUtils.yaw
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
 import io.github.axisangles.ktmath.Quaternion
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.TestFactory
 class MountingResetTests {
 
 	@TestFactory
-	fun testResetAndMounting(): List<DynamicTest> = TrackerUtils.directions.flatMap { e ->
-		TrackerUtils.directions.map { m ->
+	fun testResetAndMounting(): List<DynamicTest> = TrackerTestUtils.directions.flatMap { e ->
+		TrackerTestUtils.directions.map { m ->
 			DynamicTest.dynamicTest(
 				"Full and Mounting Reset Test of Tracker (Expected: ${deg(e)}, reference: ${deg(m)})",
 			) {
@@ -35,7 +35,7 @@ class MountingResetTests {
 
 	private fun checkResetMounting(expected: Quaternion, reference: Quaternion) {
 		// Compute the pitch/roll for the expected mounting
-		val trackerRot = (expected * (TrackerUtils.frontRot / expected))
+		val trackerRot = (expected * (TrackerTestUtils.frontRot / expected))
 
 		val tracker = Tracker(
 			null,
@@ -119,7 +119,7 @@ class MountingResetTests {
 		val expected = Quaternion.SLIMEVR.RIGHT
 		val reference = EulerAngles(EulerOrder.YZX, FastMath.PI / 8f, FastMath.HALF_PI, 0f).toQuaternion()
 		// Compute the pitch/roll for the expected mounting
-		val trackerRot = (expected * (TrackerUtils.frontRot / expected))
+		val trackerRot = (expected * (TrackerTestUtils.frontRot / expected))
 
 		val tracker = Tracker(
 			null,

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -47,7 +47,6 @@ class MountingResetTests {
 			imuType = IMUType.UNKNOWN,
 			needsReset = true,
 			needsMounting = true,
-			trackRotDirection = false,
 		)
 
 		// Apply full reset and mounting
@@ -132,7 +131,6 @@ class MountingResetTests {
 			imuType = IMUType.UNKNOWN,
 			needsReset = true,
 			needsMounting = true,
-			trackRotDirection = false,
 		)
 
 		// Apply full reset and mounting

--- a/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
@@ -7,8 +7,8 @@ import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
 import dev.slimevr.tracking.trackers.TrackerStatus
 import dev.slimevr.tracking.trackers.udp.IMUType
-import dev.slimevr.unit.TrackerUtils.assertAnglesApproxEqual
-import dev.slimevr.unit.TrackerUtils.quatApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.quatApproxEqual
 import io.eiren.util.collections.FastList
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
@@ -81,7 +81,7 @@ class SkeletonResetTests {
 		hpm.resetTrackersYaw(resetSource)
 
 		for (tracker in tracks) {
-			val yaw = TrackerUtils.yaw(tracker.getRotation())
+			val yaw = TrackerTestUtils.yaw(tracker.getRotation())
 			assertAnglesApproxEqual(0f, yaw, "\"${tracker.name}\" did not reset to the reference rotation.")
 		}
 	}
@@ -141,8 +141,8 @@ class SkeletonResetTests {
 			val actualMounting = tracker.resetsHandler.mountRotFix
 
 			// Make sure yaw matches
-			val expectedY = TrackerUtils.yaw(expectedMounting)
-			val actualY = TrackerUtils.yaw(actualMounting)
+			val expectedY = TrackerTestUtils.yaw(expectedMounting)
+			val actualY = TrackerTestUtils.yaw(actualMounting)
 			assertAnglesApproxEqual(expectedY, actualY, "\"${tracker.name}\" did not reset to the reference rotation.")
 
 			// X and Z components should be zero for mounting
@@ -175,5 +175,5 @@ class SkeletonResetTests {
 		return tracker
 	}
 
-	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerUtils.frontRot / rot)
+	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerTestUtils.frontRot / rot)
 }

--- a/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
@@ -170,7 +170,6 @@ class SkeletonResetTests {
 			needsReset = true,
 			needsMounting = reset,
 			isHmd = hmd,
-			trackRotDirection = false,
 		)
 		tracker.status = TrackerStatus.OK
 		return tracker

--- a/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
@@ -1,15 +1,10 @@
 package dev.slimevr.unit
 
 import com.jme3.math.FastMath
-import dev.slimevr.VRServer.Companion.getNextLocalTrackerId
 import dev.slimevr.tracking.processor.HumanPoseManager
-import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
-import dev.slimevr.tracking.trackers.TrackerStatus
-import dev.slimevr.tracking.trackers.udp.IMUType
 import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
 import dev.slimevr.unit.TrackerTestUtils.quatApproxEqual
-import io.eiren.util.collections.FastList
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
 import io.github.axisangles.ktmath.Quaternion
@@ -23,31 +18,17 @@ class SkeletonResetTests {
 	@Test
 	fun testSkeletonReset() {
 		val rand = Random(42)
-
-		val hmd = mkTrack(TrackerPosition.HEAD, true, true, false)
-		val chest = mkTrack(TrackerPosition.CHEST)
-		val hip = mkTrack(TrackerPosition.HIP)
-
-		val upperLeft = mkTrack(TrackerPosition.LEFT_UPPER_LEG)
-		val lowerLeft = mkTrack(TrackerPosition.LEFT_LOWER_LEG)
-
-		val upperRight = mkTrack(TrackerPosition.RIGHT_UPPER_LEG)
-		val lowerRight = mkTrack(TrackerPosition.RIGHT_LOWER_LEG)
-
-		// Collect all our trackers
-		val tracks = arrayOf(chest, hip, upperLeft, lowerLeft, upperRight, lowerRight)
-		val tracksWithHmd = tracks.plus(hmd)
-		val trackerList = FastList(tracksWithHmd)
+		val trackers = TestTrackerSet()
 
 		// Initialize skeleton and everything
-		val hpm = HumanPoseManager(trackerList)
+		val hpm = HumanPoseManager(trackers.allL)
 
 		val headRot1 = EulerAngles(EulerOrder.YZX, 0f, FastMath.HALF_PI, FastMath.QUARTER_PI).toQuaternion()
 		val expectRot1 = EulerAngles(EulerOrder.YZX, 0f, FastMath.HALF_PI, 0f).toQuaternion()
 
 		// Randomize tracker orientations, these should be zeroed and matched to the
 		// headset yaw by full reset
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val init = EulerAngles(
 				EulerOrder.YZX,
 				rand.nextFloat() * FastMath.TWO_PI,
@@ -56,10 +37,10 @@ class SkeletonResetTests {
 			).toQuaternion()
 			tracker.setRotation(init)
 		}
-		hmd.setRotation(headRot1)
+		trackers.head.setRotation(headRot1)
 		hpm.resetTrackersFull(resetSource)
 
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val actual = tracker.getRotation()
 			assert(quatApproxEqual(expectRot1, actual)) {
 				"\"${tracker.name}\" did not reset to the reference rotation. Expected <$expectRot1>, actual <$actual>."
@@ -68,7 +49,7 @@ class SkeletonResetTests {
 
 		// Randomize full tracker orientations, these should match the headset yaw but
 		// retain orientation otherwise
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val init = EulerAngles(
 				EulerOrder.YZX,
 				rand.nextFloat() * FastMath.TWO_PI,
@@ -77,10 +58,10 @@ class SkeletonResetTests {
 			).toQuaternion()
 			tracker.setRotation(init)
 		}
-		hmd.setRotation(Quaternion.IDENTITY)
+		trackers.head.setRotation(Quaternion.IDENTITY)
 		hpm.resetTrackersYaw(resetSource)
 
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val yaw = TrackerTestUtils.yaw(tracker.getRotation())
 			assertAnglesApproxEqual(0f, yaw, "\"${tracker.name}\" did not reset to the reference rotation.")
 		}
@@ -88,32 +69,19 @@ class SkeletonResetTests {
 
 	@Test
 	fun testSkeletonMount() {
-		val hmd = mkTrack(TrackerPosition.HEAD, true, true, false)
-		val chest = mkTrack(TrackerPosition.CHEST)
-		val hip = mkTrack(TrackerPosition.HIP)
-
-		val upperLeft = mkTrack(TrackerPosition.LEFT_UPPER_LEG)
-		val lowerLeft = mkTrack(TrackerPosition.LEFT_LOWER_LEG)
-
-		val upperRight = mkTrack(TrackerPosition.RIGHT_UPPER_LEG)
-		val lowerRight = mkTrack(TrackerPosition.RIGHT_LOWER_LEG)
-
-		// Collect all our trackers
-		val tracks = arrayOf(chest, hip, upperLeft, lowerLeft, upperRight, lowerRight)
-		val tracksWithHmd = tracks.plus(hmd)
-		val trackerList = FastList(tracksWithHmd)
+		val trackers = TestTrackerSet()
 
 		// Initialize skeleton and everything
-		val hpm = HumanPoseManager(trackerList)
+		val hpm = HumanPoseManager(trackers.allL)
 
 		// Just a bunch of random mounting orientations
 		val expected = arrayOf(
-			Pair(chest, Quaternion.SLIMEVR.FRONT),
-			Pair(hip, Quaternion.SLIMEVR.RIGHT),
-			Pair(upperLeft, Quaternion.SLIMEVR.BACK),
-			Pair(lowerLeft, Quaternion.SLIMEVR.LEFT),
-			Pair(upperRight, Quaternion.SLIMEVR.FRONT),
-			Pair(lowerRight, Quaternion.SLIMEVR.RIGHT),
+			Pair(trackers.chest, Quaternion.SLIMEVR.FRONT),
+			Pair(trackers.hip, Quaternion.SLIMEVR.RIGHT),
+			Pair(trackers.leftThigh, Quaternion.SLIMEVR.BACK),
+			Pair(trackers.leftCalf, Quaternion.SLIMEVR.LEFT),
+			Pair(trackers.rightThigh, Quaternion.SLIMEVR.FRONT),
+			Pair(trackers.rightCalf, Quaternion.SLIMEVR.RIGHT),
 		)
 		// Rotate the tracker to fit the expected mounting orientation
 		for ((tracker, mountRot) in expected) {
@@ -153,26 +121,6 @@ class SkeletonResetTests {
 				"\"${tracker.name}\" did not reset to the reference rotation. Expected <0.0>, actual <${actualMounting.z}>."
 			}
 		}
-	}
-
-	fun mkTrack(pos: TrackerPosition, hmd: Boolean = false, computed: Boolean = false, reset: Boolean = true): Tracker {
-		val name = "test ${pos.designation}"
-		val tracker = Tracker(
-			null,
-			getNextLocalTrackerId(),
-			name,
-			name,
-			pos,
-			hasPosition = hmd,
-			hasRotation = true,
-			isComputed = computed,
-			imuType = IMUType.UNKNOWN,
-			needsReset = true,
-			needsMounting = reset,
-			isHmd = hmd,
-		)
-		tracker.status = TrackerStatus.OK
-		return tracker
 	}
 
 	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerTestUtils.frontRot / rot)

--- a/server/core/src/test/java/dev/slimevr/unit/TestTrackerSet.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/TestTrackerSet.kt
@@ -1,0 +1,68 @@
+package dev.slimevr.unit
+
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.TrackerPosition
+import dev.slimevr.tracking.trackers.TrackerStatus
+
+class TestTrackerSet(
+	val computed: Boolean = false,
+	val positional: Boolean = false,
+	val resetHead: Boolean = false,
+) {
+
+	val head = mkTrack(0, TrackerPosition.HEAD, true)
+
+	val chest = mkTrack(1, TrackerPosition.CHEST)
+	val hip = mkTrack(2, TrackerPosition.HIP)
+
+	val leftThigh = mkTrack(3, TrackerPosition.LEFT_UPPER_LEG)
+	val leftCalf = mkTrack(4, TrackerPosition.LEFT_LOWER_LEG)
+
+	val rightThigh = mkTrack(5, TrackerPosition.RIGHT_UPPER_LEG)
+	val rightCalf = mkTrack(6, TrackerPosition.RIGHT_LOWER_LEG)
+
+	/**
+	 * All the trackers in the set.
+	 */
+	val set = arrayOf(
+		chest,
+		hip,
+		leftThigh,
+		leftCalf,
+		rightThigh,
+		rightCalf,
+	)
+
+	/**
+	 * All the trackers in the set as a list.
+	 */
+	val setL = set.asList()
+
+	/**
+	 * All the trackers in the set plus the headset.
+	 */
+	val all = set.plus(head)
+
+	/**
+	 * All the trackers in the set plus the headset as a list.
+	 */
+	val allL = all.asList()
+
+	fun mkTrack(id: Int, pos: TrackerPosition, isHmd: Boolean = false): Tracker {
+		val tracker = Tracker(
+			device = null,
+			id = id,
+			name = pos.name,
+			trackerPosition = pos,
+			trackerNum = 0,
+			hasPosition = positional || isHmd,
+			hasRotation = true,
+			isComputed = computed || isHmd,
+			needsReset = resetHead || !isHmd,
+			needsMounting = resetHead || !isHmd,
+			isHmd = isHmd,
+		)
+		tracker.status = TrackerStatus.OK
+		return tracker
+	}
+}

--- a/server/core/src/test/java/dev/slimevr/unit/TrackerTestUtils.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/TrackerTestUtils.kt
@@ -7,7 +7,7 @@ import io.github.axisangles.ktmath.Quaternion
 import org.junit.jupiter.api.AssertionFailureBuilder
 import kotlin.math.abs
 
-object TrackerUtils {
+object TrackerTestUtils {
 	val directions = arrayOf(
 		Quaternion.SLIMEVR.FRONT,
 		Quaternion.SLIMEVR.FRONT_LEFT,


### PR DESCRIPTION
Moving on from #1343

> It turns out, there is no possible way for this code to function. Quaternions have a rotation limit of 360 degrees, and even assuming a limited joint rotation of 180 degrees, it would take a mere 2 joints to hit the limit of our precision... We cannot feasibly track rotation this way, we would be better off tracking local rotations on the skeleton and assuming positive rotations (180 degrees joint limit), then comparing between joints, reaching the maximum 360 degree limit. I don't think it's actually possible for the human body to go beyond 180 degrees for any joint, but if we wanted to, then we could go even further and use either skeleton constraints or temporal tracking within the local rotations.
> 
> tl;dr: It's not reasonably possible to track rotations globally

This PR is just a simple removal of polarity tracking from quaternion moving average stuff. Currently, smoothing and prediction both still technically track the polarity, but this is how it was initially and it should be fine anyways.