### PR TITLE
Clean up skeleton interpolation and make tests

### DIFF
--- a/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
+++ b/server/core/src/main/java/io/github/axisangles/ktmath/Quaternion.kt
@@ -114,7 +114,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 	/**
 	 * computes the dot product of this quaternion with that quaternion
 	 * @param that the quaternion with which to be dotted
-	 * @return the inverse quaternion
+	 * @return the dot product between quaternions
 	 **/
 	fun dot(that: Quaternion): Float =
 		this.w * that.w + this.x * that.x + this.y * that.y + this.z * that.z
@@ -365,7 +365,7 @@ value class Quaternion(val w: Float, val x: Float, val y: Float, val z: Float) {
 
 		val angleA = atan2(2f * (abQ * bQ + aQ * rot.w), rot.w * rot.w - aQ * aQ + bQ * bQ - abQ * abQ)
 		val angleB = atan2(2f * (abQ * aQ + bQ * rot.w), rot.w * rot.w + aQ * aQ - bQ * bQ - abQ * abQ)
-		
+
 		return floatArrayOf(angleA, angleB)
 	}
 

--- a/server/core/src/test/java/dev/slimevr/unit/JointInterpTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/JointInterpTests.kt
@@ -1,0 +1,56 @@
+package dev.slimevr.unit
+
+import com.jme3.math.FastMath
+import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
+import io.github.axisangles.ktmath.EulerAngles
+import io.github.axisangles.ktmath.EulerOrder
+import io.github.axisangles.ktmath.Quaternion
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import kotlin.math.sign
+import kotlin.test.assertEquals
+
+class JointInterpTests {
+
+	// Bottom back quarter
+	val negRange = -269..-180
+
+	// Front two quarters and top back quarter
+	val posRange = -179..90
+
+	val pitchRange = negRange.map {
+		AngleTest(it.toFloat(), -1f)
+	}.plus(
+		posRange.map {
+			AngleTest(it.toFloat(), 1f)
+		},
+	)
+
+	@get:TestFactory
+	val pitchTests: List<DynamicTest>
+		get() = pitchRange
+			.map { a: AngleTest ->
+				DynamicTest.dynamicTest(
+					"Dot product test for ${if (a.sign > 0f) "positive" else "negative"} signs <$a>",
+				) {
+					testSign(
+						Quaternion.IDENTITY,
+						EulerAngles(
+							EulerOrder.YZX,
+							a.pitch * FastMath.DEG_TO_RAD,
+							0f,
+							0f,
+						).toQuaternion(),
+						a.sign,
+					)
+				}
+			}
+
+	fun testSign(ref: Quaternion, extended: Quaternion?, expectedSign: Float) {
+		val result = HumanSkeleton.signExtendedRot(ref, extended)
+		val dot = ref.dot(result)
+		assertEquals(expectedSign.sign, dot.sign, "Resulting dot ($dot) does not match the expected sign ($expectedSign)")
+	}
+
+	data class AngleTest(val pitch: Float, val sign: Float)
+}

--- a/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/MountingResetTests.kt
@@ -4,9 +4,9 @@ import com.jme3.math.FastMath
 import dev.slimevr.VRServer.Companion.getNextLocalTrackerId
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.udp.IMUType
-import dev.slimevr.unit.TrackerUtils.assertAnglesApproxEqual
-import dev.slimevr.unit.TrackerUtils.deg
-import dev.slimevr.unit.TrackerUtils.yaw
+import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.deg
+import dev.slimevr.unit.TrackerTestUtils.yaw
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
 import io.github.axisangles.ktmath.Quaternion
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.TestFactory
 class MountingResetTests {
 
 	@TestFactory
-	fun testResetAndMounting(): List<DynamicTest> = TrackerUtils.directions.flatMap { e ->
-		TrackerUtils.directions.map { m ->
+	fun testResetAndMounting(): List<DynamicTest> = TrackerTestUtils.directions.flatMap { e ->
+		TrackerTestUtils.directions.map { m ->
 			DynamicTest.dynamicTest(
 				"Full and Mounting Reset Test of Tracker (Expected: ${deg(e)}, reference: ${deg(m)})",
 			) {
@@ -35,7 +35,7 @@ class MountingResetTests {
 
 	private fun checkResetMounting(expected: Quaternion, reference: Quaternion) {
 		// Compute the pitch/roll for the expected mounting
-		val trackerRot = (expected * (TrackerUtils.frontRot / expected))
+		val trackerRot = (expected * (TrackerTestUtils.frontRot / expected))
 
 		val tracker = Tracker(
 			null,
@@ -120,7 +120,7 @@ class MountingResetTests {
 		val expected = Quaternion.SLIMEVR.RIGHT
 		val reference = EulerAngles(EulerOrder.YZX, FastMath.PI / 8f, FastMath.HALF_PI, 0f).toQuaternion()
 		// Compute the pitch/roll for the expected mounting
-		val trackerRot = (expected * (TrackerUtils.frontRot / expected))
+		val trackerRot = (expected * (TrackerTestUtils.frontRot / expected))
 
 		val tracker = Tracker(
 			null,

--- a/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
@@ -7,8 +7,8 @@ import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
 import dev.slimevr.tracking.trackers.TrackerStatus
 import dev.slimevr.tracking.trackers.udp.IMUType
-import dev.slimevr.unit.TrackerUtils.assertAnglesApproxEqual
-import dev.slimevr.unit.TrackerUtils.quatApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
+import dev.slimevr.unit.TrackerTestUtils.quatApproxEqual
 import io.eiren.util.collections.FastList
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
@@ -81,7 +81,7 @@ class SkeletonResetTests {
 		hpm.resetTrackersYaw(resetSource)
 
 		for (tracker in tracks) {
-			val yaw = TrackerUtils.yaw(tracker.getRotation())
+			val yaw = TrackerTestUtils.yaw(tracker.getRotation())
 			assertAnglesApproxEqual(0f, yaw, "\"${tracker.name}\" did not reset to the reference rotation.")
 		}
 	}
@@ -141,8 +141,8 @@ class SkeletonResetTests {
 			val actualMounting = tracker.resetsHandler.mountRotFix
 
 			// Make sure yaw matches
-			val expectedY = TrackerUtils.yaw(expectedMounting)
-			val actualY = TrackerUtils.yaw(actualMounting)
+			val expectedY = TrackerTestUtils.yaw(expectedMounting)
+			val actualY = TrackerTestUtils.yaw(actualMounting)
 			assertAnglesApproxEqual(expectedY, actualY, "\"${tracker.name}\" did not reset to the reference rotation.")
 
 			// X and Z components should be zero for mounting
@@ -176,5 +176,5 @@ class SkeletonResetTests {
 		return tracker
 	}
 
-	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerUtils.frontRot / rot)
+	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerTestUtils.frontRot / rot)
 }

--- a/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/SkeletonResetTests.kt
@@ -1,15 +1,10 @@
 package dev.slimevr.unit
 
 import com.jme3.math.FastMath
-import dev.slimevr.VRServer.Companion.getNextLocalTrackerId
 import dev.slimevr.tracking.processor.HumanPoseManager
-import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
-import dev.slimevr.tracking.trackers.TrackerStatus
-import dev.slimevr.tracking.trackers.udp.IMUType
 import dev.slimevr.unit.TrackerTestUtils.assertAnglesApproxEqual
 import dev.slimevr.unit.TrackerTestUtils.quatApproxEqual
-import io.eiren.util.collections.FastList
 import io.github.axisangles.ktmath.EulerAngles
 import io.github.axisangles.ktmath.EulerOrder
 import io.github.axisangles.ktmath.Quaternion
@@ -23,31 +18,17 @@ class SkeletonResetTests {
 	@Test
 	fun testSkeletonReset() {
 		val rand = Random(42)
-
-		val hmd = mkTrack(TrackerPosition.HEAD, true, true, false)
-		val chest = mkTrack(TrackerPosition.CHEST)
-		val hip = mkTrack(TrackerPosition.HIP)
-
-		val upperLeft = mkTrack(TrackerPosition.LEFT_UPPER_LEG)
-		val lowerLeft = mkTrack(TrackerPosition.LEFT_LOWER_LEG)
-
-		val upperRight = mkTrack(TrackerPosition.RIGHT_UPPER_LEG)
-		val lowerRight = mkTrack(TrackerPosition.RIGHT_LOWER_LEG)
-
-		// Collect all our trackers
-		val tracks = arrayOf(chest, hip, upperLeft, lowerLeft, upperRight, lowerRight)
-		val tracksWithHmd = tracks.plus(hmd)
-		val trackerList = FastList(tracksWithHmd)
+		val trackers = TestTrackerSet()
 
 		// Initialize skeleton and everything
-		val hpm = HumanPoseManager(trackerList)
+		val hpm = HumanPoseManager(trackers.allL)
 
 		val headRot1 = EulerAngles(EulerOrder.YZX, 0f, FastMath.HALF_PI, FastMath.QUARTER_PI).toQuaternion()
 		val expectRot1 = EulerAngles(EulerOrder.YZX, 0f, FastMath.HALF_PI, 0f).toQuaternion()
 
 		// Randomize tracker orientations, these should be zeroed and matched to the
 		// headset yaw by full reset
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val init = EulerAngles(
 				EulerOrder.YZX,
 				rand.nextFloat() * FastMath.TWO_PI,
@@ -56,10 +37,10 @@ class SkeletonResetTests {
 			).toQuaternion()
 			tracker.setRotation(init)
 		}
-		hmd.setRotation(headRot1)
+		trackers.head.setRotation(headRot1)
 		hpm.resetTrackersFull(resetSource)
 
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val actual = tracker.getRotation()
 			assert(quatApproxEqual(expectRot1, actual)) {
 				"\"${tracker.name}\" did not reset to the reference rotation. Expected <$expectRot1>, actual <$actual>."
@@ -68,7 +49,7 @@ class SkeletonResetTests {
 
 		// Randomize full tracker orientations, these should match the headset yaw but
 		// retain orientation otherwise
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val init = EulerAngles(
 				EulerOrder.YZX,
 				rand.nextFloat() * FastMath.TWO_PI,
@@ -77,10 +58,10 @@ class SkeletonResetTests {
 			).toQuaternion()
 			tracker.setRotation(init)
 		}
-		hmd.setRotation(Quaternion.IDENTITY)
+		trackers.head.setRotation(Quaternion.IDENTITY)
 		hpm.resetTrackersYaw(resetSource)
 
-		for (tracker in tracks) {
+		for (tracker in trackers.set) {
 			val yaw = TrackerTestUtils.yaw(tracker.getRotation())
 			assertAnglesApproxEqual(0f, yaw, "\"${tracker.name}\" did not reset to the reference rotation.")
 		}
@@ -88,32 +69,19 @@ class SkeletonResetTests {
 
 	@Test
 	fun testSkeletonMount() {
-		val hmd = mkTrack(TrackerPosition.HEAD, true, true, false)
-		val chest = mkTrack(TrackerPosition.CHEST)
-		val hip = mkTrack(TrackerPosition.HIP)
-
-		val upperLeft = mkTrack(TrackerPosition.LEFT_UPPER_LEG)
-		val lowerLeft = mkTrack(TrackerPosition.LEFT_LOWER_LEG)
-
-		val upperRight = mkTrack(TrackerPosition.RIGHT_UPPER_LEG)
-		val lowerRight = mkTrack(TrackerPosition.RIGHT_LOWER_LEG)
-
-		// Collect all our trackers
-		val tracks = arrayOf(chest, hip, upperLeft, lowerLeft, upperRight, lowerRight)
-		val tracksWithHmd = tracks.plus(hmd)
-		val trackerList = FastList(tracksWithHmd)
+		val trackers = TestTrackerSet()
 
 		// Initialize skeleton and everything
-		val hpm = HumanPoseManager(trackerList)
+		val hpm = HumanPoseManager(trackers.allL)
 
 		// Just a bunch of random mounting orientations
 		val expected = arrayOf(
-			Pair(chest, Quaternion.SLIMEVR.FRONT),
-			Pair(hip, Quaternion.SLIMEVR.RIGHT),
-			Pair(upperLeft, Quaternion.SLIMEVR.BACK),
-			Pair(lowerLeft, Quaternion.SLIMEVR.LEFT),
-			Pair(upperRight, Quaternion.SLIMEVR.FRONT),
-			Pair(lowerRight, Quaternion.SLIMEVR.RIGHT),
+			Pair(trackers.chest, Quaternion.SLIMEVR.FRONT),
+			Pair(trackers.hip, Quaternion.SLIMEVR.RIGHT),
+			Pair(trackers.leftThigh, Quaternion.SLIMEVR.BACK),
+			Pair(trackers.leftCalf, Quaternion.SLIMEVR.LEFT),
+			Pair(trackers.rightThigh, Quaternion.SLIMEVR.FRONT),
+			Pair(trackers.rightCalf, Quaternion.SLIMEVR.RIGHT),
 		)
 		// Rotate the tracker to fit the expected mounting orientation
 		for ((tracker, mountRot) in expected) {
@@ -153,27 +121,6 @@ class SkeletonResetTests {
 				"\"${tracker.name}\" did not reset to the reference rotation. Expected <0.0>, actual <${actualMounting.z}>."
 			}
 		}
-	}
-
-	fun mkTrack(pos: TrackerPosition, hmd: Boolean = false, computed: Boolean = false, reset: Boolean = true): Tracker {
-		val name = "test ${pos.designation}"
-		val tracker = Tracker(
-			null,
-			getNextLocalTrackerId(),
-			name,
-			name,
-			pos,
-			hasPosition = hmd,
-			hasRotation = true,
-			isComputed = computed,
-			imuType = IMUType.UNKNOWN,
-			needsReset = true,
-			needsMounting = reset,
-			isHmd = hmd,
-			trackRotDirection = false,
-		)
-		tracker.status = TrackerStatus.OK
-		return tracker
 	}
 
 	fun mkTrackMount(rot: Quaternion): Quaternion = rot * (TrackerTestUtils.frontRot / rot)

--- a/server/core/src/test/java/dev/slimevr/unit/TestTrackerSet.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/TestTrackerSet.kt
@@ -1,0 +1,69 @@
+package dev.slimevr.unit
+
+import dev.slimevr.tracking.trackers.Tracker
+import dev.slimevr.tracking.trackers.TrackerPosition
+import dev.slimevr.tracking.trackers.TrackerStatus
+
+class TestTrackerSet(
+	val computed: Boolean = false,
+	val positional: Boolean = false,
+	val resetHead: Boolean = false,
+) {
+
+	val head = mkTrack(0, TrackerPosition.HEAD, true)
+
+	val chest = mkTrack(1, TrackerPosition.CHEST)
+	val hip = mkTrack(2, TrackerPosition.HIP)
+
+	val leftThigh = mkTrack(3, TrackerPosition.LEFT_UPPER_LEG)
+	val leftCalf = mkTrack(4, TrackerPosition.LEFT_LOWER_LEG)
+
+	val rightThigh = mkTrack(5, TrackerPosition.RIGHT_UPPER_LEG)
+	val rightCalf = mkTrack(6, TrackerPosition.RIGHT_LOWER_LEG)
+
+	/**
+	 * All the trackers in the set.
+	 */
+	val set = arrayOf(
+		chest,
+		hip,
+		leftThigh,
+		leftCalf,
+		rightThigh,
+		rightCalf,
+	)
+
+	/**
+	 * All the trackers in the set as a list.
+	 */
+	val setL = set.asList()
+
+	/**
+	 * All the trackers in the set plus the headset.
+	 */
+	val all = set.plus(head)
+
+	/**
+	 * All the trackers in the set plus the headset as a list.
+	 */
+	val allL = all.asList()
+
+	fun mkTrack(id: Int, pos: TrackerPosition, isHmd: Boolean = false): Tracker {
+		val tracker = Tracker(
+			device = null,
+			id = id,
+			name = pos.name,
+			trackerPosition = pos,
+			trackerNum = 0,
+			hasPosition = positional || isHmd,
+			hasRotation = true,
+			isComputed = computed || isHmd,
+			needsReset = resetHead || !isHmd,
+			needsMounting = resetHead || !isHmd,
+			isHmd = isHmd,
+			trackRotDirection = false,
+		)
+		tracker.status = TrackerStatus.OK
+		return tracker
+	}
+}

--- a/server/core/src/test/java/dev/slimevr/unit/TrackerTestUtils.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/TrackerTestUtils.kt
@@ -7,7 +7,7 @@ import io.github.axisangles.ktmath.Quaternion
 import org.junit.jupiter.api.AssertionFailureBuilder
 import kotlin.math.abs
 
-object TrackerUtils {
+object TrackerTestUtils {
 	val directions = arrayOf(
 		Quaternion.SLIMEVR.FRONT,
 		Quaternion.SLIMEVR.FRONT_LEFT,


### PR DESCRIPTION
Skeleton intepolation handling is a bit of a mess right now, this PR cleans things up, documents parts of it that are confusing, and adds unit tests to ensure functionality.

This is yet to be tested, so it should remain a draft. Please wait until after v0.14.0 to merge this, as this is a scary change.