### PR TITLE
Fix GUI freezing when reopening config folder

### DIFF
--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -59,6 +59,19 @@ fn warning(msg: String) {
 }
 
 #[tauri::command]
+fn open_config_folder(app_handle: tauri::AppHandle) {
+	let path = app_handle
+		.path()
+		.app_config_dir()
+		.unwrap_or_else(|_| Path::new(".").to_path_buf());
+	let path_str = path.to_string_lossy().into_owned();
+
+	if let Err(err) = open::that(path_str) {
+		eprintln!("Failed to open config folder: {}", err);
+	}
+}
+
+#[tauri::command]
 fn open_logs_folder(app_handle: tauri::AppHandle) {
 	let config_dir = app_handle
 		.path()
@@ -68,7 +81,7 @@ fn open_logs_folder(app_handle: tauri::AppHandle) {
 	let path_str = path.to_string_lossy().into_owned();
 
 	if let Err(err) = open::that(path_str) {
-		eprintln!("Failed to open config folder: {}", err);
+		eprintln!("Failed to open logs folder: {}", err);
 	}
 }
 
@@ -246,6 +259,7 @@ fn setup_tauri(
 			logging,
 			erroring,
 			warning,
+			open_config_folder,
 			open_logs_folder,
 			tray::update_translations,
 			tray::update_tray_text,

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -61,11 +61,6 @@
     "shortDescription": "",
     "licenseFile": "../../LICENSE-MIT"
   },
-  "plugins": {
-    "shell": {
-      "open": "^((https?://\\w+)|(file://)).+"
-    }
-  },
   "productName": "slimevr",
   "version": "../package.json",
   "identifier": "dev.slimevr.SlimeVR",

--- a/gui/src/components/settings/pages/AdvancedSettings.tsx
+++ b/gui/src/components/settings/pages/AdvancedSettings.tsx
@@ -9,13 +9,12 @@ import { BugIcon } from '@/components/commons/icon/BugIcon';
 import { Button } from '@/components/commons/Button';
 import { SettingsResetModal } from '@/components/settings/SettingsResetModal';
 
-import { open } from '@tauri-apps/plugin-shell';
 import { error } from '@/utils/logging';
-import { appConfigDir } from '@tauri-apps/api/path';
 import { defaultConfig as defaultGUIConfig, useConfig } from '@/hooks/config';
 import { defaultValues as defaultDevConfig } from '@/components/widgets/DeveloperModeWidget';
 import { RpcMessage, SettingsResetRequestT } from 'solarxr-protocol';
 import { useWebsocketAPI } from '@/hooks/websocket-api';
+import { invoke } from '@tauri-apps/api/core';
 
 function guiDefaults() {
   // Destructure the properties to exclude "lang"
@@ -40,8 +39,7 @@ export function AdvancedSettings() {
 
   const openConfigFolder = async () => {
     try {
-      const configPath = await appConfigDir();
-      await open('file://' + configPath);
+      await invoke<string | null>('open_config_folder');
     } catch (err) {
       error('Failed to open config folder:', err);
     }


### PR DESCRIPTION
For some reason, the GUI freezes when you click on "open folder" again, without closing the first explorer window. Fixed by moving the code to the rust side.

what even.