### PR TITLE
Simplify mounting reset status checking

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -29,7 +29,6 @@ import io.github.axisangles.ktmath.Vector3
 import io.github.axisangles.ktmath.Vector3.Companion.NEG_Y
 import io.github.axisangles.ktmath.Vector3.Companion.NULL
 import io.github.axisangles.ktmath.Vector3.Companion.POS_Y
-import solarxr_protocol.rpc.StatusData
 import java.lang.IllegalArgumentException
 import kotlin.properties.Delegates
 
@@ -1599,8 +1598,14 @@ class HumanSkeleton(
 
 	@VRServerThread
 	fun resetTrackersMounting(resetSourceName: String?) {
-		val server = humanPoseManager.server
-		if (server != null && server.statusSystem.hasStatusType(StatusData.StatusTrackerReset)) {
+		val trackersToReset = trackersToReset
+
+		// TODO: PLEASE rewrite this handling at some point in the future... This is so
+		//  hacky!! Surely there's a better way to check reset status - Butterscotch
+		// If there's a server present (required for status) and any tracker reports a
+		// non-zero reset status (indicates reset required), then block mounting reset,
+		// as it requires a full reset first
+		if (humanPoseManager.server != null && trackersToReset.any { it != null && it.lastResetStatus != 0u }) {
 			LogManager.info("[HumanSkeleton] Reset: mounting ($resetSourceName) failed, reset required")
 			return
 		}


### PR DESCRIPTION
Currently we're over-detecting on mounting reset status checking, hopefully only checking trackers that will actually be reset can reduce the false positive? Also let's just check the tracker directly, as we really shouldn't rely on the status system in that way.

This whole thing has turned into quite a mess, maybe the status system isn't a good idea? We could probably just replace it with direct SolarXR packets that evaluate the current state rather than trying to track the state separately.