### PR TITLE
Scale arms on proportions reset

### DIFF
--- a/server/core/src/main/java/dev/slimevr/autobone/errors/BodyProportionError.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/errors/BodyProportionError.kt
@@ -57,6 +57,18 @@ class BodyProportionError : IAutoBoneError {
 				0.002f,
 			),
 			makeLimiter(
+				SkeletonConfigOffsets.SHOULDERS_WIDTH,
+				0.04f,
+			),
+			makeLimiter(
+				SkeletonConfigOffsets.UPPER_ARM,
+				0.02f,
+			),
+			makeLimiter(
+				SkeletonConfigOffsets.LOWER_ARM,
+				0.02f,
+			),
+			makeLimiter(
 				SkeletonConfigOffsets.UPPER_CHEST,
 				0.01f,
 			),

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
@@ -452,7 +452,15 @@ class SkeletonConfigManager(
 
 	fun resetOffset(config: SkeletonConfigOffsets) {
 		when (config) {
-			SkeletonConfigOffsets.UPPER_CHEST, SkeletonConfigOffsets.CHEST, SkeletonConfigOffsets.WAIST, SkeletonConfigOffsets.HIP, SkeletonConfigOffsets.UPPER_LEG, SkeletonConfigOffsets.LOWER_LEG -> {
+			SkeletonConfigOffsets.UPPER_ARM,
+			SkeletonConfigOffsets.LOWER_ARM,
+			SkeletonConfigOffsets.UPPER_CHEST,
+			SkeletonConfigOffsets.CHEST,
+			SkeletonConfigOffsets.WAIST,
+			SkeletonConfigOffsets.HIP,
+			SkeletonConfigOffsets.UPPER_LEG,
+			SkeletonConfigOffsets.LOWER_LEG,
+			-> {
 				val height = humanPoseManager?.server?.configManager?.vrConfig?.skeleton?.userHeight ?: -1f
 				if (height > AutoBone.MIN_HEIGHT) { // Reset only if floor level seems right,
 					val proportionLimiter = proportionLimitMap[config]


### PR DESCRIPTION
Sort of a bug? Arms aren't being scaled with the rest of the proportions, so we get unusually short arms for tall people and unusually long arms for short people lol. Here's a simple fix that just sets up scaling based on the default proportions.