### PR TITLE
Limit prediction slerp amount

### DIFF
--- a/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
+++ b/server/core/src/main/java/dev/slimevr/filtering/QuaternionMovingAverage.kt
@@ -64,7 +64,7 @@ class QuaternionMovingAverage(
 				rotBuffer?.forEach { quatBuf *= it }
 
 				// Calculate how much to slerp
-				val amt = predictFactor * fpsTimer.timePerFrame
+				val amt = (predictFactor * fpsTimer.timePerFrame).coerceAtMost(1f)
 
 				// Slerps the target rotation to that predicted rotation by amt
 				filteredQuaternion = filteredQuaternion.interpR(quatBuf, amt)


### PR DESCRIPTION
Fixes #1111, which seems to be more of an issue now. Tested at as low as 0.5 TPS server tickrate, tracking seems to hold up solidly. Without this, it jitters like crazy and throws NaNs after a few seconds at 10 TPS, which is totally possible under heavy load, especially on low end devices like Quest standalone.

There may also be a tracker tickrate component to this issue, further testing is required.
Update: Tested with low tracker tickrate as well as low tracker tickrate *and* low server tickrate, both work as expected with this PR.