### PR TITLE
fw update server deadlock fix

### DIFF
--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -91,7 +91,7 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 	private suspend fun startOtaUpdate(
 		part: DownloadedFirmwarePart,
 		deviceId: UpdateDeviceId<Int>,
-	): Unit = suspendCancellableCoroutine  { c ->
+	): Unit = suspendCancellableCoroutine { c ->
 		val udpDevice: UDPDevice? =
 			(server.deviceManager.devices.find { device -> device is UDPDevice && device.id == deviceId.id }) as UDPDevice?
 

--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -88,12 +88,12 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 		}
 	}
 
-	private fun startOtaUpdate(
+	private suspend fun startOtaUpdate(
 		part: DownloadedFirmwarePart,
 		deviceId: UpdateDeviceId<Int>,
-	) {
+	): Unit = suspendCancellableCoroutine  { c ->
 		val udpDevice: UDPDevice? =
-			(this.server.deviceManager.devices.find { device -> device is UDPDevice && device.id == deviceId.id }) as UDPDevice?
+			(server.deviceManager.devices.find { device -> device is UDPDevice && device.id == deviceId.id }) as UDPDevice?
 
 		if (udpDevice == null) {
 			onStatusChange(
@@ -102,14 +102,18 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 					FirmwareUpdateStatus.ERROR_DEVICE_NOT_FOUND,
 				),
 			)
-			return
+			return@suspendCancellableCoroutine
 		}
-		OTAUpdateTask(
+		val task = OTAUpdateTask(
 			part.firmware,
 			deviceId,
 			udpDevice.ipAddress,
-			this::onStatusChange,
-		).run()
+			::onStatusChange,
+		)
+		c.invokeOnCancellation {
+			task.cancel()
+		}
+		task.run()
 	}
 
 	private fun startSerialUpdate(
@@ -256,8 +260,10 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 		clearJob = mainScope.async {
 			oldClearJob?.await()
 			watchRestartQueue.clear()
+			LogManager.info("[FirmwareUpdateHandler] Before join")
 			runningJobs.forEach { it.cancelAndJoin() }
 			runningJobs.clear()
+			LogManager.info("[FirmwareUpdateHandler] Clearing jobs")
 		}
 	}
 

--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -260,10 +260,9 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 		clearJob = mainScope.async {
 			oldClearJob?.await()
 			watchRestartQueue.clear()
-			LogManager.info("[FirmwareUpdateHandler] Before join")
 			runningJobs.forEach { it.cancelAndJoin() }
 			runningJobs.clear()
-			LogManager.info("[FirmwareUpdateHandler] Clearing jobs")
+			LogManager.info("[FirmwareUpdateHandler] Update jobs canceled")
 		}
 	}
 

--- a/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
@@ -21,10 +21,10 @@ class OTAUpdateTask(
 	private val statusCallback: Consumer<UpdateStatusEvent<Int>>,
 ) {
 	private val receiveBuffer: ByteArray = ByteArray(38)
-	var socketServer: ServerSocket? = null;
-	var uploadSocket: Socket? = null;
-	var authSocket: DatagramSocket? = null;
-	var canceled: Boolean = false;
+	var socketServer: ServerSocket? = null
+	var uploadSocket: Socket? = null
+	var authSocket: DatagramSocket? = null
+	var canceled: Boolean = false
 
 	@Throws(NoSuchAlgorithmException::class)
 	private fun bytesToMd5(bytes: ByteArray): String {
@@ -150,7 +150,7 @@ class OTAUpdateTask(
 
 	fun run() {
 		ServerSocket(0).use { serverSocket ->
-			socketServer = serverSocket;
+			socketServer = serverSocket
 			if (!authenticate(serverSocket.localPort)) {
 				statusCallback.accept(
 					UpdateStatusEvent(
@@ -181,11 +181,10 @@ class OTAUpdateTask(
 	}
 
 	fun cancel() {
-		println("OTA CANCEL");
-		canceled = true;
-		socketServer?.close();
-		authSocket?.close();
-		uploadSocket?.close();
+		canceled = true
+		socketServer?.close()
+		authSocket?.close()
+		uploadSocket?.close()
 	}
 
 	companion object {

--- a/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
@@ -7,6 +7,7 @@ import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.net.Socket
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.*
@@ -20,6 +21,10 @@ class OTAUpdateTask(
 	private val statusCallback: Consumer<UpdateStatusEvent<Int>>,
 ) {
 	private val receiveBuffer: ByteArray = ByteArray(38)
+	var socketServer: ServerSocket? = null;
+	var uploadSocket: Socket? = null;
+	var authSocket: DatagramSocket? = null;
+	var canceled: Boolean = false;
 
 	@Throws(NoSuchAlgorithmException::class)
 	private fun bytesToMd5(bytes: ByteArray): String {
@@ -36,6 +41,7 @@ class OTAUpdateTask(
 	private fun authenticate(localPort: Int): Boolean {
 		try {
 			DatagramSocket().use { socket ->
+				authSocket = socket
 				statusCallback.accept(UpdateStatusEvent(deviceId, FirmwareUpdateStatus.AUTHENTICATING))
 				LogManager.info("[OTAUpdate] Sending OTA invitation to: $deviceIp")
 
@@ -98,15 +104,15 @@ class OTAUpdateTask(
 			LogManager.info("[OTAUpdate] Waiting for device...")
 
 			val connection = serverSocket.accept()
+			this.uploadSocket = connection
 			connection.setSoTimeout(1000)
-
 			val dos = DataOutputStream(connection.getOutputStream())
 			val dis = DataInputStream(connection.getInputStream())
 
 			LogManager.info("[OTAUpdate] Upload size: ${firmware.size} bytes")
 			var offset = 0
 			val chunkSize = 2048
-			while (offset != firmware.size) {
+			while (offset != firmware.size && !canceled) {
 				statusCallback.accept(
 					UpdateStatusEvent(
 						deviceId,
@@ -126,6 +132,7 @@ class OTAUpdateTask(
 				// for the OK response. Saving time
 				dis.skipNBytes(4)
 			}
+			if (canceled) return false
 
 			LogManager.info("[OTAUpdate] Waiting for result...")
 			// We set the timeout of the connection bigger as it can take some time for the MCU
@@ -143,6 +150,7 @@ class OTAUpdateTask(
 
 	fun run() {
 		ServerSocket(0).use { serverSocket ->
+			socketServer = serverSocket;
 			if (!authenticate(serverSocket.localPort)) {
 				statusCallback.accept(
 					UpdateStatusEvent(
@@ -170,6 +178,14 @@ class OTAUpdateTask(
 				),
 			)
 		}
+	}
+
+	fun cancel() {
+		println("OTA CANCEL");
+		canceled = true;
+		socketServer?.close();
+		authSocket?.close();
+		uploadSocket?.close();
 	}
 
 	companion object {


### PR DESCRIPTION
OTA update task would not get cancelled and make the updater not be able to queue new update task.
This pr watch the coroutine cancel event and close ota sockets. As DatagramPackets are not cancellable by coroutines directly