### PR TITLE
Load configured height for manual height config

### DIFF
--- a/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckFloorHeight.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/autobone-steps/CheckFloorHeight.tsx
@@ -12,7 +12,11 @@ import { Typography } from '@/components/commons/Typography';
 import { Localized, useLocalization } from '@fluent/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocaleConfig } from '@/i18n/config';
-import { EYE_HEIGHT_TO_HEIGHT_RATIO, useHeightContext } from '@/hooks/height';
+import {
+  EYE_HEIGHT_TO_HEIGHT_RATIO,
+  useHeightContext,
+  validateHeight,
+} from '@/hooks/height';
 import { useInterval } from '@/hooks/timeout';
 import { TooSmolModal } from './TooSmolModal';
 
@@ -26,8 +30,7 @@ export function CheckFloorHeightStep({
   variant: 'onboarding' | 'alone';
 }) {
   const { l10n } = useLocalization();
-  const { floorHeight, hmdHeight, setFloorHeight, validateHeight } =
-    useHeightContext();
+  const { floorHeight, hmdHeight, setFloorHeight } = useHeightContext();
   const [fetchHeight, setFetchHeight] = useState(false);
   const { sendRPCPacket, useRPCPacket } = useWebsocketAPI();
   const [isOpen, setOpen] = useState(false);

--- a/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
@@ -46,10 +46,10 @@ export function ManualHeightStep({
 
   // Load the last configured height
   useEffect(() => {
-    const height = currentHeight();
     reset({
       height:
-        (currentHeight && currentHeight / EYE_HEIGHT_TO_HEIGHT_RATIO) || DEFAULT_FULL_HEIGHT,
+        (currentHeight && currentHeight / EYE_HEIGHT_TO_HEIGHT_RATIO) ||
+        DEFAULT_FULL_HEIGHT,
     });
   }, [currentHeight]);
 

--- a/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
@@ -2,9 +2,13 @@ import { useWebsocketAPI } from '@/hooks/websocket-api';
 import { Button } from '@/components/commons/Button';
 import { Typography } from '@/components/commons/Typography';
 import { useLocalization } from '@fluent/react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocaleConfig } from '@/i18n/config';
-import { EYE_HEIGHT_TO_HEIGHT_RATIO, useHeightContext } from '@/hooks/height';
+import {
+  DEFAULT_FULL_HEIGHT,
+  EYE_HEIGHT_TO_HEIGHT_RATIO,
+  useHeightContext,
+} from '@/hooks/height';
 import { useForm } from 'react-hook-form';
 import {
   ChangeSettingsRequestT,
@@ -31,13 +35,23 @@ export function ManualHeightStep({
 }) {
   const { state } = useOnboarding();
   const { l10n } = useLocalization();
-  const { setHmdHeight } = useHeightContext();
-  const { control, handleSubmit, formState, watch } = useForm<HeightForm>({
-    defaultValues: { height: 1.5 },
-  });
+  const { setHmdHeight, currentHeight } = useHeightContext();
+  const { control, handleSubmit, formState, watch, reset } =
+    useForm<HeightForm>({
+      defaultValues: { height: DEFAULT_FULL_HEIGHT },
+    });
   const { sendRPCPacket } = useWebsocketAPI();
   const { currentLocales } = useLocaleConfig();
   const height = watch('height');
+
+  // Load the last configured height
+  useEffect(() => {
+    const height = currentHeight();
+    reset({
+      height:
+        (height && height / EYE_HEIGHT_TO_HEIGHT_RATIO) || DEFAULT_FULL_HEIGHT,
+    });
+  }, [currentHeight()]);
 
   const mFormat = useMemo(
     () =>

--- a/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
@@ -49,9 +49,9 @@ export function ManualHeightStep({
     const height = currentHeight();
     reset({
       height:
-        (height && height / EYE_HEIGHT_TO_HEIGHT_RATIO) || DEFAULT_FULL_HEIGHT,
+        (currentHeight && currentHeight / EYE_HEIGHT_TO_HEIGHT_RATIO) || DEFAULT_FULL_HEIGHT,
     });
-  }, [currentHeight()]);
+  }, [currentHeight]);
 
   const mFormat = useMemo(
     () =>

--- a/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/scaled-steps/ManualHeightStep.tsx
@@ -63,7 +63,7 @@ export function ManualHeightStep({
     [currentLocales]
   );
 
-  const submitHmdHeight = (values: HeightForm) => {
+  const submitFullHeight = (values: HeightForm) => {
     const newHeight = values.height * EYE_HEIGHT_TO_HEIGHT_RATIO;
     setHmdHeight(newHeight);
     const settingsRequest = new ChangeSettingsRequestT();
@@ -80,7 +80,7 @@ export function ManualHeightStep({
   return (
     <form
       className="flex flex-col flex-grow"
-      onSubmit={handleSubmit(submitHmdHeight)}
+      onSubmit={handleSubmit(submitFullHeight)}
     >
       <div className="flex gap-2 flex-grow">
         <div className="flex flex-grow flex-col gap-4">

--- a/gui/src/hooks/height.ts
+++ b/gui/src/hooks/height.ts
@@ -8,7 +8,7 @@ export interface HeightContext {
   setHmdHeight: React.Dispatch<React.SetStateAction<number | null>>;
   floorHeight: number | null;
   setFloorHeight: React.Dispatch<React.SetStateAction<number | null>>;
-  currentHeight: () => number | null;
+  currentHeight: number | null;
 }
 
 export function useProvideHeightContext(): HeightContext {
@@ -30,7 +30,7 @@ export function useProvideHeightContext(): HeightContext {
     }
   });
 
-  const currentHeight = () => computeHeight(hmdHeight, floorHeight);
+  const currentHeight = useMemo(() => computeHeight(hmdHeight, floorHeight), [hmdHeight, floorHeight])
 
   return { hmdHeight, setHmdHeight, floorHeight, setFloorHeight, currentHeight };
 }

--- a/gui/src/hooks/height.ts
+++ b/gui/src/hooks/height.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useWebsocketAPI } from './websocket-api';
 import { RpcMessage, SettingsRequestT, SettingsResponseT } from 'solarxr-protocol';
 import { MIN_HEIGHT } from './manual-proportions';
@@ -30,7 +30,10 @@ export function useProvideHeightContext(): HeightContext {
     }
   });
 
-  const currentHeight = useMemo(() => computeHeight(hmdHeight, floorHeight), [hmdHeight, floorHeight])
+  const currentHeight = useMemo(
+    () => computeHeight(hmdHeight, floorHeight),
+    [hmdHeight, floorHeight]
+  );
 
   return { hmdHeight, setHmdHeight, floorHeight, setFloorHeight, currentHeight };
 }

--- a/gui/src/hooks/height.ts
+++ b/gui/src/hooks/height.ts
@@ -8,27 +8,13 @@ export interface HeightContext {
   setHmdHeight: React.Dispatch<React.SetStateAction<number | null>>;
   floorHeight: number | null;
   setFloorHeight: React.Dispatch<React.SetStateAction<number | null>>;
-  validateHeight: (
-    hmdHeight: number | null | undefined,
-    floorHeight: number | null | undefined
-  ) => boolean;
+  currentHeight: () => number | null;
 }
 
 export function useProvideHeightContext(): HeightContext {
   const [hmdHeight, setHmdHeight] = useState<number | null>(null);
   const [floorHeight, setFloorHeight] = useState<number | null>(null);
   const { sendRPCPacket, useRPCPacket } = useWebsocketAPI();
-
-  function validateHeight(
-    hmdHeight: number | null | undefined,
-    floorHeight: number | null | undefined
-  ) {
-    return (
-      hmdHeight !== undefined &&
-      hmdHeight !== null &&
-      hmdHeight - (floorHeight ?? 0) > MIN_HEIGHT
-    );
-  }
 
   useEffect(
     () => sendRPCPacket(RpcMessage.SettingsRequest, new SettingsRequestT()),
@@ -44,7 +30,9 @@ export function useProvideHeightContext(): HeightContext {
     }
   });
 
-  return { hmdHeight, setHmdHeight, floorHeight, setFloorHeight, validateHeight };
+  const currentHeight = () => computeHeight(hmdHeight, floorHeight);
+
+  return { hmdHeight, setHmdHeight, floorHeight, setFloorHeight, currentHeight };
 }
 
 export const HeightContextC = createContext<HeightContext>(undefined as never);
@@ -57,7 +45,28 @@ export function useHeightContext() {
   return context;
 }
 
+export function validateHeight(
+  hmdHeight: number | null | undefined,
+  floorHeight: number | null | undefined
+) {
+  const height = computeHeight(hmdHeight, floorHeight);
+  return height != null && height >= MIN_HEIGHT;
+}
+
+export function computeHeight(
+  hmdHeight: number | null | undefined,
+  floorHeight: number | null | undefined
+) {
+  return hmdHeight !== undefined && hmdHeight !== null
+    ? hmdHeight - (floorHeight ?? 0)
+    : null;
+}
+
 // The headset height is not the full height! This value compensates for the
 // offset from the headset height to the user full height
 // From Drillis and Contini (1966)
 export const EYE_HEIGHT_TO_HEIGHT_RATIO = 0.936;
+
+// Based on average human height (1.65m)
+// From https://ourworldindata.org/human-height (January 2024)
+export const DEFAULT_EYE_HEIGHT = 1.65 * EYE_HEIGHT_TO_HEIGHT_RATIO;

--- a/gui/src/hooks/height.ts
+++ b/gui/src/hooks/height.ts
@@ -69,4 +69,5 @@ export const EYE_HEIGHT_TO_HEIGHT_RATIO = 0.936;
 
 // Based on average human height (1.65m)
 // From https://ourworldindata.org/human-height (January 2024)
-export const DEFAULT_EYE_HEIGHT = 1.65 * EYE_HEIGHT_TO_HEIGHT_RATIO;
+export const DEFAULT_FULL_HEIGHT = 1.65;
+export const DEFAULT_EYE_HEIGHT = DEFAULT_FULL_HEIGHT * EYE_HEIGHT_TO_HEIGHT_RATIO;


### PR DESCRIPTION
Currently we only load the configured height for automatic height config, we should do the same for manual.

This PR is still a draft because it doesn't seem to actually apply the default. This is probably because of retaining the initial state before the config is loaded.