### PR TITLE
Add OTA port to firewall script

### DIFF
--- a/server/core/resources/firewall.bat
+++ b/server/core/resources/firewall.bat
@@ -23,6 +23,9 @@ call :AddRule "SlimeVR TCP 21110 outgoing" "dir=out action=allow protocol=TCP lo
 rem OpenJDK Platform Binary access
 call :AddRule "SlimeVR OpenJDK Platform incoming" "dir=in action=allow program=%~dp0jre\bin\java.exe enable=yes"
 call :AddRule "SlimeVR OpenJDK Platform outgoing" "dir=out action=allow program=%~dp0jre\bin\java.exe enable=yes"
+rem ESP8266 OTA default port
+call :AddRule "SlimeVR UDP 8266 incoming" "dir=in action=allow protocol=UDP localport=8266 enable=yes"
+call :AddRule "SlimeVR UDP 8266 outgoing" "dir=out action=allow protocol=UDP localport=8266 enable=yes"
 
 echo Done!
 pause


### PR DESCRIPTION
8266/UDP is used for initiating and authenticating OTA requests with ESP8266, the TCP side is dynamically allocated so we can't explicitly allow it