### PR TITLE
Fix for override.ftl not working

### DIFF
--- a/gui/src-tauri/capabilities/migrated.json
+++ b/gui/src-tauri/capabilities/migrated.json
@@ -24,6 +24,12 @@
     "store:allow-get",
     "store:allow-set",
     "store:allow-save",
-    "fs:allow-write-text-file"
+    "fs:allow-write-text-file",
+    "fs:allow-read-text-file",
+    "fs:allow-exists",
+    {
+      "identifier": "fs:scope",
+      "allow": [{ "path": "$APPDATA" }, { "path": "$APPDATA/**" }]
+    }
   ]
 }

--- a/gui/src/i18n/config.tsx
+++ b/gui/src/i18n/config.tsx
@@ -118,7 +118,7 @@ export const langs = [
 // only on launch :P
 const overrideLangExists = exists(OVERRIDE_FILENAME, {
     baseDir: BaseDirectory.AppConfig,
-    }).catch((e) => false);
+    }).catch(() => false);
 
 // Fetch translation file
 async function fetchMessages(locale: string): Promise<[string, string]> {

--- a/gui/src/i18n/config.tsx
+++ b/gui/src/i18n/config.tsx
@@ -117,8 +117,8 @@ export const langs = [
 // We doing this only once, don't want an override check to be done on runtime,
 // only on launch :P
 const overrideLangExists = exists(OVERRIDE_FILENAME, {
-    baseDir: BaseDirectory.AppConfig,
-    }).catch(() => false);
+  baseDir: BaseDirectory.AppConfig,
+}).catch(() => false);
 
 // Fetch translation file
 async function fetchMessages(locale: string): Promise<[string, string]> {

--- a/gui/src/i18n/config.tsx
+++ b/gui/src/i18n/config.tsx
@@ -116,7 +116,9 @@ export const langs = [
 // AppConfig path: https://docs.rs/tauri/1.2.4/tauri/api/path/fn.config_dir.html
 // We doing this only once, don't want an override check to be done on runtime,
 // only on launch :P
-const overrideLangExists = exists(OVERRIDE_FILENAME).catch(() => false);
+const overrideLangExists = exists(OVERRIDE_FILENAME, {
+    baseDir: BaseDirectory.AppConfig,
+    }).catch((e) => false);
 
 // Fetch translation file
 async function fetchMessages(locale: string): Promise<[string, string]> {


### PR DESCRIPTION
-Add Permissions for exists and read_text_file allow the appdata of the app to be accessible. -Make sure exist looks at the right directory

Needs to be tested on:
[x] Windows
[ ] Linux
[ ] Android
[ ] Quest
[ ] Apple

for not breaking anything.
Server has to be restarted to get the translations from override.ftl or to switch to a other language.