### PR TITLE
differentiable reset sounds

### DIFF
--- a/gui/src/components/home/ResetButton.tsx
+++ b/gui/src/components/home/ResetButton.tsx
@@ -99,7 +99,7 @@ export function ResetButton({
   const maybePlaySoundOnResetStart = () => {
     if (!config?.feedbackSound) return;
     if (type !== ResetType.Yaw)
-      playSoundOnResetStarted(config?.feedbackSoundVolume);
+      playSoundOnResetStarted(type, config?.feedbackSoundVolume);
   };
 
   const triggerReset = () => {

--- a/gui/src/hooks/app.ts
+++ b/gui/src/hooks/app.ts
@@ -125,7 +125,7 @@ export function useProvideAppContext(): AppContext {
       switch (status) {
         case ResetStatus.STARTED: {
           if (resetType !== ResetType.Yaw)
-            playSoundOnResetStarted(config?.feedbackSoundVolume);
+            playSoundOnResetStarted(resetType, config?.feedbackSoundVolume);
           break;
         }
         case ResetStatus.FINISHED: {

--- a/gui/src/sounds/sounds.ts
+++ b/gui/src/sounds/sounds.ts
@@ -15,7 +15,7 @@ export async function playSoundOnResetEnded(resetType: ResetType, volume = 1) {
   switch (resetType) {
     case ResetType.Yaw: {
       xylophone.play({
-        notes: ['C4'],
+        notes: ['B3', 'D4'],
         offset: 0.15,
         type: 'custom',
         volume,
@@ -43,13 +43,27 @@ export async function playSoundOnResetEnded(resetType: ResetType, volume = 1) {
   }
 }
 
-export async function playSoundOnResetStarted(volume = 1) {
-  await xylophone.play({
-    notes: ['A4'],
-    offset: 0.4,
-    type: 'custom',
-    volume,
-  });
+export async function playSoundOnResetStarted(resetType: ResetType, volume = 1) {
+  switch (resetType) {
+    case ResetType.Full: {
+      await xylophone.play({
+        notes: ['D4', 'F#4'],
+        offset: 0.15,
+        type: 'custom',
+        volume,
+      });
+      break;
+    }
+    case ResetType.Mounting: {
+      await xylophone.play({
+        notes: ['F#4', 'A4'],
+        offset: 0.15,
+        type: 'custom',
+        volume,
+      });
+      break;
+    }
+  }
 }
 
 let lastTap = 0;


### PR DESCRIPTION
original sounds between full reset and mounting could be differentiated by speed, so instead play a unique pattern
I am not sure this is needed, but maybe it is a good idea.