### PR TITLE
make tracker entry borders consistent with no border

### DIFF
--- a/gui/src/components/tracker/TrackerCard.tsx
+++ b/gui/src/components/tracker/TrackerCard.tsx
@@ -203,7 +203,8 @@ export function TrackerCard({
           'rounded-lg overflow-hidden transition-[box-shadow] duration-200 ease-linear',
           interactable && 'hover:bg-background-50 cursor-pointer',
           outlined && 'outline outline-2 outline-accent-background-40',
-          warning && 'border-status-warning border-solid border-2',
+          warning &&
+            'outline outline-2 -outline-offset-2 outline-status-warning',
           bg
         )}
         style={

--- a/gui/src/components/tracker/TrackersTable.tsx
+++ b/gui/src/components/tracker/TrackersTable.tsx
@@ -142,12 +142,12 @@ export function RowContainer({
         }}
         className={classNames(
           'h-[50px]  flex flex-col justify-center px-3 transition-[box-shadow] duration-200 ease-linear',
-          rounded === 'left' && 'rounded-l-lg',
-          rounded === 'right' && 'rounded-r-lg',
+          rounded === 'left' && 'rounded-l-lg border-l-2',
+          rounded === 'right' && 'rounded-r-lg border-r-2',
           hover ? 'bg-background-50 cursor-pointer' : 'bg-background-60',
-          warning && 'border-status-warning border-solid border-t-2 border-b-2',
-          rounded === 'left' && warning && 'border-l-2',
-          rounded === 'right' && warning && 'border-r-2'
+          (warning &&
+            'border-status-warning border-solid border-t-2 border-b-2') ||
+            'border-transparent'
         )}
       >
         {children}


### PR DESCRIPTION
fix misalignment when some trackers have warnings but not others

On TrackerCard: use outline instead of border, it does not interfere with outline used in assignment
On TrackerTable: persistent border and use transparent