### PR TITLE
Fix battery resistances being sent as string instead of numbers

### DIFF
--- a/gui/src/hooks/firmware-tool.ts
+++ b/gui/src/hooks/firmware-tool.ts
@@ -188,6 +188,7 @@ export function useFirmwareToolContext(): FirmwareToolContext {
           boardConfig: {
             ...currConfig.boardConfig,
             ...form,
+            batteryResistances: form.batteryResistances.map((r) => Number(r)),
           },
         };
       });


### PR DESCRIPTION
Fixes: #1406
