### PR TITLE
Allow partial/separate resets for feet and fingers

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -237,6 +237,8 @@ reset-reset_all_warning_default-v2 =
 
 reset-full = Full Reset
 reset-mounting = Reset Mounting
+reset-mounting-feet = Reset Mounting Feet
+reset-mounting-fingers = Reset Mounting Fingers
 reset-yaw = Yaw Reset
 
 ## Serial detection stuff

--- a/gui/src/components/WidgetsComponent.tsx
+++ b/gui/src/components/WidgetsComponent.tsx
@@ -75,6 +75,16 @@ export function WidgetsComponent() {
         <ResetButton type={ResetType.Full} size="big"></ResetButton>
         <ResetButton type={ResetType.Mounting} size="big"></ResetButton>
         <ClearMountingButton></ClearMountingButton>
+        <ResetButton
+          type={ResetType.Mounting}
+          size="big"
+          bodyPartsToReset="feet"
+        ></ResetButton>
+        <ResetButton
+          type={ResetType.Mounting}
+          size="big"
+          bodyPartsToReset="fingers"
+        ></ResetButton>
         <BVHButton></BVHButton>
         <TrackingPauseButton></TrackingPauseButton>
         <ClearDriftCompensationButton

--- a/gui/src/components/home/ResetButton.tsx
+++ b/gui/src/components/home/ResetButton.tsx
@@ -1,6 +1,7 @@
 import { useLocalization } from '@fluent/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  BodyPart,
   ResetRequestT,
   ResetType,
   RpcMessage,
@@ -26,12 +27,14 @@ import classNames from 'classnames';
 export function ResetButton({
   type,
   size = 'big',
+  bodyPartsToReset = 'default',
   className,
   onReseted,
 }: {
   className?: string;
   type: ResetType;
   size: 'big' | 'small';
+  bodyPartsToReset?: 'default' | 'feet' | 'fingers';
   onReseted?: () => void;
 }) {
   const { l10n } = useLocalization();
@@ -50,9 +53,53 @@ export function ResetButton({
     [statuses]
   );
 
+  const feetBodyParts = [BodyPart.LEFT_FOOT, BodyPart.RIGHT_FOOT];
+  const fingerBodyParts = [
+    BodyPart.LEFT_THUMB_METACARPAL,
+    BodyPart.LEFT_THUMB_PROXIMAL,
+    BodyPart.LEFT_THUMB_DISTAL,
+    BodyPart.LEFT_INDEX_PROXIMAL,
+    BodyPart.LEFT_INDEX_INTERMEDIATE,
+    BodyPart.LEFT_INDEX_DISTAL,
+    BodyPart.LEFT_MIDDLE_PROXIMAL,
+    BodyPart.LEFT_MIDDLE_INTERMEDIATE,
+    BodyPart.LEFT_MIDDLE_DISTAL,
+    BodyPart.LEFT_RING_PROXIMAL,
+    BodyPart.LEFT_RING_INTERMEDIATE,
+    BodyPart.LEFT_RING_DISTAL,
+    BodyPart.LEFT_LITTLE_PROXIMAL,
+    BodyPart.LEFT_LITTLE_INTERMEDIATE,
+    BodyPart.LEFT_LITTLE_DISTAL,
+    BodyPart.RIGHT_THUMB_METACARPAL,
+    BodyPart.RIGHT_THUMB_PROXIMAL,
+    BodyPart.RIGHT_THUMB_DISTAL,
+    BodyPart.RIGHT_INDEX_PROXIMAL,
+    BodyPart.RIGHT_INDEX_INTERMEDIATE,
+    BodyPart.RIGHT_INDEX_DISTAL,
+    BodyPart.RIGHT_MIDDLE_PROXIMAL,
+    BodyPart.RIGHT_MIDDLE_INTERMEDIATE,
+    BodyPart.RIGHT_MIDDLE_DISTAL,
+    BodyPart.RIGHT_RING_PROXIMAL,
+    BodyPart.RIGHT_RING_INTERMEDIATE,
+    BodyPart.RIGHT_RING_DISTAL,
+    BodyPart.RIGHT_LITTLE_PROXIMAL,
+    BodyPart.RIGHT_LITTLE_INTERMEDIATE,
+    BodyPart.RIGHT_LITTLE_DISTAL,
+  ];
+
   const reset = () => {
     const req = new ResetRequestT();
     req.resetType = type;
+    if (bodyPartsToReset == 'default') {
+      // Default (server handles it)
+      req.bodyParts = [];
+    } else if (bodyPartsToReset == 'feet') {
+      // Feet
+      req.bodyParts = feetBodyParts;
+    } else if (bodyPartsToReset == 'fingers') {
+      // Fingers
+      req.bodyParts = fingerBodyParts;
+    }
     sendRPCPacket(RpcMessage.ResetRequest, req);
   };
 
@@ -75,13 +122,22 @@ export function ResetButton({
   const text = useMemo(() => {
     switch (type) {
       case ResetType.Yaw:
-        return l10n.getString('reset-yaw');
+        return l10n.getString(
+          'reset-yaw' +
+            (bodyPartsToReset != 'default' ? '-' + bodyPartsToReset : '')
+        );
       case ResetType.Mounting:
-        return l10n.getString('reset-mounting');
+        return l10n.getString(
+          'reset-mounting' +
+            (bodyPartsToReset != 'default' ? '-' + bodyPartsToReset : '')
+        );
       case ResetType.Full:
-        return l10n.getString('reset-full');
+        return l10n.getString(
+          'reset-full' +
+            (bodyPartsToReset != 'default' ? '-' + bodyPartsToReset : '')
+        );
     }
-  }, [type]);
+  }, [type, bodyPartsToReset]);
 
   const getIcon = () => {
     switch (type) {

--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -97,7 +97,6 @@ interface SettingsForm {
     correctionStrength: number;
   };
   resetsSettings: {
-    resetMountingFeet: boolean;
     armsMountingResetMode: number;
     yawResetSmoothTime: number;
     saveMountingReset: boolean;
@@ -163,7 +162,6 @@ const defaultValues: SettingsForm = {
   },
   legTweaks: { correctionStrength: 0.3 },
   resetsSettings: {
-    resetMountingFeet: false,
     armsMountingResetMode: 0,
     yawResetSmoothTime: 0.0,
     saveMountingReset: false,
@@ -299,8 +297,6 @@ export function GeneralSettings() {
 
     if (values.resetsSettings) {
       const resetsSettings = new ResetsSettingsT();
-      resetsSettings.resetMountingFeet =
-        values.resetsSettings.resetMountingFeet;
       resetsSettings.armsMountingResetMode =
         values.resetsSettings.armsMountingResetMode;
       resetsSettings.yawResetSmoothTime =
@@ -967,24 +963,6 @@ export function GeneralSettings() {
                 name="resetsSettings.resetHmdPitch"
                 label={l10n.getString(
                   'settings-general-fk_settings-reset_settings-reset_hmd_pitch'
-                )}
-              />
-            </div>
-            <div className="flex flex-col pt-2 pb-3">
-              <Typography color="secondary">
-                {l10n.getString(
-                  'settings-general-fk_settings-leg_fk-reset_mounting_feet-description'
-                )}
-              </Typography>
-            </div>
-            <div className="grid sm:grid-cols-1 gap-3 pb-3">
-              <CheckBox
-                variant="toggle"
-                outlined
-                control={control}
-                name="resetsSettings.resetMountingFeet"
-                label={l10n.getString(
-                  'settings-general-fk_settings-leg_fk-reset_mounting_feet'
                 )}
               />
             </div>

--- a/server/core/src/main/java/dev/slimevr/VRServer.kt
+++ b/server/core/src/main/java/dev/slimevr/VRServer.kt
@@ -40,6 +40,7 @@ import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
+import kotlin.collections.ArrayList
 import kotlin.concurrent.schedule
 
 typealias BridgeProvider = (
@@ -297,16 +298,16 @@ class VRServer @JvmOverloads constructor(
 		}
 	}
 
-	fun resetTrackersFull(resetSourceName: String?) {
-		queueTask { humanPoseManager.resetTrackersFull(resetSourceName) }
+	fun resetTrackersFull(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
+		queueTask { humanPoseManager.resetTrackersFull(resetSourceName, bodyParts) }
 	}
 
-	fun resetTrackersYaw(resetSourceName: String?) {
-		queueTask { humanPoseManager.resetTrackersYaw(resetSourceName) }
+	fun resetTrackersYaw(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers) {
+		queueTask { humanPoseManager.resetTrackersYaw(resetSourceName, bodyParts) }
 	}
 
-	fun resetTrackersMounting(resetSourceName: String?) {
-		queueTask { humanPoseManager.resetTrackersMounting(resetSourceName) }
+	fun resetTrackersMounting(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFeetAndFingers) {
+		queueTask { humanPoseManager.resetTrackersMounting(resetSourceName, bodyParts) }
 	}
 
 	fun clearTrackersMounting(resetSourceName: String?) {

--- a/server/core/src/main/java/dev/slimevr/config/ResetsConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/ResetsConfig.kt
@@ -31,9 +31,6 @@ enum class ArmsResetModes(val id: Int) {
 
 class ResetsConfig {
 
-	// Enable mounting reset for feet?
-	var resetMountingFeet = false
-
 	// Reset mode used for the arms
 	var mode = ArmsResetModes.BACK
 

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
@@ -329,9 +329,11 @@ class RPCHandler(private val api: ProtocolAPI) : ProtocolHandler<RpcMessageHeade
 		// Get the list of bodyparts we want to reset
 		// If empty, check in HumanSkeleton will reset all
 		val bodyParts = mutableListOf<Int>()
-		val buffer = req.bodyPartsAsByteBuffer()
-		while (buffer.hasRemaining()) {
-			bodyParts.add(buffer.get().toInt())
+		if (req.bodyPartsLength() > 0) {
+			val buffer = req.bodyPartsAsByteBuffer()
+			while (buffer.hasRemaining()) {
+				bodyParts.add(buffer.get().toInt())
+			}
 		}
 
 		if (req.resetType() == ResetType.Yaw) {

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
@@ -326,9 +326,35 @@ class RPCHandler(private val api: ProtocolAPI) : ProtocolHandler<RpcMessageHeade
 	fun onResetRequest(conn: GenericConnection, messageHeader: RpcMessageHeader) {
 		val req = messageHeader.message(ResetRequest()) as? ResetRequest ?: return
 
-		if (req.resetType() == ResetType.Yaw) api.server.resetTrackersYaw(RESET_SOURCE_NAME)
-		if (req.resetType() == ResetType.Full) api.server.resetTrackersFull(RESET_SOURCE_NAME)
-		if (req.resetType() == ResetType.Mounting) api.server.resetTrackersMounting(RESET_SOURCE_NAME)
+		// Get the list of bodyparts we want to reset
+		// If empty, check in HumanSkeleton will reset all
+		val bodyParts = mutableListOf<Int>()
+		val buffer = req.bodyPartsAsByteBuffer()
+		while (buffer.hasRemaining()) {
+			bodyParts.add(buffer.get().toInt())
+		}
+
+		if (req.resetType() == ResetType.Yaw) {
+			if (bodyParts.isEmpty()) {
+				api.server.resetTrackersYaw(RESET_SOURCE_NAME)
+			} else {
+				api.server.resetTrackersYaw(RESET_SOURCE_NAME, bodyParts.toList())
+			}
+		}
+		if (req.resetType() == ResetType.Full) {
+			if (bodyParts.isEmpty()) {
+				api.server.resetTrackersFull(RESET_SOURCE_NAME)
+			} else {
+				api.server.resetTrackersFull(RESET_SOURCE_NAME, bodyParts.toList())
+			}
+		}
+		if (req.resetType() == ResetType.Mounting) {
+			if (bodyParts.isEmpty()) {
+				api.server.resetTrackersMounting(RESET_SOURCE_NAME)
+			} else {
+				api.server.resetTrackersMounting(RESET_SOURCE_NAME, bodyParts.toList())
+			}
+		}
 	}
 
 	fun onClearMountingResetRequest(

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsBuilder.java
@@ -346,7 +346,6 @@ public class RPCSettingsBuilder {
 		return ResetsSettings
 			.createResetsSettings(
 				fbb,
-				resetsConfig.getResetMountingFeet(),
 				resetsConfig.getMode().getId(),
 				resetsConfig.getYawResetSmoothTime(),
 				resetsConfig.getSaveMountingReset(),

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/settings/RPCSettingsHandler.kt
@@ -347,7 +347,6 @@ class RPCSettingsHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) {
 			if (mode != null) {
 				resetsConfig.mode = mode
 			}
-			resetsConfig.resetMountingFeet = req.resetsSettings().resetMountingFeet()
 			resetsConfig.saveMountingReset = req.resetsSettings().saveMountingReset()
 			resetsConfig.yawResetSmoothTime = req.resetsSettings().yawResetSmoothTime()
 			resetsConfig.resetHmdPitch = req.resetsSettings().resetHmdPitch()

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
@@ -10,10 +10,7 @@ import dev.slimevr.tracking.processor.config.SkeletonConfigOffsets
 import dev.slimevr.tracking.processor.config.SkeletonConfigToggles
 import dev.slimevr.tracking.processor.config.SkeletonConfigValues
 import dev.slimevr.tracking.processor.skeleton.HumanSkeleton
-import dev.slimevr.tracking.trackers.Tracker
-import dev.slimevr.tracking.trackers.TrackerPosition
-import dev.slimevr.tracking.trackers.TrackerRole
-import dev.slimevr.tracking.trackers.TrackerStatus
+import dev.slimevr.tracking.trackers.*
 import dev.slimevr.trackingpause.TrackingPauseHandler
 import dev.slimevr.util.ann.VRServerThread
 import io.eiren.util.ann.ThreadSafe
@@ -482,8 +479,9 @@ class HumanPoseManager(val server: VRServer?) {
 		skeletonConfigManager.computeNodeOffset(node)
 	}
 
-	fun resetTrackersFull(resetSourceName: String?) {
-		skeleton.resetTrackersFull(resetSourceName)
+	@JvmOverloads
+	fun resetTrackersFull(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
+		skeleton.resetTrackersFull(resetSourceName, bodyParts)
 		if (server != null) {
 			if (skeleton.headTracker == null && skeleton.neckTracker == null) {
 				server.vrcOSCHandler.yawAlign(IDENTITY)
@@ -498,8 +496,9 @@ class HumanPoseManager(val server: VRServer?) {
 		}
 	}
 
-	fun resetTrackersYaw(resetSourceName: String?) {
-		skeleton.resetTrackersYaw(resetSourceName)
+	@JvmOverloads
+	fun resetTrackersYaw(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers) {
+		skeleton.resetTrackersYaw(resetSourceName, bodyParts)
 		if (server != null) {
 			if (skeleton.headTracker == null && skeleton.neckTracker == null) {
 				server.vrcOSCHandler.yawAlign(IDENTITY)
@@ -571,8 +570,9 @@ class HumanPoseManager(val server: VRServer?) {
 		}
 	}
 
-	fun resetTrackersMounting(resetSourceName: String?) {
-		skeleton.resetTrackersMounting(resetSourceName)
+	@JvmOverloads
+	fun resetTrackersMounting(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFeetAndFingers) {
+		skeleton.resetTrackersMounting(resetSourceName, bodyParts)
 	}
 
 	fun clearTrackersMounting(resetSourceName: String?) {

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -11,6 +11,7 @@ import dev.slimevr.tracking.processor.config.SkeletonConfigValues
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerPosition
 import dev.slimevr.tracking.trackers.TrackerRole
+import dev.slimevr.tracking.trackers.TrackerUtils
 import dev.slimevr.tracking.trackers.TrackerUtils.getFirstAvailableTracker
 import dev.slimevr.tracking.trackers.TrackerUtils.getTrackerForSkeleton
 import dev.slimevr.tracking.trackers.udp.TrackerDataType
@@ -26,6 +27,7 @@ import io.github.axisangles.ktmath.Vector3
 import io.github.axisangles.ktmath.Vector3.Companion.NEG_Y
 import io.github.axisangles.ktmath.Vector3.Companion.NULL
 import io.github.axisangles.ktmath.Vector3.Companion.POS_Y
+import solarxr_protocol.datatypes.BodyPart
 import java.lang.IllegalArgumentException
 import kotlin.properties.Delegates
 
@@ -1502,17 +1504,21 @@ class HumanSkeleton(
 			rightLittleDistalTracker,
 		)
 
-	fun resetTrackersFull(resetSourceName: String?) {
+	@JvmOverloads
+	fun resetTrackersFull(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
 		var referenceRotation = IDENTITY
-		headTracker?.let {
-			// Always reset the head (ifs in resetsHandler)
-			it.resetsHandler.resetFull(referenceRotation)
-			referenceRotation = it.getRotation()
+		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
+			headTracker?.let {
+				// Always reset the head (ifs in resetsHandler)
+				it.resetsHandler.resetFull(referenceRotation)
+				referenceRotation = it.getRotation()
+			}
 		}
+
 		// Resets all axes of the trackers with the HMD as reference.
 		for (tracker in trackersToReset) {
 			// Only reset if tracker needsReset
-			if (tracker != null && (tracker.needsReset || tracker.isHmd)) {
+			if (tracker != null && (tracker.needsReset || tracker.isHmd) && (bodyParts.isEmpty() || bodyParts.contains(tracker.trackerPosition?.bodyPart))) {
 				tracker.resetsHandler.resetFull(referenceRotation)
 			}
 		}
@@ -1528,19 +1534,22 @@ class HumanSkeleton(
 	}
 
 	@VRServerThread
-	fun resetTrackersYaw(resetSourceName: String?) {
+	@JvmOverloads
+	fun resetTrackersYaw(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers) {
 		// Resets the yaw of the trackers with the head as reference.
 		var referenceRotation = IDENTITY
-		headTracker?.let {
-			// Only reset if head needsReset and isn't computed
-			if (it.needsReset && !it.isComputed) {
-				it.resetsHandler.resetYaw(referenceRotation)
+		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
+			headTracker?.let {
+				// Only reset if head needsReset and isn't computed
+				if (it.needsReset && !it.isComputed) {
+					it.resetsHandler.resetYaw(referenceRotation)
+				}
+				referenceRotation = it.getRotation()
 			}
-			referenceRotation = it.getRotation()
 		}
 		for (tracker in trackersToReset) {
 			// Only reset if tracker needsReset
-			if (tracker != null && tracker.needsReset) {
+			if (tracker != null && tracker.needsReset && (bodyParts.isEmpty() || bodyParts.contains(tracker.trackerPosition?.bodyPart))) {
 				tracker.resetsHandler.resetYaw(referenceRotation)
 			}
 		}
@@ -1549,7 +1558,8 @@ class HumanSkeleton(
 	}
 
 	@VRServerThread
-	fun resetTrackersMounting(resetSourceName: String?) {
+	@JvmOverloads
+	fun resetTrackersMounting(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
 		val trackersToReset = trackersToReset
 
 		// TODO: PLEASE rewrite this handling at some point in the future... This is so
@@ -1564,16 +1574,18 @@ class HumanSkeleton(
 
 		// Resets the mounting orientation of the trackers with the HMD as reference.
 		var referenceRotation = IDENTITY
-		headTracker?.let {
-			// Only reset if head needsMounting or is computed but not HMD
-			if (it.needsMounting || (it.isComputed && !it.isHmd)) {
-				it.resetsHandler.resetMounting(referenceRotation)
+		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
+			headTracker?.let {
+				// Only reset if head needsMounting or is computed but not HMD
+				if (it.needsMounting || (it.isComputed && !it.isHmd)) {
+					it.resetsHandler.resetMounting(referenceRotation)
+				}
+				referenceRotation = it.getRotation()
 			}
-			referenceRotation = it.getRotation()
 		}
 		for (tracker in trackersToReset) {
 			// Only reset if tracker needsMounting
-			if (tracker != null && tracker.needsMounting) {
+			if (tracker != null && tracker.needsMounting && (bodyParts.isEmpty() || bodyParts.contains(tracker.trackerPosition?.bodyPart))) {
 				tracker.resetsHandler.resetMounting(referenceRotation)
 			}
 		}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerPosition.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerPosition.kt
@@ -135,5 +135,99 @@ enum class TrackerPosition(
 
 		@JvmStatic
 		fun getById(id: Int): TrackerPosition? = byId[id]
+
+		fun isThigh(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.LEFT_UPPER_LEG ||
+					it == TrackerPosition.RIGHT_UPPER_LEG
+			}
+			return false
+		}
+
+		fun isLeftArm(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.LEFT_SHOULDER ||
+					it == TrackerPosition.LEFT_UPPER_ARM ||
+					it == TrackerPosition.LEFT_LOWER_ARM ||
+					it == TrackerPosition.LEFT_HAND
+			}
+			return false
+		}
+
+		fun isRightArm(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.RIGHT_SHOULDER ||
+					it == TrackerPosition.RIGHT_UPPER_ARM ||
+					it == TrackerPosition.RIGHT_LOWER_ARM ||
+					it == TrackerPosition.RIGHT_HAND
+			}
+			return false
+		}
+
+		fun isLeftLowerArm(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.LEFT_LOWER_ARM ||
+					it == TrackerPosition.LEFT_HAND
+			}
+			return false
+		}
+
+		fun isRightLowerArm(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.RIGHT_LOWER_ARM ||
+					it == TrackerPosition.RIGHT_HAND
+			}
+			return false
+		}
+
+		fun isFoot(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.LEFT_FOOT ||
+					it == TrackerPosition.RIGHT_FOOT
+			}
+			return false
+		}
+
+		fun isLeftFinger(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.LEFT_THUMB_METACARPAL ||
+					it == TrackerPosition.LEFT_THUMB_PROXIMAL ||
+					it == TrackerPosition.LEFT_THUMB_DISTAL ||
+					it == TrackerPosition.LEFT_INDEX_PROXIMAL ||
+					it == TrackerPosition.LEFT_INDEX_INTERMEDIATE ||
+					it == TrackerPosition.LEFT_INDEX_DISTAL ||
+					it == TrackerPosition.LEFT_MIDDLE_PROXIMAL ||
+					it == TrackerPosition.LEFT_MIDDLE_INTERMEDIATE ||
+					it == TrackerPosition.LEFT_MIDDLE_DISTAL ||
+					it == TrackerPosition.LEFT_RING_PROXIMAL ||
+					it == TrackerPosition.LEFT_RING_INTERMEDIATE ||
+					it == TrackerPosition.LEFT_RING_DISTAL ||
+					it == TrackerPosition.LEFT_LITTLE_PROXIMAL ||
+					it == TrackerPosition.LEFT_LITTLE_INTERMEDIATE ||
+					it == TrackerPosition.LEFT_LITTLE_DISTAL
+			}
+			return false
+		}
+
+		fun isRightFinger(trackerPosition: TrackerPosition?): Boolean {
+			trackerPosition?.let {
+				return it == TrackerPosition.RIGHT_THUMB_METACARPAL ||
+					it == TrackerPosition.RIGHT_THUMB_PROXIMAL ||
+					it == TrackerPosition.RIGHT_THUMB_DISTAL ||
+					it == TrackerPosition.RIGHT_INDEX_PROXIMAL ||
+					it == TrackerPosition.RIGHT_INDEX_INTERMEDIATE ||
+					it == TrackerPosition.RIGHT_INDEX_DISTAL ||
+					it == TrackerPosition.RIGHT_MIDDLE_PROXIMAL ||
+					it == TrackerPosition.RIGHT_MIDDLE_INTERMEDIATE ||
+					it == TrackerPosition.RIGHT_MIDDLE_DISTAL ||
+					it == TrackerPosition.RIGHT_RING_PROXIMAL ||
+					it == TrackerPosition.RIGHT_RING_INTERMEDIATE ||
+					it == TrackerPosition.RIGHT_RING_DISTAL ||
+					it == TrackerPosition.RIGHT_LITTLE_PROXIMAL ||
+					it == TrackerPosition.RIGHT_LITTLE_INTERMEDIATE ||
+					it == TrackerPosition.RIGHT_LITTLE_DISTAL
+			}
+			return false
+		}
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -280,9 +280,9 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		}
 
 		// Adjust for T-Pose (down)
-		tposeDownFix = if (((isLeftArmTracker() || isLeftFingerTracker()) && armsResetMode == ArmsResetModes.TPOSE_DOWN)) {
+		tposeDownFix = if (((TrackerPosition.isLeftArm(tracker.trackerPosition) || TrackerPosition.isLeftFinger(tracker.trackerPosition)) && armsResetMode == ArmsResetModes.TPOSE_DOWN)) {
 			EulerAngles(EulerOrder.YZX, 0f, 0f, -FastMath.HALF_PI).toQuaternion()
-		} else if (((isRightArmTracker() || isRightFingerTracker()) && armsResetMode == ArmsResetModes.TPOSE_DOWN)) {
+		} else if (((TrackerPosition.isRightArm(tracker.trackerPosition) || TrackerPosition.isRightFinger(tracker.trackerPosition)) && armsResetMode == ArmsResetModes.TPOSE_DOWN)) {
 			EulerAngles(EulerOrder.YZX, 0f, 0f, FastMath.HALF_PI).toQuaternion()
 		} else {
 			Quaternion.IDENTITY
@@ -412,7 +412,7 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			return
 		} else if (tracker.trackerDataType == TrackerDataType.FLEX_ANGLE) {
 			return
-		} else if (!resetMountingFeet && isFootTracker()) {
+		} else if (!resetMountingFeet && TrackerPosition.isFoot(tracker.trackerPosition)) {
 			return
 		}
 
@@ -434,25 +434,25 @@ class TrackerResetsHandler(val tracker: Tracker) {
 		var yawAngle = atan2(rotVector.x, rotVector.z)
 
 		// Adjust for T-Pose and fingers
-		if ((isLeftArmTracker() && armsResetMode == ArmsResetModes.TPOSE_DOWN) ||
-			(isRightArmTracker() && armsResetMode == ArmsResetModes.TPOSE_UP) ||
-			isLeftFingerTracker()
+		if ((TrackerPosition.isLeftArm(tracker.trackerPosition) && armsResetMode == ArmsResetModes.TPOSE_DOWN) ||
+			(TrackerPosition.isRightArm(tracker.trackerPosition) && armsResetMode == ArmsResetModes.TPOSE_UP) ||
+			TrackerPosition.isLeftFinger(tracker.trackerPosition)
 		) {
 			// Tracker goes right
 			yawAngle -= FastMath.HALF_PI
 		}
-		if ((isLeftArmTracker() && armsResetMode == ArmsResetModes.TPOSE_UP) ||
-			(isRightArmTracker() && armsResetMode == ArmsResetModes.TPOSE_DOWN) ||
-			isRightFingerTracker()
+		if ((TrackerPosition.isLeftArm(tracker.trackerPosition) && armsResetMode == ArmsResetModes.TPOSE_UP) ||
+			(TrackerPosition.isRightArm(tracker.trackerPosition) && armsResetMode == ArmsResetModes.TPOSE_DOWN) ||
+			TrackerPosition.isRightFinger(tracker.trackerPosition)
 		) {
 			// Tracker goes left
 			yawAngle += FastMath.HALF_PI
 		}
 
 		// Adjust for forward/back arms and thighs
-		val isLowerArmBack = armsResetMode == ArmsResetModes.BACK && (isLeftLowerArmTracker() || isRightLowerArmTracker())
-		val isArmForward = armsResetMode == ArmsResetModes.FORWARD && (isLeftArmTracker() || isRightArmTracker())
-		if (!isThighTracker() && !isArmForward && !isLowerArmBack) {
+		val isLowerArmBack = armsResetMode == ArmsResetModes.BACK && (TrackerPosition.isLeftLowerArm(tracker.trackerPosition) || TrackerPosition.isRightLowerArm(tracker.trackerPosition))
+		val isArmForward = armsResetMode == ArmsResetModes.FORWARD && (TrackerPosition.isLeftArm(tracker.trackerPosition) || TrackerPosition.isRightArm(tracker.trackerPosition))
+		if (!TrackerPosition.isThigh(tracker.trackerPosition) && !isArmForward && !isLowerArmBack) {
 			// Tracker goes back
 			yawAngle -= FastMath.PI
 		}
@@ -627,99 +627,5 @@ class TrackerResetsHandler(val tracker: Tracker) {
 					)
 			}
 		}
-	}
-
-	private fun isThighTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.LEFT_UPPER_LEG ||
-				it == TrackerPosition.RIGHT_UPPER_LEG
-		}
-		return false
-	}
-
-	private fun isLeftArmTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.LEFT_SHOULDER ||
-				it == TrackerPosition.LEFT_UPPER_ARM ||
-				it == TrackerPosition.LEFT_LOWER_ARM ||
-				it == TrackerPosition.LEFT_HAND
-		}
-		return false
-	}
-
-	private fun isRightArmTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.RIGHT_SHOULDER ||
-				it == TrackerPosition.RIGHT_UPPER_ARM ||
-				it == TrackerPosition.RIGHT_LOWER_ARM ||
-				it == TrackerPosition.RIGHT_HAND
-		}
-		return false
-	}
-
-	private fun isLeftLowerArmTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.LEFT_LOWER_ARM ||
-				it == TrackerPosition.LEFT_HAND
-		}
-		return false
-	}
-
-	private fun isRightLowerArmTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.RIGHT_LOWER_ARM ||
-				it == TrackerPosition.RIGHT_HAND
-		}
-		return false
-	}
-
-	private fun isFootTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.LEFT_FOOT ||
-				it == TrackerPosition.RIGHT_FOOT
-		}
-		return false
-	}
-
-	private fun isLeftFingerTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.LEFT_THUMB_METACARPAL ||
-				it == TrackerPosition.LEFT_THUMB_PROXIMAL ||
-				it == TrackerPosition.LEFT_THUMB_DISTAL ||
-				it == TrackerPosition.LEFT_INDEX_PROXIMAL ||
-				it == TrackerPosition.LEFT_INDEX_INTERMEDIATE ||
-				it == TrackerPosition.LEFT_INDEX_DISTAL ||
-				it == TrackerPosition.LEFT_MIDDLE_PROXIMAL ||
-				it == TrackerPosition.LEFT_MIDDLE_INTERMEDIATE ||
-				it == TrackerPosition.LEFT_MIDDLE_DISTAL ||
-				it == TrackerPosition.LEFT_RING_PROXIMAL ||
-				it == TrackerPosition.LEFT_RING_INTERMEDIATE ||
-				it == TrackerPosition.LEFT_RING_DISTAL ||
-				it == TrackerPosition.LEFT_LITTLE_PROXIMAL ||
-				it == TrackerPosition.LEFT_LITTLE_INTERMEDIATE ||
-				it == TrackerPosition.LEFT_LITTLE_DISTAL
-		}
-		return false
-	}
-
-	private fun isRightFingerTracker(): Boolean {
-		tracker.trackerPosition?.let {
-			return it == TrackerPosition.RIGHT_THUMB_METACARPAL ||
-				it == TrackerPosition.RIGHT_THUMB_PROXIMAL ||
-				it == TrackerPosition.RIGHT_THUMB_DISTAL ||
-				it == TrackerPosition.RIGHT_INDEX_PROXIMAL ||
-				it == TrackerPosition.RIGHT_INDEX_INTERMEDIATE ||
-				it == TrackerPosition.RIGHT_INDEX_DISTAL ||
-				it == TrackerPosition.RIGHT_MIDDLE_PROXIMAL ||
-				it == TrackerPosition.RIGHT_MIDDLE_INTERMEDIATE ||
-				it == TrackerPosition.RIGHT_MIDDLE_DISTAL ||
-				it == TrackerPosition.RIGHT_RING_PROXIMAL ||
-				it == TrackerPosition.RIGHT_RING_INTERMEDIATE ||
-				it == TrackerPosition.RIGHT_RING_DISTAL ||
-				it == TrackerPosition.RIGHT_LITTLE_PROXIMAL ||
-				it == TrackerPosition.RIGHT_LITTLE_INTERMEDIATE ||
-				it == TrackerPosition.RIGHT_LITTLE_DISTAL
-		}
-		return false
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerResetsHandler.kt
@@ -40,7 +40,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	private var compensateDrift = false
 	private var driftPrediction = false
 	private var driftCompensationEnabled = false
-	private var resetMountingFeet = false
 	private var armsResetMode = ArmsResetModes.BACK
 	private var yawResetSmoothTime = 0.0f
 	private lateinit var fpsTimer: NanoTimer
@@ -172,7 +171,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 	 * Reads/loads reset settings from the given config
 	 */
 	fun readResetConfig(config: ResetsConfig) {
-		resetMountingFeet = config.resetMountingFeet
 		armsResetMode = config.mode
 		yawResetSmoothTime = config.yawResetSmoothTime
 		if (!::fpsTimer.isInitialized) {
@@ -411,8 +409,6 @@ class TrackerResetsHandler(val tracker: Tracker) {
 			tracker.resetFilteringQuats(reference)
 			return
 		} else if (tracker.trackerDataType == TrackerDataType.FLEX_ANGLE) {
-			return
-		} else if (!resetMountingFeet && TrackerPosition.isFoot(tracker.trackerPosition)) {
 			return
 		}
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/TrackerUtils.kt
@@ -1,5 +1,7 @@
 package dev.slimevr.tracking.trackers
 
+import solarxr_protocol.datatypes.BodyPart
+
 object TrackerUtils {
 
 	/**
@@ -90,4 +92,23 @@ object TrackerUtils {
 	fun getFirstAvailableTracker(
 		vararg trackers: Tracker?,
 	): Tracker? = trackers.firstOrNull { it != null }
+
+	val allBodyPartsButFingers = listOf(
+		BodyPart.HEAD, BodyPart.NECK, BodyPart.UPPER_CHEST,
+		BodyPart.CHEST, BodyPart.WAIST, BodyPart.HIP,
+		BodyPart.LEFT_UPPER_LEG, BodyPart.RIGHT_UPPER_LEG, BodyPart.LEFT_LOWER_LEG,
+		BodyPart.RIGHT_LOWER_LEG, BodyPart.LEFT_LOWER_ARM, BodyPart.RIGHT_LOWER_ARM,
+		BodyPart.LEFT_UPPER_ARM, BodyPart.RIGHT_UPPER_ARM, BodyPart.LEFT_HAND,
+		BodyPart.RIGHT_HAND, BodyPart.LEFT_SHOULDER, BodyPart.RIGHT_SHOULDER,
+		BodyPart.LEFT_FOOT, BodyPart.RIGHT_FOOT,
+	)
+
+	val allBodyPartsButFeetAndFingers = listOf(
+		BodyPart.HEAD, BodyPart.NECK, BodyPart.UPPER_CHEST,
+		BodyPart.CHEST, BodyPart.WAIST, BodyPart.HIP,
+		BodyPart.LEFT_UPPER_LEG, BodyPart.RIGHT_UPPER_LEG, BodyPart.LEFT_LOWER_LEG,
+		BodyPart.RIGHT_LOWER_LEG, BodyPart.LEFT_LOWER_ARM, BodyPart.RIGHT_LOWER_ARM,
+		BodyPart.LEFT_UPPER_ARM, BodyPart.RIGHT_UPPER_ARM, BodyPart.LEFT_HAND,
+		BodyPart.RIGHT_HAND, BodyPart.LEFT_SHOULDER, BodyPart.RIGHT_SHOULDER,
+	)
 }


### PR DESCRIPTION
This adds an array on every reset used to specify which trackers should be reset. 
If the array is empty, the server will decide which trackers will be reset (all except fingers and feet during mounting basically).
This deprecates the feet reset feature since I believe it is much better to keep it a separate mounting reset.
This is also backwards compatible.

Needs solar (need edit)