### PR TITLE
[Stay Aligned] Increase yaw correction rate for good IMUs

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAlignedDefaults.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/stayaligned/StayAlignedDefaults.kt
@@ -41,9 +41,9 @@ object StayAlignedDefaults {
 	const val YAW_ERRORS_NEIGHBOR_ERROR_WEIGHT = 1.0f
 
 	// Yaw correction for each type of IMU
-	val YAW_CORRECTION_IMU_GOOD = Angle.ofDeg(0.1f)
-	val YAW_CORRECTION_IMU_OK = Angle.ofDeg(0.2f)
-	val YAW_CORRECTION_IMU_BAD = Angle.ofDeg(0.4f)
+	val YAW_CORRECTION_IMU_GOOD = Angle.ofDeg(0.15f)
+	val YAW_CORRECTION_IMU_OK = Angle.ofDeg(0.20f)
+	val YAW_CORRECTION_IMU_BAD = Angle.ofDeg(0.40f)
 	val YAW_CORRECTION_IMU_DISABLED = Angle.ZERO
 
 	val IMU_TO_YAW_CORRECTION = buildMap {


### PR DESCRIPTION
Increasing it to 0.15 deg/s.

At 0.10 deg/s, I was noticing that even BNO085s were drifting. Before c56d95351630c30baad64198f60ca010baeb9665, we applied 0.20 deg/s to all IMUs. This choice of 0.15 deg/s seems to work well.