### PR TITLE
Free the text coursour? 

### DIFF
--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -7,7 +7,6 @@ body {
   font-family: var(--font-name), 'Noto Sans CJK', sans-serif, emoji;
   width: 100vw;
   height: 100vh;
-  user-select: none;
   background: theme('colors.background.20');
 
   /*Scrollbar for firefox */


### PR DESCRIPTION
I got information, that Slime VR server had a problem in the past, that when you select text - you cannot click it off normally to empty space to deselect. Right now, that problem don't exist anymore. 

Now you can copy and past any alert, parameters and text visualizations if you wanted to do that for debug, tech support or other cases. 

If anyone has any concerns on that change - please share them. <3