### PR TITLE
Fix neck length not being able to be used for VMC

### DIFF
--- a/server/core/src/main/java/dev/slimevr/osc/VMCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/osc/VMCHandler.kt
@@ -367,16 +367,17 @@ class VMCHandler(
 					if (!anchorHip) {
 						// Anchor from head
 						outputUnityArmature?.let { unityArmature ->
-							// Scale the SlimeVR head position with the VRM model
-							val slimevrScaledHeadPos = humanPoseManager.getBone(BoneType.HEAD).getTailPosition() *
-								(vrmHeight / humanPoseManager.userHeightFromConfig)
+							// Scale the SlimeVR neck position with the VRM model
+							// We're only getting the height up to the neck because we don't want to factor the neck's length into the scaling
+							val slimevrScaledRootPos = humanPoseManager.getBone(BoneType.NECK).getTailPosition() *
+								(vrmHeight / humanPoseManager.userNeckHeightFromConfig)
 
 							// Get the VRM head and hip positions
 							val vrmHeadPos = unityArmature.getHeadNodeOfBone(UnityBone.HEAD)!!.parent!!.worldTransform.translation
 							val vrmHipPos = unityArmature.getHeadNodeOfBone(UnityBone.HIPS)!!.worldTransform.translation
 
 							// Calculate the new VRM hip position by subtracting the difference head-hip distance from the SlimeVR head
-							val calculatedVrmHipPos = slimevrScaledHeadPos - (vrmHeadPos - vrmHipPos)
+							val calculatedVrmHipPos = slimevrScaledRootPos - (vrmHeadPos - vrmHipPos)
 
 							// Set the VRM's hip position
 							unityArmature.getHeadNodeOfBone(UnityBone.HIPS)?.localTransform?.translation = calculatedVrmHipPos

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
@@ -643,6 +643,10 @@ class HumanPoseManager(val server: VRServer?) {
 		get() = skeletonConfigManager.userHeightFromOffsets
 
 	@get:ThreadSafe
+	val userNeckHeightFromConfig: Float
+		get() = skeletonConfigManager.userNeckHeightFromOffsets
+
+	@get:ThreadSafe
 	val realUserHeight: Float
 		get() = skeletonConfigManager.userHeightFromOffsets / BodyProportionError.eyeHeightToHeightRatio
 

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
@@ -34,6 +34,9 @@ class SkeletonConfigManager(
 	var userHeightFromOffsets: Float = calculateUserHeight()
 		private set
 
+	var userNeckHeightFromOffsets: Float = calculateUserHeight()
+		private set
+
 	init {
 		if (humanPoseManager?.isSkeletonPresent != false) {
 			updateSettingsInSkeleton()
@@ -87,6 +90,7 @@ class SkeletonConfigManager(
 
 		// Re-calculate user height
 		userHeightFromOffsets = calculateUserHeight()
+		userNeckHeightFromOffsets = userHeightFromOffsets - getOffset(SkeletonConfigOffsets.NECK)
 	}
 
 	fun setOffset(config: SkeletonConfigOffsets, newValue: Float?) {


### PR DESCRIPTION
This basically uses the neck position instead of the head position for VMC when anchoring from the head.

This behaviour change is only relevent for people using positional trackers (or HMDs) for the head, as using a head tracker with no position will have the neck length (and head shift) set to 0 in the skeleton directly.

Relevant Discord thread: https://discord.com/channels/817184208525983775/1380933378425229513/1381713892971122891