### PR TITLE
Fix mounting reset not working for feet

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -1572,7 +1572,7 @@ class HumanSkeleton(
 
 	@VRServerThread
 	@JvmOverloads
-	fun resetTrackersMounting(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
+	fun resetTrackersMounting(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFeetAndFingers) {
 		val trackersToReset = trackersToReset
 
 		// TODO: PLEASE rewrite this handling at some point in the future... This is so

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -1520,12 +1520,12 @@ class HumanSkeleton(
 	@JvmOverloads
 	fun resetTrackersFull(resetSourceName: String?, bodyParts: List<Int> = ArrayList()) {
 		var referenceRotation = IDENTITY
-		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
-			headTracker?.let {
+		headTracker?.let {
+			if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
 				// Always reset the head (ifs in resetsHandler)
 				it.resetsHandler.resetFull(referenceRotation)
-				referenceRotation = it.getRotation()
 			}
+			referenceRotation = it.getRotation()
 		}
 
 		// Resets all axes of the trackers with the HMD as reference.
@@ -1551,14 +1551,14 @@ class HumanSkeleton(
 	fun resetTrackersYaw(resetSourceName: String?, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers) {
 		// Resets the yaw of the trackers with the head as reference.
 		var referenceRotation = IDENTITY
-		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
-			headTracker?.let {
+		headTracker?.let {
+			if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
 				// Only reset if head needsReset and isn't computed
 				if (it.needsReset && !it.isComputed) {
 					it.resetsHandler.resetYaw(referenceRotation)
 				}
-				referenceRotation = it.getRotation()
 			}
+			referenceRotation = it.getRotation()
 		}
 		for (tracker in trackersToReset) {
 			// Only reset if tracker needsReset
@@ -1587,14 +1587,14 @@ class HumanSkeleton(
 
 		// Resets the mounting orientation of the trackers with the HMD as reference.
 		var referenceRotation = IDENTITY
-		if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
-			headTracker?.let {
+		headTracker?.let {
+			if (bodyParts.isEmpty() || bodyParts.contains(BodyPart.HEAD)) {
 				// Only reset if head needsMounting or is computed but not HMD
 				if (it.needsMounting || (it.isComputed && !it.isHmd)) {
 					it.resetsHandler.resetMounting(referenceRotation)
 				}
-				referenceRotation = it.getRotation()
 			}
+			referenceRotation = it.getRotation()
 		}
 		for (tracker in trackersToReset) {
 			// Only reset if tracker needsMounting


### PR DESCRIPTION
This fixes the headset reference not being used for resets that don't include the head. Also changes the tap reset default back to not including feet.
Since we don't have the foot reset toggle anymore, the GUI must be used to reset, we can maybe fix this in a better way after this PR?