### PR TITLE
fix(gui): export proportions button doesn't work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,7 +2645,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4539,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c341290d31991dbca38b31d412c73dfbdb070bb11536784f19dd2211d13b778f"
+checksum = "8c6ef84ee2f2094ce093e55106d90d763ba343fad57566992962e8f76d113f99"
 dependencies = [
  "anyhow",
  "dunce",

--- a/gui/package.json
+++ b/gui/package.json
@@ -18,7 +18,7 @@
     "@tanstack/react-query": "^5.48.0",
     "@tauri-apps/api": "^2.0.2",
     "@tauri-apps/plugin-dialog": "^2.0.0",
-    "@tauri-apps/plugin-fs": "^2.0.0",
+    "@tauri-apps/plugin-fs": "2.4.1",
     "@tauri-apps/plugin-http": "^2.5.0",
     "@tauri-apps/plugin-os": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["derive"] }
 tauri = { version = "2.0", features = ["devtools", "tray-icon", "image-png", "rustls-tls"] }
 tauri-runtime = "2.0"
 tauri-plugin-dialog = "2.0"
-tauri-plugin-fs = "2.0"
+tauri-plugin-fs = "2.4.1"
 tauri-plugin-os = "2.0"
 tauri-plugin-shell = "2.0"
 tauri-plugin-store = "2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@tauri-apps/plugin-fs':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: 2.4.1
+        version: 2.4.1
       '@tauri-apps/plugin-http':
         specifier: ^2.5.0
         version: 2.5.0
@@ -1254,8 +1254,8 @@ packages:
   '@tauri-apps/plugin-dialog@2.0.0':
     resolution: {integrity: sha512-ApNkejXP2jpPBSifznPPcHTXxu9/YaRW+eJ+8+nYwqp0lLUtebFHG4QhxitM43wwReHE81WAV1DQ/b+2VBftOA==}
 
-  '@tauri-apps/plugin-fs@2.0.0':
-    resolution: {integrity: sha512-BNEeQQ5aH8J5SwYuWgRszVyItsmquRuzK2QRkVj8Z0sCsLnSvJFYI3JHRzzr3ltZGq1nMPtblrlZzuKqVzRawA==}
+  '@tauri-apps/plugin-fs@2.4.1':
+    resolution: {integrity: sha512-vJlKZVGF3UAFGoIEVT6Oq5L4HGDCD78WmA4uhzitToqYiBKWAvZR61M6zAyQzHqLs0ADemkE4RSy/5sCmZm6ZQ==}
 
   '@tauri-apps/plugin-http@2.5.0':
     resolution: {integrity: sha512-l4M2DUIsOBIMrbj4dJZwrB4mJiB7OA/2Tj3gEbX2fjq5MOpETklJPKfDvzUTDwuq4lIKCKKykz8E8tpOgvi0EQ==}
@@ -5464,9 +5464,9 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.0.2
 
-  '@tauri-apps/plugin-fs@2.0.0':
+  '@tauri-apps/plugin-fs@2.4.1':
     dependencies:
-      '@tauri-apps/api': 2.0.2
+      '@tauri-apps/api': 2.6.0
 
   '@tauri-apps/plugin-http@2.5.0':
     dependencies:


### PR DESCRIPTION
cargo too dum to lock 2.0 as 2.0.x, instead locked it to 2.x.x or something? :shrug:

works now