### PR TITLE
Fix Android serial support

### DIFF
--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -223,7 +223,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	@Synchronized
 	private fun writeSerial(serialText: String, print: Boolean = false) {
 		try {
-			usbIoManager?.writeAsync("${serialText}\n".toByteArray())
+			currentPort?.port?.write("${serialText}\n".toByteArray(), 0)
 			if (print) {
 				addLog("-> $serialText\n")
 			}
@@ -272,7 +272,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	}
 
 	override fun write(buff: ByteArray) {
-		usbIoManager?.writeAsync(buff)
+		currentPort?.port?.write(buff, 0)
 	}
 
 	@Synchronized

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -287,6 +287,6 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	override fun onRunError(e: java.lang.Exception?) {}
 
 	companion object {
-		private val ACTION_USB_PERMISSION = "dev.slimevr.USB_PERMISSION"
+		private const val ACTION_USB_PERMISSION = "dev.slimevr.USB_PERMISSION"
 	}
 }

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -117,6 +117,11 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 			}
 		}
 
+		// If this port is still open for whatever reason, close it
+		if (port.port.isOpen) {
+			port.port.close()
+		}
+
 		LogManager.info("[SerialHandler] Device removed: ${port.descriptivePortName}")
 		listeners.forEach { it.onSerialDeviceDeleted(port) }
 	}

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -48,7 +48,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	private val manager = activity.getSystemService(Context.USB_SERVICE) as UsbManager
 	private var currentPort: SerialPortWrapper? = null
 	private var requestingPermission: String = ""
-	private var readBuffer: StringBuilder = StringBuilder(4096)
+	private var readBuffer: StringBuilder = StringBuilder(1024)
 
 	override val isConnected: Boolean
 		get() = currentPort?.port?.isOpen ?: false
@@ -295,7 +295,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 			//  than on desktop, so we don't read full lines and it causes parsing issues
 			readBuffer.append(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(data)))
 
-			if (readBuffer.contains('\n') || readBuffer.length >= 4096) {
+			if (readBuffer.contains('\n') || readBuffer.length >= 1024) {
 				addLog(readBuffer.toString(), false)
 				readBuffer.clear()
 			}

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -104,6 +104,11 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	private fun getPorts(): List<UsbSerialDriver> = UsbSerialProber.getDefaultProber().findAllDrivers(manager)
 
 	private fun onNewDevice(port: SerialPortWrapper) {
+		// If we missed clearing this on disconnect/close, clear it on discovery
+		if (requestingPermission == port.portLocation) {
+			requestingPermission = ""
+		}
+
 		listeners.forEach { it.onNewSerialDevice(port) }
 	}
 

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -62,17 +62,8 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	val usbReceiver: BroadcastReceiver = object : BroadcastReceiver() {
 		override fun onReceive(context: Context, intent: Intent) {
 			when (intent.action) {
-				UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
-					// Maybe use device from `UsbManager.EXTRA_DEVICE`? Would make
-					//  me feel better, but honestly this is just easier and probably
-					//  doesn't actually matter.
-					detectNewPorts()
-				}
-
-				UsbManager.ACTION_USB_DEVICE_DETACHED -> {
-					// Might be able to use `UsbManager.EXTRA_DEVICE` like device attached
-					//  event comment, though the device properties may no longer be available
-					//  when this event is fired. This should be checked before proceeding.
+				UsbManager.ACTION_USB_DEVICE_ATTACHED, UsbManager.ACTION_USB_DEVICE_DETACHED -> {
+					// Use device from `UsbManager.EXTRA_DEVICE` if this is a problem
 					detectNewPorts()
 				}
 
@@ -110,7 +101,6 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 		}
 
 		LogManager.info("[SerialHandler] Device added: ${port.descriptivePortName}")
-
 		listeners.forEach { it.onNewSerialDevice(port) }
 	}
 
@@ -128,7 +118,6 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 		}
 
 		LogManager.info("[SerialHandler] Device removed: ${port.descriptivePortName}")
-
 		listeners.forEach { it.onSerialDeviceDeleted(port) }
 	}
 
@@ -203,6 +192,9 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 			)
 			return false
 		}
+
+		// If we have permission, we aren't requesting anymore
+		requestingPermission = ""
 
 		val connection = manager.openDevice(newPort.port.device)
 		if (connection == null) {

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -63,10 +63,16 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 		override fun onReceive(context: Context, intent: Intent) {
 			when (intent.action) {
 				UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
+					// Maybe use device from `UsbManager.EXTRA_DEVICE`? Would make
+					//  me feel better, but honestly this is just easier and probably
+					//  doesn't actually matter.
 					detectNewPorts()
 				}
 
 				UsbManager.ACTION_USB_DEVICE_DETACHED -> {
+					// Might be able to use `UsbManager.EXTRA_DEVICE` like device attached
+					//  event comment, though the device properties may no longer be available
+					//  when this event is fired. This should be checked before proceeding.
 					detectNewPorts()
 				}
 


### PR DESCRIPTION
Fixes the major issues with serial on Android:
- Uses Android USB events to enumerate serial devices rather than polling
- Clears permission request on device removal or permission approval
  - Subsequentent connections now re-request instead of blocking due to the previous request
- Closes serial port on disconnect
  - No longer hangs after removal or on reconnection

Fixes #1334