### PR TITLE
Migrate android into tauri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ build/
 
 # Rust build artifacts
 /target
+/.tauri
+/tauri.settings.gradle
 
 # direnv has been claimed for Nix usage
 .direnv/
@@ -43,6 +45,8 @@ build/
 
 # Ignore Android local properties
 local.properties
+keystore.properties
+/.android
 
 # Ignore temporary config
 vrconfig.yml.tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,7 +4081,6 @@ name = "slimevr"
 version = "0.0.0"
 dependencies = [
  "cfg-if",
- "cfg_aliases",
  "clap",
  "clap-verbosity-flag",
  "color-eyre",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,21 @@
 plugins {
 	id("org.ajoberstar.grgit")
 }
+
+buildscript {
+	repositories {
+		google()
+		mavenCentral()
+	}
+	dependencies {
+		classpath("com.android.tools.build:gradle:8.6.1")
+		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.properties["kotlinVersion"]}")
+	}
+}
+
+subprojects.filter { it.name.contains("tauri") }.forEach {
+	it.repositories {
+		mavenCentral()
+		google()
+	}
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+	`kotlin-dsl`
+}
+
+gradlePlugin {
+    plugins {
+        create("pluginsForCoolKids") {
+            id = "rust"
+            implementationClass = "RustPlugin"
+        }
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(gradleApi())
+    implementation("com.android.tools.build:gradle:8.6.1")
+}
+

--- a/buildSrc/src/main/java/dev/slimevr/slimevr/android/BuildTask.kt
+++ b/buildSrc/src/main/java/dev/slimevr/slimevr/android/BuildTask.kt
@@ -1,0 +1,54 @@
+import java.io.File
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+open class BuildTask : DefaultTask() {
+    @Input
+    var rootDirRel: String? = null
+    @Input
+    var target: String? = null
+    @Input
+    var release: Boolean? = null
+
+    @TaskAction
+    fun assemble() {
+        val executable = """pnpm""";
+        try {
+            runTauriCli(executable)
+        } catch (e: Exception) {
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                runTauriCli("$executable.cmd")
+            } else if (Os.isFamily(Os.FAMILY_UNIX)){
+				runTauriCli("/nix/store/r2n3dbbp0djly6wjxx43sbffaq3abjpy-pnpm-10.15.0/bin/pnpm")
+            } else {
+				throw e
+			}
+        }
+    }
+
+    fun runTauriCli(executable: String) {
+        val rootDirRel = rootDirRel ?: throw GradleException("rootDirRel cannot be null")
+        val target = target ?: throw GradleException("target cannot be null")
+        val release = release ?: throw GradleException("release cannot be null")
+        val args = listOf("tauri", "android", "android-studio-script")
+
+        project.exec {
+            workingDir(File(project.projectDir, rootDirRel))
+            executable(executable)
+            args(args)
+            if (project.logger.isEnabled(LogLevel.DEBUG)) {
+                args("-vv")
+            } else if (project.logger.isEnabled(LogLevel.INFO)) {
+                args("-v")
+            }
+            if (release) {
+                args("--release")
+            }
+            args(listOf("--target", target))
+        }.assertNormalExitValue()
+    }
+}

--- a/buildSrc/src/main/java/dev/slimevr/slimevr/android/RustPlugin.kt
+++ b/buildSrc/src/main/java/dev/slimevr/slimevr/android/RustPlugin.kt
@@ -1,0 +1,85 @@
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+
+const val TASK_GROUP = "rust"
+
+open class Config {
+    lateinit var rootDirRel: String
+}
+
+open class RustPlugin : Plugin<Project> {
+    private lateinit var config: Config
+
+    override fun apply(project: Project) = with(project) {
+        config = extensions.create("rust", Config::class.java)
+
+        val defaultAbiList = listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64");
+        val abiList = (findProperty("abiList") as? String)?.split(',') ?: defaultAbiList
+
+        val defaultArchList = listOf("arm64", "arm", "x86", "x86_64");
+        val archList = (findProperty("archList") as? String)?.split(',') ?: defaultArchList
+
+        val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf("aarch64", "armv7", "i686", "x86_64")
+
+        extensions.configure<ApplicationExtension> {
+            @Suppress("UnstableApiUsage")
+            flavorDimensions.add("abi")
+            productFlavors {
+                create("universal") {
+                    dimension = "abi"
+                    ndk {
+                        abiFilters += abiList
+                    }
+                }
+                defaultArchList.forEachIndexed { index, arch ->
+                    create(arch) {
+                        dimension = "abi"
+                        ndk {
+                            abiFilters.add(defaultAbiList[index])
+                        }
+                    }
+                }
+            }
+        }
+
+        afterEvaluate {
+            for (profile in listOf("debug", "release")) {
+                val profileCapitalized = profile.replaceFirstChar { it.uppercase() }
+                val buildTask = tasks.maybeCreate(
+                    "rustBuildUniversal$profileCapitalized",
+                    DefaultTask::class.java
+                ).apply {
+                    group = TASK_GROUP
+                    description = "Build dynamic library in $profile mode for all targets"
+                }
+
+                tasks["mergeUniversal${profileCapitalized}JniLibFolders"].dependsOn(buildTask)
+
+                for (targetPair in targetsList.withIndex()) {
+                    val targetName = targetPair.value
+                    val targetArch = archList[targetPair.index]
+                    val targetArchCapitalized = targetArch.replaceFirstChar { it.uppercase() }
+                    val targetBuildTask = project.tasks.maybeCreate(
+                        "rustBuild$targetArchCapitalized$profileCapitalized",
+                        BuildTask::class.java
+                    ).apply {
+                        group = TASK_GROUP
+                        description = "Build dynamic library in $profile mode for $targetArch"
+                        rootDirRel = config.rootDirRel
+                        target = targetName
+                        release = profile == "release"
+                    }
+
+                    buildTask.dependsOn(targetBuildTask)
+                    tasks["merge$targetArchCapitalized${profileCapitalized}JniLibFolders"].dependsOn(
+                        targetBuildTask
+                    )
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,26 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  -Dfile.encoding=UTF-8 -Xmx4096M
 
 kotlin.code.style=official
 # https://github.com/Kotlin/kotlinx-atomicfu#atomicfu-compiler-plugin
 kotlinx.atomicfu.enableJvmIrTransformation=true
 
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app"s APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.nonFinalResIds=false
 org.gradle.unsafe.configuration-cache=false
 
 kotlinVersion=2.0.20

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -12,6 +12,13 @@ default-run = "slimevr"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+# The `_lib` suffix may seem redundant but it is necessary
+# to make the lib name unique and wouldn't conflict with the bin name.
+# This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
+name = "slimevr_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
@@ -22,7 +29,6 @@ custom-protocol = ["tauri/custom-protocol"]
 
 [build-dependencies]
 tauri-build = { version = "2.0", features = [] }
-cfg_aliases = "0.2"
 shadow-rs = "0.35"
 
 [dependencies]
@@ -49,7 +55,6 @@ shadow-rs = { version = "0.35", default-features = false }
 const_format = "0.2.30"
 cfg-if = "1"
 color-eyre = "0.6"
-rfd = { version = "0.15", features = ["gtk3"], default-features = false }
 dirs-next = "2.0.0"
 discord-sdk = "0.3.6"
 tokio = { version = "1.37.0", features = ["time"] }
@@ -62,3 +67,6 @@ winreg = "0.52"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = "0.8"
+
+[target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
+rfd = { version = "0.15", features = ["gtk3"], default-features = false }

--- a/gui/src-tauri/build.rs
+++ b/gui/src-tauri/build.rs
@@ -1,5 +1,3 @@
-use cfg_aliases::cfg_aliases;
-
 fn main() -> shadow_rs::SdResult<()> {
 	// Bypass for Nix script having libudev-zero and Tauri not liking it
 	if let Some(path) = option_env!("SLIMEVR_RUST_LD_LIBRARY_PATH") {
@@ -7,9 +5,5 @@ fn main() -> shadow_rs::SdResult<()> {
 	}
 
 	tauri_build::build();
-	cfg_aliases! {
-		mobile: { any(target_os = "ios", target_os = "android") },
-		desktop: { not(any(target_os = "ios", target_os = "android")) }
-	}
 	shadow_rs::new()
 }

--- a/gui/src-tauri/gen/.stowrc
+++ b/gui/src-tauri/gen/.stowrc
@@ -1,0 +1,10 @@
+--ignore='^gui$'
+--ignore='^\..+'
+--ignore='^node_modules$'
+--ignore='^build$'
+--ignore='^(local|keystore).properties$'
+--ignore='^target$'
+--ignore='^assets'
+--ignore='.*\.(toml|yaml|nix|lock|json|md)$'
+-d ../../../../
+-t android

--- a/gui/src-tauri/gen/android/app
+++ b/gui/src-tauri/gen/android/app
@@ -1,0 +1,1 @@
+../../../../server/android/

--- a/gui/src-tauri/gen/android/build.gradle.kts
+++ b/gui/src-tauri/gen/android/build.gradle.kts
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/build.gradle.kts

--- a/gui/src-tauri/gen/android/buildSrc
+++ b/gui/src-tauri/gen/android/buildSrc
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/buildSrc

--- a/gui/src-tauri/gen/android/gradle
+++ b/gui/src-tauri/gen/android/gradle
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/gradle

--- a/gui/src-tauri/gen/android/gradle.properties
+++ b/gui/src-tauri/gen/android/gradle.properties
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/gradle.properties

--- a/gui/src-tauri/gen/android/gradlew
+++ b/gui/src-tauri/gen/android/gradlew
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/gradlew

--- a/gui/src-tauri/gen/android/gradlew.bat
+++ b/gui/src-tauri/gen/android/gradlew.bat
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/gradlew.bat

--- a/gui/src-tauri/gen/android/server
+++ b/gui/src-tauri/gen/android/server
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/server

--- a/gui/src-tauri/gen/android/settings.gradle.kts
+++ b/gui/src-tauri/gen/android/settings.gradle.kts
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/settings.gradle.kts

--- a/gui/src-tauri/gen/android/solarxr-protocol
+++ b/gui/src-tauri/gen/android/solarxr-protocol
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/solarxr-protocol

--- a/gui/src-tauri/gen/android/tauri.settings.gradle
+++ b/gui/src-tauri/gen/android/tauri.settings.gradle
@@ -1,0 +1,1 @@
+../../../../../SlimeVR-Server/tauri.settings.gradle

--- a/gui/src-tauri/src/cross.rs
+++ b/gui/src-tauri/src/cross.rs
@@ -1,0 +1,6 @@
+pub struct TrayAvailable(pub bool);
+
+#[tauri::command]
+pub fn is_tray_available(tray_available: tauri::State<TrayAvailable>) -> bool {
+	tray_available.0
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,0 +1,45 @@
+use tauri::Manager;
+
+mod cross;
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+	log_panics::init();
+
+	tauri::Builder::default()
+		.plugin(
+			tauri_plugin_log::Builder::new()
+				.target(tauri_plugin_log::Target::new(
+					tauri_plugin_log::TargetKind::LogDir {
+						file_name: Some("slimevr".to_string()),
+					},
+				))
+				.max_file_size(30_000 /* bytes */)
+				.rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
+				.build(),
+		)
+		.plugin(tauri_plugin_opener::init())
+		.plugin(tauri_plugin_dialog::init())
+		.plugin(tauri_plugin_fs::init())
+		.plugin(tauri_plugin_os::init())
+		.plugin(tauri_plugin_shell::init())
+		.plugin(tauri_plugin_store::Builder::default().build())
+		.plugin(tauri_plugin_http::init())
+		.invoke_handler(tauri::generate_handler![cross::is_tray_available,])
+		.setup(move |app| {
+			log::info!("SlimeVR started!");
+
+			let _ = tauri::WebviewWindowBuilder::new(
+				app,
+				"main",
+				tauri::WebviewUrl::App("index.html".into()),
+			)
+			.build()?;
+
+			app.manage(cross::TrayAvailable(false));
+
+			Ok(())
+		})
+		.run(tauri::generate_context!())
+		.expect("error while running tauri application");
+}

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ use crate::util::{
 	get_launch_path, show_error, valid_java_paths, Cli, JAVA_BIN, MINIMUM_JAVA_VERSION,
 };
 
+mod cross;
 mod presence;
 mod state;
 mod tray;
@@ -106,6 +107,7 @@ fn main() -> Result<()> {
 	setup_webview2()?;
 
 	// Check for environment variables that can affect the server, and if so, warn in log and GUI
+	#[cfg(desktop)]
 	check_environment_variables();
 
 	// Spawn server process
@@ -189,6 +191,7 @@ fn setup_webview2() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(desktop)]
 fn check_environment_variables() {
 	use itertools::Itertools;
 	const ENVS_TO_CHECK: &[&str] = &["_JAVA_OPTIONS", "JAVA_TOOL_OPTIONS"];
@@ -264,7 +267,7 @@ fn setup_tauri(
 			open_logs_folder,
 			tray::update_translations,
 			tray::update_tray_text,
-			tray::is_tray_available,
+			cross::is_tray_available,
 			presence::discord_client_exists,
 			presence::update_presence,
 			presence::clear_presence,
@@ -299,7 +302,7 @@ fn setup_tauri(
 				tray::create_tray(handle)?;
 				presence::create_presence(handle)?;
 			} else {
-				app.manage(tray::TrayAvailable(false));
+				app.manage(cross::TrayAvailable(false));
 			}
 
 			app.manage(Mutex::new(window_state));

--- a/gui/src-tauri/src/tray.rs
+++ b/gui/src-tauri/src/tray.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Mutex};
 
+use crate::cross::TrayAvailable;
 use tauri::{
 	include_image,
 	menu::{Menu, MenuBuilder, MenuItemBuilder, MenuItemKind},
@@ -8,7 +9,6 @@ use tauri::{
 };
 
 pub struct TrayMenu<R: Runtime>(Menu<R>);
-pub struct TrayAvailable(pub bool);
 
 pub struct TrayTranslations {
 	store: Mutex<HashMap<String, String>>,
@@ -20,11 +20,6 @@ impl TrayTranslations {
 		lock.get(key)
 			.map_or_else(|| key.to_string(), |v| v.to_string())
 	}
-}
-
-#[tauri::command]
-pub fn is_tray_available(tray_available: State<TrayAvailable>) -> bool {
-	tray_available.0
 }
 
 #[tauri::command]

--- a/gui/src-tauri/tauri.android.conf.json
+++ b/gui/src-tauri/tauri.android.conf.json
@@ -1,0 +1,6 @@
+{
+    "build": {
+        "beforeDevCommand": "pnpm run start --host"
+    },
+    "identifier": "dev.slimevr.android"
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 channel = "1.82"
 profile = "default"
 components = ["rustc", "cargo", "clippy", "rustfmt", "rust-analyzer", "rust-src"]
+targets = ["x86_64-linux-android", "aarch64-linux-android", "armv7-linux-androideabi", "i686-linux-android"]

--- a/server/android/.gitignore
+++ b/server/android/.gitignore
@@ -1,2 +1,9 @@
 /build
 /src/main/resources/web-gui
+
+/src/main/java/dev/slimevr/android/generated
+/src/main/jniLibs/**/*.so
+/src/main/assets/tauri.conf.json
+/tauri.build.gradle.kts
+/proguard-tauri.pro
+/tauri.properties

--- a/server/android/src/main/AndroidManifest.xml
+++ b/server/android/src/main/AndroidManifest.xml
@@ -28,6 +28,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+                android:name="androidx.core.content.FileProvider"
+                android:authorities="${applicationId}.fileprovider"
+                android:exported="false"
+                android:grantUriPermissions="true">
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/file_paths" />
+        </provider>
 
         <service
             android:name=".ForegroundService"

--- a/server/android/src/main/java/dev/slimevr/android/Main.kt
+++ b/server/android/src/main/java/dev/slimevr/android/Main.kt
@@ -9,17 +9,7 @@ import dev.slimevr.Keybinding
 import dev.slimevr.VRServer
 import dev.slimevr.android.serial.AndroidSerialHandler
 import io.eiren.util.logging.LogManager
-import io.ktor.http.CacheControl
-import io.ktor.http.CacheControl.Visibility
-import io.ktor.server.application.install
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.http.content.CachingOptions
-import io.ktor.server.http.content.staticResources
-import io.ktor.server.netty.Netty
-import io.ktor.server.plugins.cachingheaders.CachingHeaders
-import io.ktor.server.routing.routing
 import java.io.File
-import java.time.ZonedDateTime
 import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 
@@ -29,18 +19,6 @@ val vrServerInitialized: Boolean
 	get() = ::vrServer.isInitialized
 
 fun main(activity: AppCompatActivity) {
-	// Host the web GUI server
-	embeddedServer(Netty, port = 34536) {
-		routing {
-			install(CachingHeaders) {
-				options { _, _ ->
-					CachingOptions(CacheControl.NoStore(Visibility.Public), ZonedDateTime.now())
-				}
-			}
-			staticResources("/", "web-gui", "index.html")
-		}
-	}.start(wait = false)
-
 	thread(start = true, name = "Main VRServer Thread") {
 		try {
 			LogManager.initialize(activity.filesDir)

--- a/server/android/src/main/java/dev/slimevr/android/MainActivity.kt
+++ b/server/android/src/main/java/dev/slimevr/android/MainActivity.kt
@@ -3,9 +3,7 @@ package dev.slimevr.android
 import android.content.Intent
 import android.os.Bundle
 import android.webkit.JavascriptInterface
-import android.webkit.WebSettings
-import android.webkit.WebView
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.enableEdgeToEdge
 import io.eiren.util.logging.LogManager
 
 class AndroidJsObject {
@@ -13,10 +11,10 @@ class AndroidJsObject {
 	fun isThere(): Boolean = true
 }
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : TauriActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
+		enableEdgeToEdge()
 		super.onCreate(savedInstanceState)
-		setContentView(R.layout.activity_main)
 
 		// Initialize logger (doesn't re-initialize if already run)
 		try {
@@ -32,35 +30,6 @@ class MainActivity : AppCompatActivity() {
 		} else {
 			LogManager.info("[MainActivity] VRServer is already running, skipping initialization.")
 		}
-
-		// Load the web GUI web page
-		LogManager.info("[MainActivity] Initializing GUI WebView...")
-		val guiWebView = findViewById<WebView>(R.id.guiWebView)
-
-		// ## Configure for web GUI ##
-		// Enable debug mode
-		WebView.setWebContentsDebuggingEnabled(true)
-
-		// Set required features
-		guiWebView.settings.javaScriptEnabled = true
-		guiWebView.settings.domStorageEnabled = true
-
-		// TODO: Let code know it is in android, should be gone when we start using tauri
-		guiWebView.addJavascriptInterface(AndroidJsObject(), "__ANDROID__")
-
-		// Try fixing zoom usability
-		guiWebView.settings.setSupportZoom(true)
-		guiWebView.settings.useWideViewPort = true
-		guiWebView.settings.loadWithOverviewMode = true
-		guiWebView.invokeZoomPicker()
-
-		// Disable cache! This is all local anyway
-		guiWebView.settings.cacheMode = WebSettings.LOAD_NO_CACHE
-		guiWebView.clearCache(true)
-
-		// Load GUI page
-		guiWebView.loadUrl("http://127.0.0.1:34536/")
-		LogManager.info("[MainActivity] GUI WebView has been initialized and loaded.")
 
 		// Start a foreground service to notify the user the SlimeVR Server is running
 		// This also helps prevent Android from ejecting the process unexpectedly

--- a/server/android/src/main/res/xml/file_paths.xml
+++ b/server/android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+  <external-path name="my_images" path="." />
+  <cache-path name="my_cache_images" path="." />
+</paths>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,8 @@ project(":server").projectDir = File("server")
 include(":server:core")
 include(":server:desktop")
 include(":server:android")
+try {
+	apply(from = "tauri.settings.gradle")
+} catch(e: Exception) {
+	println("Couldn't enable tauri stuff")
+}


### PR DESCRIPTION
This is a very messy migration, tauri expects its gradle project to be inside ``gui/src-tauri/gen/android/`` and it wants it to have a gradle binary and everything.
Currently I hacked it together with `stow` soft links and I don't think there is gonna be a simple way to not do this aside from making our own `tauri-cli`.

Aside from that, I tested the app and it works (needs some retouches), but I tested it on top of #1537. So if u want to test it, I guess cherry-pick the commit from here and run it on top of the other branch.

The final size of the APK is 200MB, it will be smaller if we separate all ABIs, and I also need to update Android SDK but I think I will wait for #1528 as it also updates gradle which is needed.