### PR TITLE
BVH rewrite

### DIFF
--- a/server/core/src/main/java/dev/slimevr/posestreamer/BVHFileStream.kt
+++ b/server/core/src/main/java/dev/slimevr/posestreamer/BVHFileStream.kt
@@ -143,7 +143,7 @@ class BVHFileStream : PoseDataStream {
 	@Throws(IOException::class)
 	override fun writeHeader(skeleton: HumanSkeleton, streamer: PoseStreamer) {
 		writer.write("HIERARCHY\n")
-		writeSkeletonDef(skeleton.headBone)
+		writeSkeletonDef(skeleton.getBone(bvhSettings.rootBone))
 
 		writer.write("MOTION\n")
 		writer.write("Frames: ")
@@ -173,7 +173,7 @@ class BVHFileStream : PoseDataStream {
 
 	@Throws(IOException::class)
 	override fun writeFrame(skeleton: HumanSkeleton) {
-		val rootBone = skeleton.headBone
+		val rootBone = skeleton.getBone(bvhSettings.rootBone)
 
 		val rootPos = rootBone.getPosition()
 

--- a/server/core/src/main/java/dev/slimevr/posestreamer/BVHSettings.kt
+++ b/server/core/src/main/java/dev/slimevr/posestreamer/BVHSettings.kt
@@ -1,9 +1,13 @@
 package dev.slimevr.posestreamer
 
+import dev.slimevr.tracking.processor.BoneType
+
 class BVHSettings {
 	var offsetScale: Float = 100f
 		private set
 	var positionScale: Float = 100f
+		private set
+	var rootBone: BoneType = BoneType.HIP
 		private set
 
 	constructor()
@@ -20,6 +24,11 @@ class BVHSettings {
 
 	fun setPositionScale(positionScale: Float): BVHSettings {
 		this.positionScale = positionScale
+		return this
+	}
+
+	fun setRootBone(rootBone: BoneType): BVHSettings {
+		this.rootBone = rootBone
 		return this
 	}
 


### PR DESCRIPTION
Major rework of BVH code to take full advantage of `Bone`s and unification the skeleton traversal to simplify serialization. This also implements built-in retargeting of the root, so you can now select any bone as the root. Using the new retargeting, we can use the `HIP` bone as the default so the recording can be applied directly in Blender or Unity.

Still somewhat WIP as it is not properly tested and may have some silly bugs (one I encountered when using the left hand as the root), but I'm open to early reviews.