### PR TITLE
Add boards slimevr_v1_2 and esp32s3_supermini

### DIFF
--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -171,7 +171,10 @@ export function TrackerSettingsPage() {
     tracker?.device?.hardwareInfo &&
     checkForUpdate(currentFirmwareRelease, tracker?.device);
   const updateUnavailable =
-    tracker?.device?.hardwareInfo?.officialBoardType !== BoardType.SLIMEVR ||
+    (
+        tracker?.device?.hardwareInfo?.officialBoardType !== BoardType.SLIMEVR &&
+        tracker?.device?.hardwareInfo?.officialBoardType !== BoardType.SLIMEVR_V1_2
+    ) ||
     !semver.valid(
       tracker?.device?.hardwareInfo?.firmwareVersion?.toString() ?? 'none'
     );

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -56,6 +56,8 @@ enum class BoardType(val id: UInt) {
 	ESP32C6DEVKITC1(19u),
 	GLOVE_IMU_SLIMEVR_DEV(20u),
 	GESTURES(21u),
+	SLIMEVR_V1_2(22u),
+	ESP32S3_SUPERMINI(23u),
 	DEV_RESERVED(250u),
 	;
 
@@ -84,6 +86,8 @@ enum class BoardType(val id: UInt) {
 		HARITORA -> "Haritora"
 		ESP32C6DEVKITC1 -> "Espressif ESP32-C6 DevKitC-1"
 		GLOVE_IMU_SLIMEVR_DEV -> "SlimeVR Dev IMU Glove"
+		SLIMEVR_V1_2 -> "SlimeVR v1.2"
+		ESP32S3_SUPERMINI -> "ESP32-S3 SuperMini"
 		DEV_RESERVED -> "Prototype"
 	}
 


### PR DESCRIPTION
Adds the 2 Boards as they where add in the SlimeVR-Tracker Firmware.

Add the SlimeVR v1.2 to official tracker.

Draft till Pull Request in SolarXR is done.
