### PR TITLE
Add restCalibrationStatus logic to the calibration tutorial

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -971,6 +971,7 @@ onboarding-connect_tracker-next = I connected all my trackers
 onboarding-calibration_tutorial = IMU Calibration Tutorial
 onboarding-calibration_tutorial-subtitle = This will help reduce tracker drifting!
 onboarding-calibration_tutorial-description-v1 = After turning on your trackers, place them on a stable surface for a moment to allow for calibration. Calibration can be performed at any time after the trackers are powered on—this page simply provides a tutorial. To begin, click the "{ onboarding-calibration_tutorial-calibrate }" button, then <b>do not move your trackers!</b>
+onboarding-calibration_tutorial-description-no-ready-v1 = After turning on your trackers, place them on a stable surface for a couple seconds to allow for calibration. Calibration can be performed at any time after the trackers are powered on—this page simply provides a tutorial. To begin, put down your trackers, then <b>do not move them!</b>
 onboarding-calibration_tutorial-calibrate = I placed my trackers on a table
 onboarding-calibration_tutorial-status-waiting = Waiting for you
 onboarding-calibration_tutorial-status-calibrating = Calibrating

--- a/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
+++ b/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.java
@@ -153,6 +153,12 @@ public class DataFeedBuilder {
 
 		TrackerInfo.addDataSupport(fbb, tracker.getTrackerDataType().getSolarType());
 
+		TrackerInfo
+			.addRestCalibrationStatus(
+				fbb,
+				tracker.getRestCalibrationStatus().getSolarType()
+			);
+
 		return TrackerInfo.endTrackerInfo(fbb);
 	}
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -6,6 +6,7 @@ import dev.slimevr.tracking.processor.stayaligned.trackers.StayAlignedTrackerSta
 import dev.slimevr.tracking.trackers.TrackerPosition.Companion.getByDesignation
 import dev.slimevr.tracking.trackers.udp.IMUType
 import dev.slimevr.tracking.trackers.udp.MagnetometerStatus
+import dev.slimevr.tracking.trackers.udp.RestCalibrationStatus
 import dev.slimevr.tracking.trackers.udp.TrackerDataType
 import dev.slimevr.util.InterpolationHandler
 import io.eiren.util.BufferedTimer
@@ -84,6 +85,7 @@ class Tracker @JvmOverloads constructor(
 	 */
 	val trackRotDirection: Boolean = true,
 	magStatus: MagnetometerStatus = MagnetometerStatus.NOT_SUPPORTED,
+	restCalibrationStatus: RestCalibrationStatus = RestCalibrationStatus.NOT_SUPPORTED,
 	/**
 	 * Rotation by default.
 	 * NOT the same as hasRotation (other data types emulate rotation)
@@ -106,6 +108,8 @@ class Tracker @JvmOverloads constructor(
 	var temperature: Float? = null
 	var customName: String? = null
 	var magStatus: MagnetometerStatus = magStatus
+		private set
+	var restCalibrationStatus: RestCalibrationStatus = restCalibrationStatus
 		private set
 
 	/**
@@ -472,6 +476,10 @@ class Tracker @JvmOverloads constructor(
 		} else {
 			MagnetometerStatus.DISABLED
 		}
+	}
+
+	internal fun setRestCalibrationPrivate(status: RestCalibrationStatus) {
+		restCalibrationStatus = status
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/FirmwareConstants.kt
@@ -153,6 +153,30 @@ enum class MagnetometerStatus {
 	}
 }
 
+enum class RestCalibrationStatus {
+	NOT_SUPPORTED,
+	NOT_CALIBRATED,
+	CALIBRATED,
+	;
+
+	fun getSolarType(): Int = this.ordinal
+
+	companion object {
+		private val byId = entries.associateBy { it.ordinal.toUByte() }
+
+		@JvmStatic
+		fun getById(id: UByte): RestCalibrationStatus? = byId[id]
+
+		@JvmStatic
+		fun fromBoolean(value: Boolean?): RestCalibrationStatus =
+			when (value) {
+				null -> NOT_SUPPORTED
+				true -> CALIBRATED
+				false -> NOT_CALIBRATED
+			}
+	}
+}
+
 @JvmInline
 value class SensorConfig(val v: UShort) {
 	val magStatus


### PR DESCRIPTION
Depends on https://github.com/SlimeVR/SolarXR-Protocol/pull/182

This PR implements the rest calibration status flag present in the SlimeVR firmware since version 0.5.4 into the server as well. Specifically the desk calibration tutorial now uses this flag if all of the trackers connected to the server support it. If that's not the case, the old behaviour is used as a fallback.

This flag could also be used down the line to warn the user in case their trackers haven't been calibrated yet, but this PR doesn't implement that behaviour.