### PR TITLE
Fix tracker drift logging

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
@@ -534,7 +534,7 @@ class HumanPoseManager(val server: VRServer?) {
 
 				// Get the difference between last reset and now
 				val difference = tracker
-					.getRotation() * tracker.resetsHandler.lastResetQuaternion!!.inv()
+					.getRotationNoResetSmooth() * tracker.resetsHandler.lastResetQuaternion!!.inv()
 				// Get the pure yaw
 				var trackerDriftAngle = abs(
 					(

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -411,21 +411,28 @@ class Tracker @JvmOverloads constructor(
 	}
 
 	/**
-	 * Get the rotation of the tracker after the resetsHandler's corrections and filtering if applicable
+	 * Get the rotation of the tracker after the resetsHandler's corrections, filtering,
+	 * and reset smoothing if applicable
 	 */
 	fun getRotation(): Quaternion {
-		var rot = if (trackRotDirection) {
-			filteringHandler.getFilteredRotation()
-		} else {
-			// Get non-filtered rotation
-			getAdjustedRotation()
-		}
+		var rot = getRotationNoResetSmooth()
 
 		if (yawResetSmoothing.remainingTime > 0f) {
 			rot = yawResetSmoothing.curRotation * rot
 		}
 
 		return rot
+	}
+
+	/**
+	 * Get the rotation of the tracker after the resetsHandler's corrections and
+	 * filtering if applicable
+	 */
+	fun getRotationNoResetSmooth(): Quaternion = if (trackRotDirection) {
+		filteringHandler.getFilteredRotation()
+	} else {
+		// Get non-filtered rotation
+		getAdjustedRotation()
 	}
 
 	/**


### PR DESCRIPTION
Looks like this only worked with yaw reset smoothing before by pure luck. Yaw reset smoothing keeps our rotation as pre-reset, so we should absolutely *not* include that when calculating drift.

Fixes #1583