### PR TITLE
Fix network adapter status vars

### DIFF
--- a/gui/src/components/onboarding/pages/ConnectTracker.tsx
+++ b/gui/src/components/onboarding/pages/ConnectTracker.tsx
@@ -24,7 +24,7 @@ import './ConnectTracker.scss';
 import { useAtomValue } from 'jotai';
 import { connectedIMUTrackersAtom } from '@/store/app-store';
 import { BaseModal } from '@/components/commons/BaseModal';
-import { useStatusContext } from '@/hooks/status-system';
+import { parseStatusToLocale, useStatusContext } from '@/hooks/status-system';
 import { A } from '@/components/commons/A';
 import { CONNECT_TRACKER } from '@/utils/tauri';
 
@@ -248,6 +248,7 @@ export function ConnectTrackersPage() {
               <Localized
                 key={status.id}
                 id={`status_system-${StatusData[status.dataType]}`}
+                vars={parseStatusToLocale(status, connectedIMUTrackers, l10n)}
                 elems={{
                   PublicFixLink: (
                     <A href="https://docs.slimevr.dev/common-issues.html#network-profile-is-currently-set-to-public"></A>


### PR DESCRIPTION
This is in the Connect trackers page of onboarding.

Before: 
<img width="423" height="157" alt="image" src="https://github.com/user-attachments/assets/c5d8d7a1-2ceb-46fc-b06c-37c40f641884" />

After: 
<img width="415" height="148" alt="image" src="https://github.com/user-attachments/assets/f69f2c3a-6f72-4bda-baa2-367b1f66f75e" />
