### PR TITLE
Make socket recover if slimevr crashed

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/SocketUtils.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/SocketUtils.java
@@ -5,6 +5,7 @@ import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.SocketChannel;
 
+
 public class SocketUtils {
 
 	static boolean isSocketInUse(String socketPath) {

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
@@ -47,7 +47,9 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 		File socketFile = new File(socketPath);
 		if (socketFile.exists()) {
 			if (SocketUtils.isSocketInUse(socketPath)) {
-				throw new RuntimeException(socketPath + " socket is already in use by another process.");
+				throw new RuntimeException(
+					socketPath + " socket is already in use by another process."
+				);
 			} else {
 				LogManager.warning("[" + bridgeName + "] Cleaning up stale socket: " + socketPath);
 				if (!socketFile.delete()) {

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketRpcBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketRpcBridge.java
@@ -39,7 +39,9 @@ public class UnixSocketRpcBridge implements dev.slimevr.bridge.Bridge,
 		File socketFile = new File(socketPath);
 		if (socketFile.exists()) {
 			if (SocketUtils.isSocketInUse(socketPath)) {
-				throw new RuntimeException(socketPath + " socket is already in use by another process.");
+				throw new RuntimeException(
+					socketPath + " socket is already in use by another process."
+				);
 			} else {
 				LogManager.warning("[SolarXR Bridge] Cleaning up stale socket: " + socketPath);
 				if (!socketFile.delete()) {


### PR DESCRIPTION
Fixes an issue where if slimevr server crash, the deleteOnExit is not necessarly called. Resulting in the server being unable to start anymore unless you delete the socket files manually.

This PR will try to see if the socket is not already used and if not will delete the old one upon restart preventing the deadlock.
