### PR TITLE
Fix for hands trackers not lining up properly in SteamVR

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/config/SkeletonConfigManager.kt
@@ -290,7 +290,7 @@ class SkeletonConfigManager(
 				nodeOffset,
 				0f,
 				-getOffset(SkeletonConfigOffsets.HAND_Y),
-				-getOffset(SkeletonConfigOffsets.HAND_Z),
+				0f,
 			)
 
 			BoneType.LEFT_ELBOW_TRACKER, BoneType.RIGHT_ELBOW_TRACKER -> setNodeOffset(


### PR DESCRIPTION
A somewhat simple fix for an issue I found during my investigations of using SlimeVR trackers as hand controllers.
I noticed a skeleton offset on the hands was causing them to not align properly in SteamVR, and they now line up correctly with this adjustment.