### PR TITLE
Disable root overscroll

### DIFF
--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -61,6 +61,7 @@ body {
 :root {
   // overflow: hidden; -- NEVER EVER BRING THIS BACK <3
   background: theme('colors.background.20');
+  overscroll-behavior: none;
 
   --navbar-w: 101px;
   --topbar-h: 38px;


### PR DESCRIPTION
Fixes Edge Webview elastic scroll on the entire UI:


https://github.com/user-attachments/assets/39faa21b-333b-41aa-ac0a-a98fe9d849b8

