### PR TITLE
Disable R8 optimization for Android

### DIFF
--- a/server/android/proguard-rules.pro
+++ b/server/android/proguard-rules.pro
@@ -26,7 +26,7 @@
 -dontwarn reactor.blockhound.integration.BlockHoundIntegration
 
 -keep class io.ktor.** { *; }
--keep class io.netty.** {*; }
+-keep class io.netty.** { *; }
 -keep class kotlin.reflect.jvm.internal.** { *; }
 -keep class kotlinx.coroutines.** { *; }
 -dontwarn kotlinx.atomicfu.**
@@ -34,5 +34,29 @@
 -dontwarn com.typesafe.**
 -dontwarn org.slf4j.**
 
+# Proguard configuration for Jackson 2.x
+# https://github.com/FasterXML/jackson-docs/wiki/JacksonOnAndroid
+#-keep class java.beans.** { *; }
+#-dontwarn java.beans.**
+#
+#-keep class com.fasterxml.jackson.** { *; }
+#-dontwarn com.fasterxml.jackson.databind.**
+#
+#-keep class com.github.jonpeterson.jackson.** { *; }
+#
+#-keepclassmembers class * {
+#     @com.fasterxml.jackson.annotation.* *;
+#}
+
+# Proguard configuration for SnakeYAML 2.X
+#-keep class org.yaml.snakeyaml.** { *; }
+#-dontwarn org.yaml.snakeyaml.**
+
+# Don't mess with SlimeVR config, the class structure is essential for serialization
+-keep class dev.slimevr.config.** { *; }
+
 # Obfuscation is fine but it makes crash logs unreadable, we don't really need it for our app
 -dontobfuscate
+
+# Temporary measure to keep config functional, beware Jackson issues if removing!!
+-dontoptimize


### PR DESCRIPTION
Currently breaks config stuff, this way of disabling it should be more explicit and we can build from this to potentially actually optimize in the future.