### PR TITLE
[Stay Aligned] Fix broken tracker rotations

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -316,7 +316,7 @@ class Tracker @JvmOverloads constructor(
 		rot = Quaternion.rotationAroundYAxis(stayAligned.yawCorrection.toRad()) * rot
 
 		// Reset if needed and is not computed and internal
-		return if (needReset && !(isComputed && isInternal) && trackerDataType == TrackerDataType.ROTATION) {
+		return if (allowReset && !(isComputed && isInternal) && trackerDataType == TrackerDataType.ROTATION) {
 			// Adjust to reset, mounting and drift compensation
 			resetsHandler.getReferenceAdjustedDriftRotationFrom(rot)
 		} else {


### PR DESCRIPTION
Stay Aligned was getting completely wrong rotations to process.

https://github.com/SlimeVR/SlimeVR-Server/commit/2e1ec07b237bd6036c7e957fbf3b6e5badb8886f introduced a regression during a refactor. The check in `getAdjustedRotationForceStayAligned` should be `allowsReset`, same as with `getAdjustedRotation`.