### PR TITLE
DesktopHID only warn if device cannot open

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
@@ -56,11 +56,14 @@ class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tra
 
 	private fun checkConfigureDevice(hidDevice: HidDevice) {
 		if (hidDevice.vendorId == HID_TRACKER_RECEIVER_VID && hidDevice.productId == HID_TRACKER_RECEIVER_PID) { // TODO: Use correct ids
+			val serial = hidDevice.serialNumber ?: "Unknown HID Device"
 			if (hidDevice.isClosed) {
-				check(hidDevice.open()) { "Unable to open device" }
+				if (!hidDevice.open()) {
+					LogManager.warning("[TrackerServer] Unable to open device: $serial")
+					return
+				}
 			}
 			// TODO: Configure the device here
-			val serial = hidDevice.serialNumber ?: "Unknown HID Device"
 			// val product = hidDevice.product
 			// val manufacturer = hidDevice.manufacturer
 			this.devicesBySerial[serial]?.let {


### PR DESCRIPTION
bad timing can cause a device to attempt to open while it is being removed
```
20:46:13 [INFO] [TrackerServer] Linked HID device reattached: x
20:46:13 [SEVERE] Exception in thread "hid4java data reader" java.lang.IllegalStateException: Device has not been opened
20:46:13 [SEVERE]       at org.hid4java.HidDevice.readAll(HidDevice.java:473)
20:46:13 [SEVERE]       at dev.slimevr.desktop.tracking.trackers.hid.DesktopHIDManager.dataRead(DesktopHIDManager.kt:151)
20:46:13 [SEVERE]       at dev.slimevr.desktop.tracking.trackers.hid.DesktopHIDManager._get_dataReadRunnable_$lambda$4(DesktopHIDManager.kt:118)
20:46:13 [SEVERE]       at java.base/java.lang.Thread.run(Thread.java:840)
20:46:14 [INFO] [TrackerServer] Linked HID device removed: x
```
change to warn instead of entering illegal state:
```
20:49:26 [INFO] [TrackerServer] Linked HID device reattached: x
20:49:28 [INFO] [TrackerServer] Linked HID device removed: x
20:49:36 [INFO] [TrackerServer] Linked HID device reattached: x
20:49:37 [INFO] [TrackerServer] Linked HID device removed: x
20:49:38 [WARNING] [TrackerServer] Unable to open device: x
20:49:43 [INFO] [TrackerServer] Linked HID device reattached: x
20:49:45 [INFO] [TrackerServer] Linked HID device removed: x
20:49:47 [INFO] [TrackerServer] Linked HID device reattached: x
```