### PR TITLE
Hide devices with unknown board type in DIY firmware tool

### DIFF
--- a/gui/src/components/firmware-tool/steps/FlashingMethodStep.tsx
+++ b/gui/src/components/firmware-tool/steps/FlashingMethodStep.tsx
@@ -231,7 +231,10 @@ function OTADevicesList({
   const allDevices = useAtomValue(devicesAtom);
 
   const devices =
-    allDevices.filter(({ trackers }) => {
+    allDevices.filter(({ hardwareInfo, trackers }) => {
+      // filter out devices we can't update
+      if (!hardwareInfo?.officialBoardType) return false;
+
       // if the device has no trackers it is prob misconfigured so we skip for safety
       if (trackers.length <= 0) return false;
 


### PR DESCRIPTION
Fixes feeder devices showing as OTA devices in DIY fw tool.
<img width="1924" height="1112" alt="image" src="https://github.com/user-attachments/assets/6750c281-8ba7-4838-b1dc-9f0af305d478" />
