### PR TITLE
Hide tracker firmware version when board type is unknown

### DIFF
--- a/gui/src/components/tracker/TrackerSettings.tsx
+++ b/gui/src/components/tracker/TrackerSettings.tsx
@@ -226,31 +226,33 @@ export function TrackerSettingsPage() {
                     v{tracker?.device?.hardwareInfo?.firmwareVersion}
                   </Typography>
                 </div>
-                <div className="flex justify-between gap-2">
-                  <Typography id="tracker-settings-latest-version" />
-                  {!updateUnavailable && (
-                    <>
-                      {currentFirmwareRelease && (
-                        <Typography
-                          color={
-                            needUpdate === 'updated'
-                              ? undefined
-                              : 'text-accent-background-10'
-                          }
-                          textAlign="text-end"
-                          whitespace="whitespace-pre-wrap"
-                        >
-                          {currentFirmwareRelease.name}
-                        </Typography>
-                      )}
-                    </>
-                  )}
-                  {updateUnavailable && (
-                    <Typography id="tracker-settings-update-unavailable-v2">
-                      No releases found
-                    </Typography>
-                  )}
-                </div>
+                {!!tracker?.device?.hardwareInfo?.officialBoardType && (
+                  <div className="flex justify-between gap-2">
+                    <Typography id="tracker-settings-latest-version" />
+                    {!updateUnavailable && (
+                      <>
+                        {currentFirmwareRelease && (
+                          <Typography
+                            color={
+                              needUpdate === 'updated'
+                                ? undefined
+                                : 'text-accent-background-10'
+                            }
+                            textAlign="text-end"
+                            whitespace="whitespace-pre-wrap"
+                          >
+                            {currentFirmwareRelease.name}
+                          </Typography>
+                        )}
+                      </>
+                    )}
+                    {updateUnavailable && (
+                      <Typography id="tracker-settings-update-unavailable-v2">
+                        No releases found
+                      </Typography>
+                    )}
+                  </div>
+                )}
               </div>
               {!updateUnavailable && (
                 <Tooltip


### PR DESCRIPTION
Side-by-side comparison:
<p float=left>
  <img align="top" width="325" height="675" alt="image" src="https://github.com/user-attachments/assets/d2e9edd5-3ee2-4f67-bd46-b06716cabd5e" />
  <img align="top" width="328" height="490" alt="image" src="https://github.com/user-attachments/assets/3f5cebfe-e405-4f51-b994-a35b0987eae3" />
</p>
