### PR TITLE
ProtocolAPI: Initialise RPCHandler after other members

### DIFF
--- a/server/core/src/main/java/dev/slimevr/protocol/ProtocolAPI.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/ProtocolAPI.kt
@@ -8,11 +8,10 @@ import solarxr_protocol.MessageBundle
 import java.nio.ByteBuffer
 
 class ProtocolAPI(val server: VRServer) {
-	val rpcHandler: RPCHandler = RPCHandler(this)
+	val apiServers: MutableList<ProtocolAPIServer> = ArrayList()
 	val dataFeedHandler: DataFeedHandler = DataFeedHandler(this)
 	val pubSubHandler: PubSubHandler = PubSubHandler(this)
-
-	val apiServers: MutableList<ProtocolAPIServer> = ArrayList()
+	val rpcHandler: RPCHandler = RPCHandler(this)
 
 	fun onMessage(conn: GenericConnection, message: ByteBuffer) {
 		val messageBundle = MessageBundle.getRootAsMessageBundle(message)


### PR DESCRIPTION
The RPCHandler was being initialised before apiServers, so when RPCVRChatHandler tried to access apiServers on init it would crash with a NullPointerException.

```
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [INFO] Running version 99de554
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [INFO] Using config dir: /home/sapphire/.config/dev.slimevr.SlimeVR/vrconfig.yml
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [INFO] [VRChatRegEdit] Using VRChat registry file: /home/sapphire/.steam/root/steamapps/compatdata/438100/pfx/user.reg
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE] java.lang.NullPointerException: Cannot invoke "java.lang.Iterable.iterator()" because "$this$forEach$iv" is null
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE]         at dev.slimevr.protocol.rpc.games.vrchat.RPCVRChatHandler.onChange(RPCVRChatHandler.kt:83)
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE]         at dev.slimevr.games.vrchat.VRChatConfigManager.addListener(VRCConfigHandler.kt:182)
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE]         at dev.slimevr.protocol.rpc.games.vrchat.RPCVRChatHandler.<init>(RPCVRChatHandler.kt:19)
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE]         at dev.slimevr.protocol.rpc.RPCHandler.<init>(RPCHandler.kt:52)
Jan 22 21:33:21 elysium slimevr-server[1125233]: 21:33:21 [SEVERE]         at dev.slimevr.protocol.ProtocolAPI.<init>(ProtocolAPI.kt:11)
Jan 22 21:33:21 elysium systemd[965]: slimevr-server.service: Main process exited, code=exited, status=1/FAILURE
```

Fixes: 8f57ef2de409c240be88a97cce8c13d8522fe454