### PR TITLE
Fix unassigned HMD flightlist step never showing

### DIFF
--- a/server/core/src/main/java/dev/slimevr/trackingchecklist/TrackingChecklistManager.kt
+++ b/server/core/src/main/java/dev/slimevr/trackingchecklist/TrackingChecklistManager.kt
@@ -216,7 +216,7 @@ class TrackingChecklistManager(private val vrServer: VRServer) : VRCConfigListen
 			}
 		}
 		val hmd =
-			assignedTrackers.firstOrNull { it.isHmd && !it.isInternal && it.status.sendData }
+			vrServer.allTrackers.firstOrNull { it.status != TrackerStatus.DISCONNECTED && it.isHmd && !it.isInternal && it.status.sendData }
 		val assignedHmd = hmd == null || vrServer.humanPoseManager.skeleton.headTracker != null
 		updateValidity(TrackingChecklistStepId.UNASSIGNED_HMD, assignedHmd) {
 			if (!assignedHmd) {


### PR DESCRIPTION
The step would never show since we were looking in the `assignedTrackers` list for the HMD, which only contains assigned trackers.