### PR TITLE
Fix scheduled resets triggering immediately when delay is unspecified

### DIFF
--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
@@ -39,24 +39,39 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 		}
 
 		if (req.resetType() == ResetType.Yaw) {
-			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.yawResetDelay) * 1000).toLong())
+			val delay = if (req.hasDelay()) {
+				req.delay()
 			} else {
-				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.yawResetDelay) * 1000).toLong(), bodyParts.toList())
+				resetsConfig.yawResetDelay
+			}
+			if (bodyParts.isEmpty()) {
+				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong())
+			} else {
+				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList())
 			}
 		}
 		if (req.resetType() == ResetType.Full) {
-			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.fullResetDelay) * 1000).toLong())
+			val delay = if (req.hasDelay()) {
+				req.delay()
 			} else {
-				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.fullResetDelay) * 1000).toLong(), bodyParts.toList())
+				resetsConfig.fullResetDelay
+			}
+			if (bodyParts.isEmpty()) {
+				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong())
+			} else {
+				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList())
 			}
 		}
 		if (req.resetType() == ResetType.Mounting) {
-			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.mountingResetDelay) * 1000).toLong())
+			val delay = if (req.hasDelay()) {
+				req.delay()
 			} else {
-				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, ((req.delay() ?: resetsConfig.mountingResetDelay) * 1000).toLong(), bodyParts.toList())
+				resetsConfig.mountingResetDelay
+			}
+			if (bodyParts.isEmpty()) {
+				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong())
+			} else {
+				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList())
 			}
 		}
 	}


### PR DESCRIPTION
The generated Flatbuffers code returns a default of 0.f if no delay is specified in the packet.