### PR TITLE
Feature: Firmware Tool Checks / Support for ESP8266 USB Flash mode

### DIFF
--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -156,6 +156,15 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 				flasher.addBin(part.firmware, part.offset.toInt())
 			}
 
+// TODO:
+//  - Check if FW is able to use flashmode
+//  - Add check if the flashmode was successfully set to surpress the request
+//    for manual flashmode setting prompt in gui
+
+			server.serialHandler.openSerial(deviceId.id, false)
+			server.serialHandler.write("SET FLASHMODE\r\n".toByteArray())
+			server.serialHandler.closeSerial()
+
 			flasher.addProgressListener(object : FlashingProgressListener {
 				override fun progress(progress: Float) {
 					onStatusChange(

--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -11,6 +11,7 @@ import dev.slimevr.serial.SerialPort
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerStatus
 import dev.slimevr.tracking.trackers.TrackerStatusListener
+import dev.slimevr.tracking.trackers.udp.MCUType
 import dev.slimevr.tracking.trackers.udp.UDPDevice
 import io.eiren.util.logging.LogManager
 import kotlinx.coroutines.*
@@ -101,11 +102,27 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 			)
 			return@suspendCancellableCoroutine
 		}
+
+// TODO:
+//  - Use the Firmware Builder to get the expected MCU
+//    It would be wrong to assume that the Target MCU is the correct one,
+//    just because the device is listening on the correct port.
+//    The Upload protocol does not verify the compatibility of the firmware with the MCU.
+
+		val port = when (udpDevice.mcuType) {
+			MCUType.ESP8266 -> 8266
+			MCUType.ESP32, MCUType.ESP32_C3 -> 3232
+			else -> error("MCU-Typ: ${udpDevice.mcuType} not supported for OTA updates")
+		}
+
+		LogManager.info("[FirmwareUpdateHandler] Starting OTA update for device ${deviceId.id} at ${udpDevice.ipAddress.hostAddress}:$port and MCU ${udpDevice.mcuType}")
+
 		val task = OTAUpdateTask(
 			part.firmware,
 			deviceId,
 			udpDevice.ipAddress,
 			::onStatusChange,
+			port,
 		)
 		c.invokeOnCancellation {
 			task.cancel()

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -190,7 +190,7 @@ class DesktopSerialHandler :
 	}
 
 	override fun write(buff: ByteArray) {
-		LogManager.info("[SerialHandler] WRITING $buff")
+		LogManager.info("[SerialHandler] WRITING ${buff.toString(Charsets.UTF_8)}")
 		currentPort?.outputStream?.write(buff)
 	}
 


### PR DESCRIPTION
Target is the following additions:

- [x] Add OTA Support for ESP32 chips / newer OTA protocol

Todo:
- [ ] Automatically detect if the Firmware supports flashmode. If yes, do not ask to set the Flash pin. This feature is mainly for ESP8266 for Officials SlimeVR Trackers. Other boards should relay on RTS/DTR signal like D1 Mini,...

- [ ] OTA Add a check not to flash wrong firmware to wrong boards more likely MCU. (Currently its possible to flash a esp32 firmware to a esp8266 tracker.
  The OTA Protocol seems not to have any protection against it, expect the OTA Port
- [ ] Firmware Tool need to deliver the MCU for a board. (Probably with backup for older firmware with a fallback default)
- [ ] Firmware Flasher tool needs to verify / show only compatible tracker with the selected firmware.
- [ ] Firmware Flasher tool needs to display a warning if flashing a different board than it was before. (SlimeVR vs SlimeVR v1.2)