### PR TITLE
Add ESP32-S2 to USB-Serial Accept-List

### DIFF
--- a/gui/src-tauri/69-slimevr-devices.rules
+++ b/gui/src-tauri/69-slimevr-devices.rules
@@ -26,8 +26,10 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1A86", ATTRS{idProduct}=="55D4", MODE="0660
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="10C4", ATTRS{idProduct}=="EA60", MODE="0660", TAG+="uaccess"
 
 ## Espressif
-# ESP32-C3
+# ESP32-S3 / ESP32-C3 / ESP32-C5 / ESP32-C6 / ESP32-C61 / ESP32-H2 / ESP32-P4
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="303A", ATTRS{idProduct}=="1001", MODE="0660", TAG+="uaccess"
+# ESP32-S2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="303A", ATTRS{idProduct}=="0002", MODE="0660", TAG+="uaccess"
 
 ## FTDI
 # FT232BM/L/Q, FT245BM/L/Q

--- a/server/core/src/main/java/dev/slimevr/serial/SerialHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/serial/SerialHandler.kt
@@ -36,7 +36,7 @@ abstract class SerialHandler {
 			// CP210x
 			Pair(0x10C4, 0xEA60),
 			// / Espressif
-			// ESP32-C3
+			// ESP32-S3 / ESP32-C3 / ESP32-C5 / ESP32-C6 / ESP32-C61 / ESP32-H2 / ESP32-P4
 			Pair(0x303A, 0x1001),
 			// ESP32-S2
 			Pair(0x303A, 0x0002),


### PR DESCRIPTION
We are building DIY trackers with an ESP32-S2 as MCU.
This should not clutter the list too much.