### PR TITLE
fix: use base64 BWIFI for WiFi credential provisioning

### DIFF
--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -281,8 +281,11 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 
 	@Synchronized
 	override fun setWifi(ssid: String, passwd: String) {
-		writeSerial("SET WIFI \"${ssid}\" \"${passwd}\"")
-		addLog("-> SET WIFI \"$ssid\" \"${passwd.replace(".".toRegex(), "*")}\"\n")
+		val encoder = java.util.Base64.getEncoder()
+		val b64ssid = encoder.encodeToString(ssid.toByteArray(StandardCharsets.UTF_8))
+		val b64passwd = encoder.encodeToString(passwd.toByteArray(StandardCharsets.UTF_8))
+		writeSerial("SET BWIFI $b64ssid $b64passwd")
+		addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")
 	}
 
 	override fun getCurrentPort(): SlimeSerialPort? = this.currentPort

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -284,7 +284,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 		val b64ssid = Base64.Default.encode(ssid.encodeToByteArray())
 		val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
 		writeSerial("SET BWIFI $b64ssid $b64passwd")
-		addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")
+		addLog("-> SET BWIFI $b64ssid ${"*".repeat(b64passwd.length)}\n")
 	}
 
 	override fun getCurrentPort(): SlimeSerialPort? = this.currentPort

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.stream.Stream
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.streams.asSequence
 import kotlin.streams.asStream
 import dev.slimevr.serial.SerialPort as SlimeSerialPort
@@ -279,10 +281,11 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 		currentPort?.port?.write(buff, 0)
 	}
 
+	@OptIn(ExperimentalEncodingApi::class)
 	@Synchronized
 	override fun setWifi(ssid: String, passwd: String) {
-		val b64ssid = Base64.Default.encode(ssid.encodeToByteArray())
-		val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
+		val b64ssid = Base64.encode(ssid.encodeToByteArray())
+		val b64passwd = Base64.encode(passwd.encodeToByteArray())
 		writeSerial("SET BWIFI $b64ssid $b64passwd")
 		addLog("-> SET BWIFI $b64ssid ${"*".repeat(b64passwd.length)}\n")
 	}

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -281,9 +281,8 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 
 	@Synchronized
 	override fun setWifi(ssid: String, passwd: String) {
-		val encoder = java.util.Base64.getEncoder()
-		val b64ssid = encoder.encodeToString(ssid.toByteArray(StandardCharsets.UTF_8))
-		val b64passwd = encoder.encodeToString(passwd.toByteArray(StandardCharsets.UTF_8))
+		val b64ssid = Base64.Default.encode(ssid.encodeToByteArray())
+		val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
 		writeSerial("SET BWIFI $b64ssid $b64passwd")
 		addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")
 	}

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -199,9 +199,8 @@ class DesktopSerialHandler :
 		val os = currentPort?.outputStream ?: return
 		val writer = OutputStreamWriter(os)
 		try {
-			val encoder = java.util.Base64.getEncoder()
-			val b64ssid = encoder.encodeToString(ssid.toByteArray(StandardCharsets.UTF_8))
-			val b64passwd = encoder.encodeToString(passwd.toByteArray(StandardCharsets.UTF_8))
+			val b64ssid = Base64.Default.encode(ssid.encodeToByteArray())
+			val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
 			writer.append("SET BWIFI ").append(b64ssid).append(" ").append(b64passwd).append("\n")
 			writer.flush()
 			addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -199,9 +199,12 @@ class DesktopSerialHandler :
 		val os = currentPort?.outputStream ?: return
 		val writer = OutputStreamWriter(os)
 		try {
-			writer.append("SET WIFI \"").append(ssid).append("\" \"").append(passwd).append("\"\n")
+			val encoder = java.util.Base64.getEncoder()
+			val b64ssid = encoder.encodeToString(ssid.toByteArray(StandardCharsets.UTF_8))
+			val b64passwd = encoder.encodeToString(passwd.toByteArray(StandardCharsets.UTF_8))
+			writer.append("SET BWIFI ").append(b64ssid).append(" ").append(b64passwd).append("\n")
 			writer.flush()
-			addLog("-> SET WIFI \"$ssid\" \"${passwd.replace(".".toRegex(), "*")}\"\n")
+			addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")
 		} catch (e: IOException) {
 			addLog("$e\n")
 			LogManager.warning("[SerialHandler] Serial port write error", e)

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -14,6 +14,8 @@ import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.stream.Stream
 import kotlin.concurrent.timerTask
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.streams.asSequence
 import kotlin.streams.asStream
 import dev.slimevr.serial.SerialPort as SlimeSerialPort
@@ -194,13 +196,14 @@ class DesktopSerialHandler :
 		currentPort?.outputStream?.write(buff)
 	}
 
+	@OptIn(ExperimentalEncodingApi::class)
 	@Synchronized
 	override fun setWifi(ssid: String, passwd: String) {
 		val os = currentPort?.outputStream ?: return
 		val writer = OutputStreamWriter(os)
 		try {
-			val b64ssid = Base64.Default.encode(ssid.encodeToByteArray())
-			val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
+			val b64ssid = Base64.encode(ssid.encodeToByteArray())
+			val b64passwd = Base64.encode(passwd.encodeToByteArray())
 			writer.append("SET BWIFI ").append(b64ssid).append(" ").append(b64passwd).append("\n")
 			writer.flush()
 			addLog("-> SET BWIFI $b64ssid ${"*".repeat(b64passwd.length)}\n")

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -203,7 +203,7 @@ class DesktopSerialHandler :
 			val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
 			writer.append("SET BWIFI ").append(b64ssid).append(" ").append(b64passwd).append("\n")
 			writer.flush()
-			addLog("-> SET BWIFI $b64ssid ${b64passwd.replace(".".toRegex(), "*")}\n")
+			addLog("-> SET BWIFI $b64ssid ${StringUtils.repeat('*', b64passwd.length)}\n")
 		} catch (e: IOException) {
 			addLog("$e\n")
 			LogManager.warning("[SerialHandler] Serial port write error", e)

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -203,7 +203,7 @@ class DesktopSerialHandler :
 			val b64passwd = Base64.Default.encode(passwd.encodeToByteArray())
 			writer.append("SET BWIFI ").append(b64ssid).append(" ").append(b64passwd).append("\n")
 			writer.flush()
-			addLog("-> SET BWIFI $b64ssid ${StringUtils.repeat('*', b64passwd.length)}\n")
+			addLog("-> SET BWIFI $b64ssid ${"*".repeat(b64passwd.length)}\n")
 		} catch (e: IOException) {
 			addLog("$e\n")
 			LogManager.warning("[SerialHandler] Serial port write error", e)


### PR DESCRIPTION
SSIDs containing non-alphanumeric characters (periods, hyphens, etc.) fail to connect when sent via the plain-text SET WIFI serial command.

The firmware already supports SET BWIFI which accepts base64-encoded SSID and password, eliminating all parsing issues. This change switches both the desktop and Android serial handlers to use it.