### PR TITLE
Smaller release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ rust-version = "1.82" # Tauri's MSRV
 repository = "https://github.com/SlimeVR/SlimeVR-Server"
 
 [profile.release]
-lto = "thin"
+lto = true
+strip = true


### PR DESCRIPTION
Note: fat LTO adds a minute or two to build time, but results in 23% smaller binaries (52MB -> 41MB)

Time for clean build before this PR: 1:24
After this PR: 2:51 