### PR TITLE
Allow 0% battery level

### DIFF
--- a/gui/src/components/commons/icon/BatteryIcon.tsx
+++ b/gui/src/components/commons/icon/BatteryIcon.tsx
@@ -62,13 +62,13 @@ export function BatteryIcon({
       <g mask="url(#mask0_4_39)" className={classNames(col, 'opacity-100')}>
         <rect width={charging ? 18 : value > 2 ? 0 : value * 18} height="9" />
       </g>
-      {charging && value <= 1 && (
+      {charging && (value <= 1 || value > 2) && (
         <path
           d="M 7.7638355,8.4189633 8.0112251,4.9834646 5.7712838,4.9834645 8.5644084,0.07977871 8.3170195,3.5152773 H 10.55696 Z"
           fill="#081e30"
         />
       )}
-      {charging && value > 1 && value < 2 && (
+      {charging && value > 1 && value <= 2 && (
         <path
           d="M 5.5342464,4.6225095 C 6.1777799,5.0106205 6.6131537,5.2516456 7.5253371,6.545223 8.4340868,4.4016445 8.7809738,3.661475 10.605195,1.5520288"
           fill="none"

--- a/gui/src/components/commons/icon/BatteryIcon.tsx
+++ b/gui/src/components/commons/icon/BatteryIcon.tsx
@@ -60,7 +60,7 @@ export function BatteryIcon({
         />
       </mask>
       <g mask="url(#mask0_4_39)" className={classNames(col, 'opacity-100')}>
-        <rect width={charging ? 18 : value * 18} height="9" />
+        <rect width={charging ? 18 : value > 2 ? 0 : value * 18} height="9" />
       </g>
       {charging && value <= 1 && (
         <path
@@ -68,7 +68,7 @@ export function BatteryIcon({
           fill="#081e30"
         />
       )}
-      {charging && value > 1 && (
+      {charging && value > 1 && value < 2 && (
         <path
           d="M 5.5342464,4.6225095 C 6.1777799,5.0106205 6.6131537,5.2516456 7.5253371,6.545223 8.4340868,4.4016445 8.7809738,3.661475 10.605195,1.5520288"
           fill="none"

--- a/gui/src/components/tracker/TrackerBattery.tsx
+++ b/gui/src/components/tracker/TrackerBattery.tsx
@@ -13,7 +13,9 @@ export function TrackerBattery({
   textColor = 'primary',
 }: {
   /**
-   * a [0, 1] value range is expected
+   * Normally [0, 1] value range
+   * Values >1 indicate fully charged
+   * Values <0 also indicate 0%
    */
   value: number;
   voltage?: number | null;
@@ -36,11 +38,13 @@ export function TrackerBattery({
   const debug = config?.debug || config?.devSettings.moreInfo;
   const showVoltage = moreInfo && voltage && debug;
 
+  const pct = Math.min(Math.max(value, 0), 1);
+
   return (
     <Tooltip
       disabled={charging || !runtime || debug}
       preferedDirection="left"
-      content=<Typography>{percentFormatter.format(value)}</Typography>
+      content=<Typography>{percentFormatter.format(pct)}</Typography>
     >
       <div className="flex gap-2">
         <div className="flex flex-col justify-around">
@@ -61,7 +65,7 @@ export function TrackerBattery({
             )}
             {!charging && (!runtime || debug) && (
               <Typography color={textColor}>
-                {percentFormatter.format(value)}
+                {percentFormatter.format(pct)}
               </Typography>
             )}
             {showVoltage && (

--- a/gui/src/components/tracker/TrackerBattery.tsx
+++ b/gui/src/components/tracker/TrackerBattery.tsx
@@ -15,7 +15,7 @@ export function TrackerBattery({
   /**
    * Normally [0, 1] value range
    * Values >1 indicate fully charged
-   * Values <0 also indicate 0%
+   * Values <0 or >2 (Byte was cast to UByte, so -1 -> 255) also indicate 0%
    */
   value: number;
   voltage?: number | null;
@@ -38,7 +38,7 @@ export function TrackerBattery({
   const debug = config?.debug || config?.devSettings.moreInfo;
   const showVoltage = moreInfo && voltage && debug;
 
-  const pct = Math.min(Math.max(value, 0), 1);
+  const pct = value > 2 ? 0 : Math.min(Math.max(value, 0), 1);
 
   return (
     <Tooltip

--- a/gui/src/hooks/firmware-update.ts
+++ b/gui/src/hooks/firmware-update.ts
@@ -151,7 +151,8 @@ export function checkForUpdate(
   if (
     canUpdate &&
     device.hardwareStatus?.batteryPctEstimate != null &&
-    device.hardwareStatus.batteryPctEstimate < 50
+    (device.hardwareStatus.batteryPctEstimate < 50 ||
+      device.hardwareStatus.batteryPctEstimate > 200)
   ) {
     return 'low-battery';
   }

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -268,9 +268,9 @@ class HIDCommon {
 			}
 			// -1: Not known (e.g. not yet calculated after wake up, reusing known value is okay), 0: N/A (e.g. charging)
 			if (batt != null) {
-				tracker.batteryLevel = if (batt == 128) 1f else (batt and 127).toFloat()
+				tracker.batteryLevel = if (batt == 128) -1f else (batt and 127).toFloat()
 			}
-			// Server still won't display battery at 0% at all
+			// Server displays 0% if received 255 or -1, otherwise 0 will hide battery icon
 			if (batt_v != null) {
 				tracker.batteryVoltage = (batt_v.toFloat() + 245f) / 100f
 			}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -268,9 +268,9 @@ class HIDCommon {
 			}
 			// -1: Not known (e.g. not yet calculated after wake up, reusing known value is okay), 0: N/A (e.g. charging)
 			if (batt != null) {
+				// Server displays 0% if received 255 or -1, otherwise 0 will hide battery icon
 				tracker.batteryLevel = if (batt == 128) -1f else (batt and 127).toFloat()
 			}
-			// Server displays 0% if received 255 or -1, otherwise 0 will hide battery icon
 			if (batt_v != null) {
 				tracker.batteryVoltage = (batt_v.toFloat() + 245f) / 100f
 			}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -490,7 +490,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				// Too low or high voltage should mean there is no battery or there is a measurement error
 				// Some ESP can run at 2.3V, set a limit at 2V
 				// Below this the tracker is definitely dead if everything is working properly
-				if (it.batteryVoltage > 2f && it.batteryVoltage < 6f) {
+				if (packet.voltage > 2f && packet.voltage < 6f) {
 					// Assuming floor when converting to int
 					it.batteryLevel = if (packet.level < 0.01f) -1f else packet.level * 100
 				} else {


### PR DESCRIPTION
Server will hide battery icon if 0% is sent, but in some cases this is a valid state. Using -1 or 255 to represent 0% would hopefully not break anything else but should properly show the icon now.

I'm not sure about certain behavior when batteryLevel in server gets cast to uint8 to send to gui, e.g. it may allow 255 and not -1.