### PR TITLE
HIDCommon scheduled TIMED_OUT

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/Tracker.kt
@@ -105,7 +105,7 @@ class Tracker @JvmOverloads constructor(
 ) {
 	private val timer = BufferedTimer(1f)
 	private var timeAtLastUpdate: Long = System.currentTimeMillis()
-	private var timeScheduledSleep: Long = MAX_VALUE
+	private var timeScheduledSleep: Long = Long.MAX_VALUE
 	private var _rotation = Quaternion.IDENTITY
 
 	// IMU: +z forward, +x left, +y up

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -142,7 +142,7 @@ class HIDCommon {
 			if (tracker.status == TrackerStatus.TIMED_OUT) {
 				// If tracker was previously sleeping/shutdown, reset the sleep time and status
 				// If there is some other error, the relevant packet should set it a little later
-				tracker.setSleepTime(MAX_VALUE)
+				tracker.setSleepTime(Long.MAX_VALUE)
 				tracker.status = TrackerStatus.OK
 			}
 
@@ -281,7 +281,7 @@ class HIDCommon {
 			if (timeout != null && timeout != 0) {
 				// 0 or 65535: disable timeout
 				if (timeout == 65535) {
-					tracker.setSleepTime(MAX_VALUE)
+					tracker.setSleepTime(Long.MAX_VALUE)
 				} else {
 					tracker.setSleepTime(System.currentTimeMillis() + timeout)
 				}


### PR DESCRIPTION
I'm assuming TIMED_OUT state doesn't do too much and only lowers its priority; otherwise a new state should probably be added for this case.

Trackers can give a time when they may go to sleep, so the server can figure out when trackers should be sleeping. It also can time out if no data has been received, in case the latter isn't enough.