### PR TITLE
fix: use transaction id in reset response

### DIFF
--- a/server/core/src/main/java/dev/slimevr/VRServer.kt
+++ b/server/core/src/main/java/dev/slimevr/VRServer.kt
@@ -345,49 +345,49 @@ class VRServer @JvmOverloads constructor(
 		}
 	}
 
-	fun scheduleResetTrackersFull(resetSourceName: String?, delay: Long, bodyParts: List<Int> = ArrayList()) {
+	fun scheduleResetTrackersFull(resetSourceName: String?, delay: Long, bodyParts: List<Int> = ArrayList(), txId: Long? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Full, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Full, txId, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersFull(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Full, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Full, txId, bodyParts, delay.toInt())
 				}
 			},
 		)
 	}
 
-	fun scheduleResetTrackersYaw(resetSourceName: String?, delay: Long, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers) {
+	fun scheduleResetTrackersYaw(resetSourceName: String?, delay: Long, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers, txId: Long? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Yaw, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Yaw, txId, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersYaw(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Yaw, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Yaw, txId, bodyParts, delay.toInt())
 				}
 			},
 		)
 	}
 
-	fun scheduleResetTrackersMounting(resetSourceName: String?, delay: Long, bodyParts: List<Int>? = null) {
+	fun scheduleResetTrackersMounting(resetSourceName: String?, delay: Long, bodyParts: List<Int>? = null, txId: Long? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Mounting, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Mounting, txId, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersMounting(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Mounting, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Mounting, txId, bodyParts, delay.toInt())
 				}
 			},
 		)

--- a/server/core/src/main/java/dev/slimevr/VRServer.kt
+++ b/server/core/src/main/java/dev/slimevr/VRServer.kt
@@ -17,6 +17,7 @@ import dev.slimevr.osc.VMCHandler
 import dev.slimevr.osc.VRCOSCHandler
 import dev.slimevr.posestreamer.BVHRecorder
 import dev.slimevr.protocol.ProtocolAPI
+import dev.slimevr.protocol.rpc.TransactionInfo
 import dev.slimevr.protocol.rpc.settings.RPCSettingsHandler
 import dev.slimevr.reset.ResetHandler
 import dev.slimevr.reset.ResetTimerManager
@@ -345,49 +346,49 @@ class VRServer @JvmOverloads constructor(
 		}
 	}
 
-	fun scheduleResetTrackersFull(resetSourceName: String?, delay: Long, bodyParts: List<Int> = ArrayList(), txId: Long? = null) {
+	fun scheduleResetTrackersFull(resetSourceName: String?, delay: Long, bodyParts: List<Int> = ArrayList(), tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Full, txId, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Full, tx, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersFull(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Full, txId, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Full, tx, bodyParts, delay.toInt())
 				}
 			},
 		)
 	}
 
-	fun scheduleResetTrackersYaw(resetSourceName: String?, delay: Long, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers, txId: Long? = null) {
+	fun scheduleResetTrackersYaw(resetSourceName: String?, delay: Long, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers, tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Yaw, txId, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Yaw, tx, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersYaw(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Yaw, txId, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Yaw, tx, bodyParts, delay.toInt())
 				}
 			},
 		)
 	}
 
-	fun scheduleResetTrackersMounting(resetSourceName: String?, delay: Long, bodyParts: List<Int>? = null, txId: Long? = null) {
+	fun scheduleResetTrackersMounting(resetSourceName: String?, delay: Long, bodyParts: List<Int>? = null, tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
 			delay,
 			onTick = { progress ->
-				resetHandler.sendStarted(ResetType.Mounting, txId, bodyParts, progress, delay.toInt())
+				resetHandler.sendStarted(ResetType.Mounting, tx, bodyParts, progress, delay.toInt())
 			},
 			onComplete = {
 				queueTask {
 					humanPoseManager.resetTrackersMounting(resetSourceName, bodyParts)
-					resetHandler.sendFinished(ResetType.Mounting, txId, bodyParts, delay.toInt())
+					resetHandler.sendFinished(ResetType.Mounting, tx, bodyParts, delay.toInt())
 				}
 			},
 		)

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
@@ -374,15 +374,14 @@ class RPCHandler(private val api: ProtocolAPI) : ProtocolHandler<RpcMessageHeade
 		}
 	}
 
-	@JvmOverloads
-	fun createRPCMessage(fbb: FlatBufferBuilder, messageType: Byte, messageOffset: Int, respondTo: RpcMessageHeader? = null): Int {
+	fun createRPCMessage(fbb: FlatBufferBuilder, messageType: Byte, messageOffset: Int, txId: Long?): Int {
 		val data = IntArray(1)
 
 		RpcMessageHeader.startRpcMessageHeader(fbb)
 		RpcMessageHeader.addMessage(fbb, messageOffset)
 		RpcMessageHeader.addMessageType(fbb, messageType)
-		respondTo?.txId()?.let { txId ->
-			RpcMessageHeader.addTxId(fbb, TransactionId.createTransactionId(fbb, txId.id()))
+		txId?.let { txId ->
+			RpcMessageHeader.addTxId(fbb, TransactionId.createTransactionId(fbb, txId))
 		}
 		data[0] = RpcMessageHeader.endRpcMessageHeader(fbb)
 
@@ -392,6 +391,10 @@ class RPCHandler(private val api: ProtocolAPI) : ProtocolHandler<RpcMessageHeade
 		MessageBundle.addRpcMsgs(fbb, messages)
 		return MessageBundle.endMessageBundle(fbb)
 	}
+
+	fun createRPCMessage(fbb: FlatBufferBuilder, messageType: Byte, messageOffset: Int): Int = createRPCMessage(fbb, messageType, messageOffset, txId = null)
+
+	fun createRPCMessage(fbb: FlatBufferBuilder, messageType: Byte, messageOffset: Int, respondTo: RpcMessageHeader?): Int = createRPCMessage(fbb, messageType, messageOffset, respondTo?.txId()?.id())
 
 	override fun messagesCount(): Int = RpcMessage.names.size
 

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/TransactionInfo.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/TransactionInfo.kt
@@ -1,0 +1,8 @@
+package dev.slimevr.protocol.rpc
+
+import dev.slimevr.protocol.GenericConnection
+
+data class TransactionInfo(
+	val id: Long,
+	val conn: GenericConnection,
+)

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
@@ -5,6 +5,7 @@ import dev.slimevr.protocol.GenericConnection
 import dev.slimevr.protocol.ProtocolAPI
 import dev.slimevr.protocol.ProtocolAPIServer
 import dev.slimevr.protocol.rpc.RPCHandler
+import dev.slimevr.protocol.rpc.TransactionInfo
 import dev.slimevr.reset.ResetListener
 import solarxr_protocol.rpc.ClearMountingResetRequest
 import solarxr_protocol.rpc.ResetRequest
@@ -13,6 +14,7 @@ import solarxr_protocol.rpc.ResetStatus
 import solarxr_protocol.rpc.ResetType
 import solarxr_protocol.rpc.RpcMessage
 import solarxr_protocol.rpc.RpcMessageHeader
+import java.nio.ByteBuffer
 import java.util.function.Consumer
 
 class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetListener {
@@ -38,7 +40,9 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 			}
 		}
 
-		val txId = messageHeader.txId()?.id()
+		val tx = messageHeader.txId()?.id()?.let {
+			TransactionInfo(it, conn)
+		}
 
 		if (req.resetType() == ResetType.Yaw) {
 			val delay = if (req.hasDelay()) {
@@ -47,9 +51,9 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 				resetsConfig.yawResetDelay
 			}
 			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong(), txId = txId)
+				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong(), tx = tx)
 			} else {
-				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), txId = txId)
+				api.server.scheduleResetTrackersYaw(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), tx = tx)
 			}
 		}
 		if (req.resetType() == ResetType.Full) {
@@ -59,9 +63,9 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 				resetsConfig.fullResetDelay
 			}
 			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong(), txId = txId)
+				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong(), tx = tx)
 			} else {
-				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), txId = txId)
+				api.server.scheduleResetTrackersFull(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), tx = tx)
 			}
 		}
 		if (req.resetType() == ResetType.Mounting) {
@@ -71,35 +75,55 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 				resetsConfig.mountingResetDelay
 			}
 			if (bodyParts.isEmpty()) {
-				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong(), txId = txId)
+				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong(), tx = tx)
 			} else {
-				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), txId = txId)
+				api.server.scheduleResetTrackersMounting(RESET_SOURCE_NAME, (delay * 1000).toLong(), bodyParts.toList(), tx = tx)
 			}
 		}
 	}
 
-	fun sendResetStatusResponse(resetType: Int, status: Int, txId: Long? = null, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
-		val fbb = FlatBufferBuilder(32)
+	fun sendResetStatusResponse(resetType: Int, status: Int, tx: TransactionInfo? = null, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
+		fun buildMessage(txId: Long?): ByteBuffer {
+			val fbb = FlatBufferBuilder(32)
 
-		val bodyPartsOffset = if (bodyParts != null) ResetResponse.createBodyPartsVector(fbb, bodyParts.map { it.toByte() }.toByteArray()) else 0
+			val bodyPartsOffset = bodyParts?.let {
+				ResetResponse.createBodyPartsVector(
+					fbb,
+					bodyParts.map { it.toByte() }.toByteArray(),
+				)
+			} ?: 0
 
-		ResetResponse.startResetResponse(fbb)
-		ResetResponse.addResetType(fbb, resetType)
-		ResetResponse.addStatus(fbb, status)
-		if (bodyPartsOffset >= 0) {
-			ResetResponse.addBodyParts(fbb, bodyPartsOffset)
+			ResetResponse.startResetResponse(fbb)
+			ResetResponse.addResetType(fbb, resetType)
+			ResetResponse.addStatus(fbb, status)
+
+			if (bodyPartsOffset >= 0) {
+				ResetResponse.addBodyParts(fbb, bodyPartsOffset)
+			}
+
+			ResetResponse.addProgress(fbb, progress)
+			ResetResponse.addDuration(fbb, duration)
+
+			val update = ResetResponse.endResetResponse(fbb)
+			val outbound = rpcHandler.createRPCMessage(fbb, RpcMessage.ResetResponse, update, txId)
+			fbb.finish(outbound)
+
+			return fbb.dataBuffer()
 		}
-		ResetResponse.addProgress(fbb, progress)
-		ResetResponse.addDuration(fbb, duration)
-		val update = ResetResponse.endResetResponse(fbb)
-		val outbound = rpcHandler.createRPCMessage(fbb, RpcMessage.ResetResponse, update, txId)
-		fbb.finish(outbound)
 
-		this.forAllListeners(
-			Consumer { conn: GenericConnection ->
-				conn.send(fbb.dataBuffer())
-			},
-		)
+		tx?.let { tx ->
+			tx.conn.send(buildMessage(tx.id))
+		}
+
+		buildMessage(null).let {
+			this.forAllListeners(
+				Consumer { conn: GenericConnection ->
+					if (tx == null || tx.conn != conn) {
+						conn.send(it)
+					}
+				},
+			)
+		}
 	}
 
 	fun onClearMountingResetRequest(
@@ -115,12 +139,12 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 		api.server.clearTrackersMounting(RESET_SOURCE_NAME)
 	}
 
-	override fun onStarted(resetType: Int, txId: Long?, bodyParts: List<Int>?, progress: Int, duration: Int) {
-		sendResetStatusResponse(resetType, ResetStatus.STARTED, txId, bodyParts, progress, duration)
+	override fun onStarted(resetType: Int, tx: TransactionInfo?, bodyParts: List<Int>?, progress: Int, duration: Int) {
+		sendResetStatusResponse(resetType, ResetStatus.STARTED, tx, bodyParts, progress, duration)
 	}
 
-	override fun onFinished(resetType: Int, txId: Long?, bodyParts: List<Int>?, duration: Int) {
-		sendResetStatusResponse(resetType, ResetStatus.FINISHED, txId, bodyParts, duration, duration)
+	override fun onFinished(resetType: Int, tx: TransactionInfo?, bodyParts: List<Int>?, duration: Int) {
+		sendResetStatusResponse(resetType, ResetStatus.FINISHED, tx, bodyParts, duration, duration)
 	}
 
 	fun forAllListeners(action: Consumer<in GenericConnection?>?) {

--- a/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
@@ -6,12 +6,12 @@ import java.util.function.Consumer
 class ResetHandler {
 	private val listeners: MutableList<ResetListener> = CopyOnWriteArrayList()
 
-	fun sendStarted(resetType: Int, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
-		this.listeners.forEach { listener: ResetListener -> listener.onStarted(resetType, bodyParts, progress, duration) }
+	fun sendStarted(resetType: Int, txId: Long? = null, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
+		this.listeners.forEach { listener: ResetListener -> listener.onStarted(resetType, txId, bodyParts, progress, duration) }
 	}
 
-	fun sendFinished(resetType: Int, bodyParts: List<Int>? = null, duration: Int) {
-		this.listeners.forEach { listener: ResetListener -> listener.onFinished(resetType, bodyParts, duration) }
+	fun sendFinished(resetType: Int, txId: Long? = null, bodyParts: List<Int>? = null, duration: Int) {
+		this.listeners.forEach { listener: ResetListener -> listener.onFinished(resetType, txId, bodyParts, duration) }
 	}
 
 	fun addListener(listener: ResetListener) {

--- a/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
@@ -1,17 +1,18 @@
 package dev.slimevr.reset
 
+import dev.slimevr.protocol.rpc.TransactionInfo
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
 class ResetHandler {
 	private val listeners: MutableList<ResetListener> = CopyOnWriteArrayList()
 
-	fun sendStarted(resetType: Int, txId: Long? = null, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
-		this.listeners.forEach { listener: ResetListener -> listener.onStarted(resetType, txId, bodyParts, progress, duration) }
+	fun sendStarted(resetType: Int, tx: TransactionInfo? = null, bodyParts: List<Int>? = null, progress: Int = 0, duration: Int = 0) {
+		this.listeners.forEach { listener: ResetListener -> listener.onStarted(resetType, tx, bodyParts, progress, duration) }
 	}
 
-	fun sendFinished(resetType: Int, txId: Long? = null, bodyParts: List<Int>? = null, duration: Int) {
-		this.listeners.forEach { listener: ResetListener -> listener.onFinished(resetType, txId, bodyParts, duration) }
+	fun sendFinished(resetType: Int, tx: TransactionInfo? = null, bodyParts: List<Int>? = null, duration: Int) {
+		this.listeners.forEach { listener: ResetListener -> listener.onFinished(resetType, tx, bodyParts, duration) }
 	}
 
 	fun addListener(listener: ResetListener) {

--- a/server/core/src/main/java/dev/slimevr/reset/ResetListener.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetListener.kt
@@ -1,7 +1,7 @@
 package dev.slimevr.reset
 
 interface ResetListener {
-	fun onStarted(resetType: Int, bodyParts: List<Int>? = null, progress: Int, duration: Int)
+	fun onStarted(resetType: Int, txId: Long?, bodyParts: List<Int>? = null, progress: Int, duration: Int)
 
-	fun onFinished(resetType: Int, bodyParts: List<Int>? = null, duration: Int)
+	fun onFinished(resetType: Int, txId: Long?, bodyParts: List<Int>? = null, duration: Int)
 }

--- a/server/core/src/main/java/dev/slimevr/reset/ResetListener.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetListener.kt
@@ -1,7 +1,9 @@
 package dev.slimevr.reset
 
-interface ResetListener {
-	fun onStarted(resetType: Int, txId: Long?, bodyParts: List<Int>? = null, progress: Int, duration: Int)
+import dev.slimevr.protocol.rpc.TransactionInfo
 
-	fun onFinished(resetType: Int, txId: Long?, bodyParts: List<Int>? = null, duration: Int)
+interface ResetListener {
+	fun onStarted(resetType: Int, tx: TransactionInfo?, bodyParts: List<Int>? = null, progress: Int, duration: Int)
+
+	fun onFinished(resetType: Int, tx: TransactionInfo?, bodyParts: List<Int>? = null, duration: Int)
 }


### PR DESCRIPTION
Changes the reset response to use the transaction id of the request, for use in [solarxr-cli](https://github.com/notpeelz/solarxr-cli).

The use case is for implementing a blocking mode (`--wait` option) in `solarxr-cli reset <type>`.
This is especially useful for chaining commands, eg:
```
solarxr-cli reset --delay 3 --wait full && notify-send "Full reset done"
```

solarxr-cli branch: https://github.com/notpeelz/solarxr-cli/tree/feat-reset-transaction