### PR TITLE
Introduce VID/PID allow lists

### DIFF
--- a/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
+++ b/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
@@ -14,9 +14,6 @@ import dev.slimevr.tracking.trackers.Device
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerStatus
 import dev.slimevr.tracking.trackers.hid.HIDCommon
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_PID
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_RECEIVER_PID
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_RECEIVER_VID
 import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.PACKET_SIZE
 import dev.slimevr.tracking.trackers.hid.HIDDevice
 import io.eiren.util.logging.LogManager
@@ -94,7 +91,7 @@ class AndroidHIDManager(
 	}
 
 	fun checkConfigureDevice(usbDevice: UsbDevice, requestPermission: Boolean = false) {
-		if (usbDevice.vendorId == HID_TRACKER_RECEIVER_VID && (usbDevice.productId == HID_TRACKER_RECEIVER_PID || usbDevice.productId == HID_TRACKER_PID)) {
+		if (HIDCommon.matchesReceiver(usbDevice.vendorId, usbDevice.productId) || HIDCommon.matchesTracker(usbDevice.vendorId, usbDevice.productId)) {
 			if (usbManager.hasPermission(usbDevice)) {
 				LogManager.info("[TrackerServer] Already have permission for ${usbDevice.deviceName}")
 				proceedWithDeviceConfiguration(usbDevice)
@@ -204,7 +201,7 @@ class AndroidHIDManager(
 	private fun deviceEnumerate(requestPermission: Boolean = false) {
 		val trackersOverHID: Boolean = VRServer.instance.configManager.vrConfig.hidConfig.trackersOverHID
 		val hidDeviceList: MutableList<UsbDevice> = usbManager.deviceList.values.filter {
-			it.vendorId == HID_TRACKER_RECEIVER_VID && (it.productId == HID_TRACKER_RECEIVER_PID || (trackersOverHID && it.productId == HID_TRACKER_PID))
+			HIDCommon.matchesReceiver(it.vendorId, it.productId) || (trackersOverHID && HIDCommon.matchesTracker(it.vendorId, it.productId))
 		}.toMutableList()
 		synchronized(devicesByHID) {
 			// Work on devicesByHid and add/remove as necessary

--- a/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
+++ b/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
@@ -91,7 +91,7 @@ class AndroidHIDManager(
 	}
 
 	fun checkConfigureDevice(usbDevice: UsbDevice, requestPermission: Boolean = false) {
-		if (HIDCommon.matchesReceiver(usbDevice.vendorId, usbDevice.productId) || HIDCommon.matchesTracker(usbDevice.vendorId, usbDevice.productId)) {
+		if (HIDCommon.matchesAny(usbDevice.vendorId, usbDevice.productId)) {
 			if (usbManager.hasPermission(usbDevice)) {
 				LogManager.info("[TrackerServer] Already have permission for ${usbDevice.deviceName}")
 				proceedWithDeviceConfiguration(usbDevice)

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -28,10 +28,35 @@ class HIDCommon {
 		const val HID_TRACKER_RECEIVER_VID = 0x1209
 		const val HID_TRACKER_RECEIVER_PID = 0x7690
 		const val HID_TRACKER_PID = 0x7692
+		const val GESTURES_INC_VID = 0x4E76
+		const val GESTURES_INC_PID_D2XX = 0xD200
+		const val GESTURES_INC_PID_D2XX_MASK = 0xFF00
 
 		const val PACKET_SIZE = 16
 
 		private val AXES_OFFSET = fromRotationVector(-FastMath.HALF_PI, 0f, 0f)
+
+		private data class HidProductRule(
+			val vendorId: Int,
+			val productId: Int,
+			val productMask: Int = 0xFFFF,
+		)
+
+		private val receiverProductRules = listOf(
+			HidProductRule(HID_TRACKER_RECEIVER_VID, HID_TRACKER_RECEIVER_PID),
+			HidProductRule(GESTURES_INC_VID, GESTURES_INC_PID_D2XX, GESTURES_INC_PID_D2XX_MASK),
+		)
+		private val trackerProductRules = listOf(
+			HidProductRule(HID_TRACKER_RECEIVER_VID, HID_TRACKER_PID),
+		)
+
+		private fun matchesProductRule(vendorId: Int, productId: Int, rule: HidProductRule): Boolean = vendorId == rule.vendorId && (productId and rule.productMask) == rule.productId
+
+		fun matchesReceiver(vendorId: Int, productId: Int): Boolean = receiverProductRules.any { matchesProductRule(vendorId, productId, it) }
+
+		fun matchesTracker(vendorId: Int, productId: Int): Boolean = trackerProductRules.any { matchesProductRule(vendorId, productId, it) }
+
+		fun supportedVendorIds(): Set<Int> = (receiverProductRules + trackerProductRules).map { it.vendorId }.toSet()
 
 		fun deviceIdLookup(
 			hidDevices: MutableList<HIDDevice>,

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -26,7 +26,7 @@ import kotlin.math.sqrt
 class HIDCommon {
 	companion object {
 		const val HID_TRACKER_RECEIVER_VID = 0x1209
-		const val HID_TRACKER_RECEIVER_PID = 0x7690
+		const val HID_RECEIVER_PID = 0x7690
 		const val HID_TRACKER_PID = 0x7692
 		const val GESTURES_INC_VID = 0x4E76
 		const val GESTURES_INC_PID_D2XX = 0xD200
@@ -36,27 +36,29 @@ class HIDCommon {
 
 		private val AXES_OFFSET = fromRotationVector(-FastMath.HALF_PI, 0f, 0f)
 
-		private data class HidProductRule(
+		data class HidProductRule(
 			val vendorId: Int,
 			val productId: Int,
 			val productMask: Int = 0xFFFF,
 		)
 
-		private val receiverProductRules = listOf(
-			HidProductRule(HID_TRACKER_RECEIVER_VID, HID_TRACKER_RECEIVER_PID),
+		val receiverProductRules = listOf(
+			HidProductRule(HID_TRACKER_RECEIVER_VID, HID_RECEIVER_PID),
 			HidProductRule(GESTURES_INC_VID, GESTURES_INC_PID_D2XX, GESTURES_INC_PID_D2XX_MASK),
 		)
-		private val trackerProductRules = listOf(
+		val trackerProductRules = listOf(
 			HidProductRule(HID_TRACKER_RECEIVER_VID, HID_TRACKER_PID),
 		)
 
 		private fun matchesProductRule(vendorId: Int, productId: Int, rule: HidProductRule): Boolean = vendorId == rule.vendorId && (productId and rule.productMask) == rule.productId
 
+		fun allProductRules(): List<HidProductRule> = (receiverProductRules + trackerProductRules)
+
 		fun matchesReceiver(vendorId: Int, productId: Int): Boolean = receiverProductRules.any { matchesProductRule(vendorId, productId, it) }
 
 		fun matchesTracker(vendorId: Int, productId: Int): Boolean = trackerProductRules.any { matchesProductRule(vendorId, productId, it) }
 
-		fun supportedVendorIds(): Set<Int> = (receiverProductRules + trackerProductRules).map { it.vendorId }.toSet()
+		fun matchesAny(vendorId: Int, productId: Int): Boolean = allProductRules().any { matchesProductRule(vendorId, productId, it) }
 
 		fun deviceIdLookup(
 			hidDevices: MutableList<HIDDevice>,

--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
@@ -55,7 +55,7 @@ class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tra
 	}
 
 	private fun checkConfigureDevice(hidDevice: HidDevice) {
-		if (HIDCommon.matchesReceiver(hidDevice.vendorId, hidDevice.productId) || HIDCommon.matchesTracker(hidDevice.vendorId, hidDevice.productId)) {
+		if (HIDCommon.matchesAny(hidDevice.vendorId, hidDevice.productId)) {
 			val serial = hidDevice.serialNumber ?: "Unknown HID Device"
 			if (hidDevice.isClosed) {
 				if (!hidDevice.open()) {
@@ -210,13 +210,12 @@ class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tra
 	private fun deviceEnumerate() {
 		val trackersOverHID: Boolean = VRServer.instance.configManager.vrConfig.hidConfig.trackersOverHID
 		val hidDeviceList: MutableList<HidDevice> = mutableListOf()
-		for (vendorId in HIDCommon.supportedVendorIds()) {
+		for (rule in HIDCommon.allProductRules()) {
 			var root: HidDeviceInfoStructure? = null
 			try {
-				// Filter by vendor in hidapi, then apply product/mask matching in code.
-				root = HidApi.enumerateDevices(vendorId, 0)
+				root = HidApi.enumerateDevices(rule.vendorId, if (rule.productMask == 0xFFFF) rule.productId else 0)
 			} catch (e: Throwable) {
-				LogManager.severe("[TrackerServer] Couldn't enumerate HID devices for VID ${String.format("0x%04X", vendorId)}", e)
+				LogManager.severe("[TrackerServer] Couldn't enumerate HID devices using rule ${String.format("%04x:%04x", rule.vendorId, rule.productId)} & ${String.format("0x%04X", rule.productMask)}", e)
 			}
 			if (root != null) {
 				var hidDeviceInfoStructure: HidDeviceInfoStructure? = root

--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
@@ -6,9 +6,6 @@ import dev.slimevr.tracking.trackers.Device
 import dev.slimevr.tracking.trackers.Tracker
 import dev.slimevr.tracking.trackers.TrackerStatus
 import dev.slimevr.tracking.trackers.hid.HIDCommon
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_PID
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_RECEIVER_PID
-import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.HID_TRACKER_RECEIVER_VID
 import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.PACKET_SIZE
 import dev.slimevr.tracking.trackers.hid.HIDDevice
 import io.eiren.util.logging.LogManager
@@ -58,7 +55,7 @@ class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tra
 	}
 
 	private fun checkConfigureDevice(hidDevice: HidDevice) {
-		if (hidDevice.vendorId == HID_TRACKER_RECEIVER_VID && (hidDevice.productId == HID_TRACKER_RECEIVER_PID || hidDevice.productId == HID_TRACKER_PID)) { // TODO: Use list of valid ids
+		if (HIDCommon.matchesReceiver(hidDevice.vendorId, hidDevice.productId) || HIDCommon.matchesTracker(hidDevice.vendorId, hidDevice.productId)) {
 			val serial = hidDevice.serialNumber ?: "Unknown HID Device"
 			if (hidDevice.isClosed) {
 				if (!hidDevice.open()) {
@@ -211,37 +208,29 @@ class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tra
 	}
 
 	private fun deviceEnumerate() {
-		var rootReceivers: HidDeviceInfoStructure? = null
-		var rootTrackers: HidDeviceInfoStructure? = null
 		val trackersOverHID: Boolean = VRServer.instance.configManager.vrConfig.hidConfig.trackersOverHID
-		try {
-			rootReceivers = HidApi.enumerateDevices(HID_TRACKER_RECEIVER_VID, HID_TRACKER_RECEIVER_PID) // TODO: Use list of ids
-			rootTrackers = if (trackersOverHID) {
-				HidApi.enumerateDevices(HID_TRACKER_RECEIVER_VID, HID_TRACKER_PID)
-			} else {
-				null
-			} // TODO: Use list of ids
-		} catch (e: Throwable) {
-			LogManager.severe("[TrackerServer] Couldn't enumerate HID devices", e)
-		}
-		var root: HidDeviceInfoStructure? = rootReceivers
-		if (root == null) {
-			root = rootTrackers
-		} else {
-			var last: HidDeviceInfoStructure = root
-			while (last.hasNext()) {
-				last = last.next()
-			}
-			last.next = rootTrackers
-		}
 		val hidDeviceList: MutableList<HidDevice> = mutableListOf()
-		if (root != null) {
-			var hidDeviceInfoStructure: HidDeviceInfoStructure? = root
-			do {
-				hidDeviceList.add(HidDevice(hidDeviceInfoStructure, null, hidServicesSpecification))
-				hidDeviceInfoStructure = hidDeviceInfoStructure?.next()
-			} while (hidDeviceInfoStructure != null)
-			HidApi.freeEnumeration(root)
+		for (vendorId in HIDCommon.supportedVendorIds()) {
+			var root: HidDeviceInfoStructure? = null
+			try {
+				// Filter by vendor in hidapi, then apply product/mask matching in code.
+				root = HidApi.enumerateDevices(vendorId, 0)
+			} catch (e: Throwable) {
+				LogManager.severe("[TrackerServer] Couldn't enumerate HID devices for VID ${String.format("0x%04X", vendorId)}", e)
+			}
+			if (root != null) {
+				var hidDeviceInfoStructure: HidDeviceInfoStructure? = root
+				do {
+					val hidDevice = HidDevice(hidDeviceInfoStructure, null, hidServicesSpecification)
+					val isReceiver = HIDCommon.matchesReceiver(hidDevice.vendorId, hidDevice.productId)
+					val isTracker = HIDCommon.matchesTracker(hidDevice.vendorId, hidDevice.productId)
+					if (isReceiver || (trackersOverHID && isTracker)) {
+						hidDeviceList.add(hidDevice)
+					}
+					hidDeviceInfoStructure = hidDeviceInfoStructure?.next()
+				} while (hidDeviceInfoStructure != null)
+				HidApi.freeEnumeration(root)
+			}
 		}
 		synchronized(devicesByHID) {
 			// Work on devicesByHid and add/remove as necessary


### PR DESCRIPTION
Alternatively, we can adopt another (universal) mechanism if it is defined and adopted for SlimeVR trackers.