### PR TITLE
Revert kache and coroutines upgrade

### DIFF
--- a/server/core/build.gradle.kts
+++ b/server/core/build.gradle.kts
@@ -76,8 +76,12 @@ dependencies {
 	implementation("org.java-websocket:Java-WebSocket:1.+")
 	implementation("com.melloware:jintellitype:1.+")
 	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-	implementation("com.mayakapps.kache:kache:2.1.1")
+
+	// 2.1.1 - of kache cause OSCQuery to fail on android.
+	// Same goes for upgrading coroutines. kache prob upgrade coroutines too.
+	// proceed with caution if you plan on upgrading that library
+	implementation("com.mayakapps.kache:kache:2.1.0")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
 	api("com.github.loucass003:EspflashKotlin:v0.11.0")
 


### PR DESCRIPTION
Reverting these two libs causing issues with android.
This solve the regression caused by https://github.com/SlimeVR/SlimeVR-Server/pull/1746
