### PR TITLE
Allow passing excess CLI arguments to Electron

### DIFF
--- a/gui/electron/main/cli.ts
+++ b/gui/electron/main/cli.ts
@@ -8,7 +8,9 @@ program
     '--skip-server-if-running',
     'gui will not launch the server if it is already running'
   )
-  .allowUnknownOption();
+  .allowUnknownOption()
+  // Allow passing arguments to Electron.
+  .allowExcessArguments();
 
 if (process.platform === "linux") {
   const noUdevOption = new Option('--no-udev', 'disable udev warning');


### PR DESCRIPTION
Fixes regression in v19.0.0. Needed for NixOS packaging and Linux in general.