### PR TITLE
Kotlin 2 Kotlin, part1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ vrconfig.yml.tmp
 
 # Nixos
 .bin/
+
+# macOS
+.DS_Store

--- a/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
+++ b/server/android/src/main/java/dev/slimevr/android/serial/AndroidSerialHandler.kt
@@ -17,7 +17,6 @@ import dev.slimevr.serial.SerialListener
 import io.eiren.util.logging.LogManager
 import java.io.IOException
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.stream.Stream
 import kotlin.streams.asSequence
@@ -128,9 +127,10 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 	}
 
 	private fun detectNewPorts() {
-		val addDifferences = knownPorts.asSequence() - lastKnownPorts
-		val delDifferences = lastKnownPorts - knownPorts.asSequence().toSet()
-		lastKnownPorts = knownPorts.asSequence().toSet()
+		val knownPortsSet = knownPorts.asSequence().toSet()
+		val addDifferences = knownPortsSet - lastKnownPorts
+		val delDifferences = lastKnownPorts - knownPortsSet
+		lastKnownPorts = knownPortsSet
 		addDifferences.forEach { onNewDevice(it) }
 		delDifferences.forEach { onDeviceDel(it) }
 	}
@@ -297,7 +297,7 @@ class AndroidSerialHandler(val activity: AppCompatActivity) :
 			// Collect serial in a buffer until newline (or character limit)
 			// This is somewhat of a workaround for Android serial buffer being smaller
 			//  than on desktop, so we don't read full lines and it causes parsing issues
-			readBuffer.append(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(data)))
+			readBuffer.append(Charsets.UTF_8.decode(ByteBuffer.wrap(data)))
 
 			if (readBuffer.contains('\n') || readBuffer.length >= 1024) {
 				addLog(readBuffer.toString(), false)

--- a/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
+++ b/server/android/src/main/java/dev/slimevr/android/tracking/trackers/hid/AndroidHIDManager.kt
@@ -18,7 +18,6 @@ import dev.slimevr.tracking.trackers.hid.HIDCommon.Companion.PACKET_SIZE
 import dev.slimevr.tracking.trackers.hid.HIDDevice
 import io.eiren.util.logging.LogManager
 import java.nio.ByteBuffer
-import java.util.function.Consumer
 
 const val ACTION_USB_PERMISSION = "dev.slimevr.USB_PERMISSION"
 
@@ -27,7 +26,7 @@ const val ACTION_USB_PERMISSION = "dev.slimevr.USB_PERMISSION"
  */
 class AndroidHIDManager(
 	name: String,
-	private val trackersConsumer: Consumer<Tracker>,
+	private val trackersConsumer: (Tracker) -> Unit,
 	private val context: Context,
 ) : Thread(name) {
 	private val devices: MutableList<HIDDevice> = mutableListOf()

--- a/server/core/src/main/java/dev/slimevr/VRServer.kt
+++ b/server/core/src/main/java/dev/slimevr/VRServer.kt
@@ -41,10 +41,8 @@ import io.eiren.util.collections.FastList
 import io.eiren.util.logging.LogManager
 import solarxr_protocol.datatypes.TrackerIdT
 import solarxr_protocol.rpc.ResetType
-import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.Timer
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.function.Consumer
 import kotlin.collections.ArrayList
 import kotlin.concurrent.schedule
 
@@ -71,8 +69,8 @@ class VRServer @JvmOverloads constructor(
 	private val trackers: MutableList<Tracker> = FastList()
 	val trackersServer: TrackersUDPServer
 	private val bridges: MutableList<Bridge> = FastList()
-	private val tasks: Queue<Runnable> = LinkedBlockingQueue()
-	private val newTrackersConsumers: MutableList<Consumer<Tracker>> = FastList()
+	private val tasks: ArrayDeque<Runnable> = ArrayDeque()
+	private val newTrackersConsumers: MutableList<(Tracker) -> Unit> = FastList()
 	private val trackerStatusListeners: MutableList<TrackerStatusListener> = FastList()
 	private val onTick: MutableList<Runnable> = FastList()
 	private val lock = acquireMulticastLock()
@@ -214,11 +212,11 @@ class VRServer @JvmOverloads constructor(
 	}
 
 	@ThreadSafe
-	fun addNewTrackerConsumer(consumer: Consumer<Tracker>) {
+	fun addNewTrackerConsumer(consumer: (Tracker) -> Unit) {
 		queueTask {
 			newTrackersConsumers.add(consumer)
 			for (tracker in trackers) {
-				consumer.accept(tracker)
+				consumer(tracker)
 			}
 		}
 	}
@@ -235,7 +233,7 @@ class VRServer @JvmOverloads constructor(
 	}
 
 	@ThreadSafe
-	fun addSkeletonUpdatedCallback(consumer: Consumer<HumanSkeleton>) {
+	fun addSkeletonUpdatedCallback(consumer: (HumanSkeleton) -> Unit) {
 		queueTask { humanPoseManager.addSkeletonUpdatedCallback(consumer) }
 	}
 
@@ -246,7 +244,7 @@ class VRServer @JvmOverloads constructor(
 			// final long start = System.currentTimeMillis();
 			fpsTimer.update()
 			do {
-				val task = tasks.poll() ?: break
+				val task = tasks.removeFirstOrNull() ?: break
 				task.run()
 			} while (true)
 			for (task in onTick) {
@@ -296,7 +294,7 @@ class VRServer @JvmOverloads constructor(
 			trackers.add(tracker)
 			trackerAdded(tracker)
 			for (tc in newTrackersConsumers) {
-				tc.accept(tracker)
+				tc(tracker)
 			}
 		}
 	}

--- a/server/core/src/main/java/dev/slimevr/autobone/AutoBone.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/AutoBone.kt
@@ -20,8 +20,6 @@ import io.github.axisangles.ktmath.Vector3
 import org.apache.commons.lang3.tuple.Pair
 import java.io.File
 import java.util.*
-import java.util.function.Consumer
-import java.util.function.Function
 import kotlin.math.*
 
 class AutoBone(private val server: VRServer) {
@@ -74,17 +72,14 @@ class AutoBone(private val server: VRServer) {
 		// Get current or default skeleton configs
 		val skeleton = server.humanPoseManager
 		// Still compensate for a null skeleton, as it may not be initialized yet
-		val getOffset: Function<SkeletonConfigOffsets, Float> =
-			if (skeleton != null) {
-				Function { key: SkeletonConfigOffsets -> skeleton.getOffset(key) }
-			} else {
-				val defaultConfig = SkeletonConfigManager(false)
-				Function { config: SkeletonConfigOffsets ->
-					defaultConfig.getOffset(config)
-				}
-			}
+		val defaultConfig = SkeletonConfigManager(false)
+		val getOffset: (SkeletonConfigOffsets) -> Float = if (skeleton != null) {
+			{ key: SkeletonConfigOffsets -> skeleton.getOffset(key) }
+		} else {
+			{ config: SkeletonConfigOffsets -> defaultConfig.getOffset(config) }
+		}
 		for (bone in adjustOffsets) {
-			val offset = getOffset.apply(bone)
+			val offset = getOffset(bone)
 			if (offset > 0f) {
 				offsets[bone] = offset
 			}
@@ -216,7 +211,7 @@ class AutoBone(private val server: VRServer) {
 		frames: PoseFrames,
 		config: AutoBoneConfig = globalConfig,
 		skeletonConfig: SkeletonConfig = globalSkeletonConfig,
-		epochCallback: Consumer<Epoch>? = null,
+		epochCallback: ((Epoch) -> Unit)? = null,
 	): AutoBoneResults {
 		check(frames.frameHolders.isNotEmpty()) { "Recording has no trackers." }
 		check(frames.maxFrameCount > 0) { "Recording has no frames." }
@@ -296,7 +291,7 @@ class AutoBone(private val server: VRServer) {
 
 	private fun epoch(
 		step: PoseFrameStep<AutoBoneStep>,
-		epochCallback: Consumer<Epoch>? = null,
+		epochCallback: ((Epoch) -> Unit)? = null,
 	) {
 		val config = step.config
 		val epoch = step.epoch
@@ -319,7 +314,7 @@ class AutoBone(private val server: VRServer) {
 			for (entry in scaledOffsets.entries) {
 				entry.setValue(entry.value * estimatedHeight)
 			}
-			epochCallback.accept(Epoch(epoch + 1, config.numEpochs, step.data.errorStats, scaledOffsets))
+			epochCallback(Epoch(epoch + 1, config.numEpochs, step.data.errorStats, scaledOffsets))
 		}
 	}
 

--- a/server/core/src/main/java/dev/slimevr/autobone/AutoBoneHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/AutoBoneHandler.kt
@@ -14,6 +14,7 @@ import dev.slimevr.tracking.processor.config.SkeletonConfigOffsets
 import io.eiren.util.StringUtils
 import io.eiren.util.collections.FastList
 import io.eiren.util.logging.LogManager
+import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.tuple.Pair
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -118,7 +119,7 @@ class AutoBoneHandler(private val server: VRServer) {
 							eta = totalTime - (progress.frame * totalTime / progress.totalFrames),
 						)
 					}
-				val frames = framesFuture.get()
+				val frames = runBlocking { framesFuture.await() }
 				LogManager.info("[AutoBone] Done recording!")
 
 				// Save a recurring recording for users to send as debug info
@@ -188,7 +189,7 @@ class AutoBoneHandler(private val server: VRServer) {
 			val framesFuture = poseRecorder.framesAsync
 			if (framesFuture != null) {
 				announceProcessStatus(AutoBoneProcessType.SAVE, "Waiting for recording...")
-				val frames = framesFuture.get()
+				val frames = runBlocking { framesFuture.await() }
 				check(frames.frameHolders.isNotEmpty()) { "Recording has no trackers." }
 				check(frames.maxFrameCount > 0) { "Recording has no frames." }
 				announceProcessStatus(AutoBoneProcessType.SAVE, "Saving recording...")
@@ -242,7 +243,7 @@ class AutoBoneHandler(private val server: VRServer) {
 				val framesFuture = poseRecorder.framesAsync
 				if (framesFuture != null) {
 					announceProcessStatus(AutoBoneProcessType.PROCESS, "Waiting for recording...")
-					val frames = framesFuture.get()
+					val frames = runBlocking { framesFuture.await() }
 					frameRecordings.add(Pair.of("<Recording>", frames))
 				} else {
 					announceProcessStatus(

--- a/server/core/src/main/java/dev/slimevr/autobone/PoseFrameIterator.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/PoseFrameIterator.kt
@@ -42,7 +42,7 @@ object PoseFrameIterator {
 		val frameCount = step.maxFrameCount
 
 		// Perform any setup that needs to be done before the current epoch
-		step.preEpoch?.accept(step)
+		step.preEpoch?.invoke(step)
 
 		val randIndices = if (config.randomizeFrameOrder) {
 			randomIndices(step.maxFrameCount, step.random)
@@ -77,7 +77,7 @@ object PoseFrameIterator {
 				}
 
 				// Process the iteration
-				step.onStep.accept(step)
+				step.onStep(step)
 
 				// Move on to the next iteration
 				frameCursor += config.cursorIncrement
@@ -85,6 +85,6 @@ object PoseFrameIterator {
 			cursorOffset++
 		}
 
-		step.postEpoch?.accept(step)
+		step.postEpoch?.invoke(step)
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/autobone/PoseFrameStep.kt
+++ b/server/core/src/main/java/dev/slimevr/autobone/PoseFrameStep.kt
@@ -5,7 +5,6 @@ import dev.slimevr.config.ConfigManager
 import dev.slimevr.poseframeformat.PoseFrames
 import dev.slimevr.poseframeformat.player.TrackerFramesPlayer
 import dev.slimevr.tracking.processor.HumanPoseManager
-import java.util.function.Consumer
 import kotlin.random.Random
 
 class PoseFrameStep<T>(
@@ -14,11 +13,11 @@ class PoseFrameStep<T>(
 	serverConfig: ConfigManager? = null,
 	val frames: PoseFrames,
 	/** The consumer run before each epoch. */
-	val preEpoch: Consumer<PoseFrameStep<T>>? = null,
+	val preEpoch: ((PoseFrameStep<T>) -> Unit)? = null,
 	/** The consumer run for each step. */
-	val onStep: Consumer<PoseFrameStep<T>>,
+	val onStep: (PoseFrameStep<T>) -> Unit,
 	/** The consumer run after each epoch. */
-	val postEpoch: Consumer<PoseFrameStep<T>>? = null,
+	val postEpoch: ((PoseFrameStep<T>) -> Unit)? = null,
 	/** The current epoch. */
 	var epoch: Int = 0,
 	/** The current frame cursor position in [frames] for skeleton1. */

--- a/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/FirmwareUpdateHandler.kt
@@ -24,8 +24,8 @@ import java.security.MessageDigest
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.stream.Collectors
 import kotlin.concurrent.scheduleAtFixedRate
+import kotlin.streams.asSequence
 
 data class DownloadedFirmwarePart(
 	val firmware: ByteArray,
@@ -120,8 +120,8 @@ class FirmwareUpdateHandler(private val server: VRServer) :
 		ssid: String,
 		password: String,
 	) {
-		// Can't use .toList() on Android
-		val serialPort = this.server.serialHandler.knownPorts.collect(Collectors.toList())
+		val serialPort = this.server.serialHandler.knownPorts
+			.asSequence()
 			.find { port -> deviceId.id == port.portLocation }
 
 		if (serialPort == null) {

--- a/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
+++ b/server/core/src/main/java/dev/slimevr/firmware/OTAUpdateTask.kt
@@ -12,15 +12,14 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
-import java.util.*
-import java.util.function.Consumer
+import java.util.UUID
 import kotlin.math.min
 
 class OTAUpdateTask(
 	private val firmware: ByteArray,
 	private val deviceId: UpdateDeviceId<Int>,
 	private val deviceIp: InetAddress,
-	private val statusCallback: Consumer<UpdateStatusEvent<Int>>,
+	private val statusCallback: (UpdateStatusEvent<Int>) -> Unit,
 ) {
 	private val receiveBuffer: ByteArray = ByteArray(38)
 	var socketServer: ServerSocket? = null
@@ -44,7 +43,7 @@ class OTAUpdateTask(
 		try {
 			DatagramSocket().use { socket ->
 				authSocket = socket
-				statusCallback.accept(UpdateStatusEvent(deviceId, FirmwareUpdateStatus.AUTHENTICATING))
+				statusCallback(UpdateStatusEvent(deviceId, FirmwareUpdateStatus.AUTHENTICATING))
 				LogManager.info("[OTAUpdate] Sending OTA invitation to: $deviceIp")
 
 				val fileMd5 = bytesToMd5(firmware)
@@ -116,7 +115,7 @@ class OTAUpdateTask(
 			var offset = 0
 			val chunkSize = 2048
 			while (offset != firmware.size && !canceled) {
-				statusCallback.accept(
+				statusCallback(
 					UpdateStatusEvent(
 						deviceId,
 						FirmwareUpdateStatus.UPLOADING,
@@ -161,7 +160,7 @@ class OTAUpdateTask(
 		ServerSocket(0).use { serverSocket ->
 			socketServer = serverSocket
 			if (!authenticate(serverSocket.localPort)) {
-				statusCallback.accept(
+				statusCallback(
 					UpdateStatusEvent(
 						deviceId,
 						FirmwareUpdateStatus.ERROR_AUTHENTICATION_FAILED,
@@ -171,7 +170,7 @@ class OTAUpdateTask(
 			}
 
 			if (!upload(serverSocket)) {
-				statusCallback.accept(
+				statusCallback(
 					UpdateStatusEvent(
 						deviceId,
 						FirmwareUpdateStatus.ERROR_UPLOAD_FAILED,
@@ -180,7 +179,7 @@ class OTAUpdateTask(
 				return
 			}
 
-			statusCallback.accept(
+			statusCallback(
 				UpdateStatusEvent(
 					deviceId,
 					FirmwareUpdateStatus.REBOOTING,

--- a/server/core/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
+++ b/server/core/src/main/java/dev/slimevr/poseframeformat/PoseRecorder.kt
@@ -7,11 +7,10 @@ import dev.slimevr.util.TickReducer
 import dev.slimevr.util.ann.VRServerThread
 import io.eiren.util.collections.FastList
 import io.eiren.util.logging.LogManager
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.tuple.Pair
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.Future
-import java.util.function.Consumer
 
 class PoseRecorder(private val server: VRServer) {
 	inner class RecordingProgress(val frame: Int, val totalFrames: Int)
@@ -23,8 +22,8 @@ class PoseRecorder(private val server: VRServer) {
 	// Default 50 TPS
 	private val ticker = TickReducer({ onTick() }, 0.02f)
 
-	private var recordingFuture: CompletableFuture<PoseFrames>? = null
-	private var frameCallback: Consumer<RecordingProgress>? = null
+	private var recordingFuture: CompletableDeferred<PoseFrames>? = null
+	private var frameCallback: ((RecordingProgress) -> Unit)? = null
 	var trackers = FastList<Pair<Tracker, TrackerFrames>>()
 
 	init {
@@ -54,7 +53,7 @@ class PoseRecorder(private val server: VRServer) {
 		}
 
 		// Send the number of finished frames
-		frameCallback?.accept(RecordingProgress(frameCursor, numFrames))
+		frameCallback?.invoke(RecordingProgress(frameCursor, numFrames))
 		// If done, send finished recording
 		if (frameCursor >= numFrames) {
 			stopFrameRecording()
@@ -66,8 +65,8 @@ class PoseRecorder(private val server: VRServer) {
 		numFrames: Int,
 		interval: Float,
 		trackers: List<Tracker?> = server.allTrackers,
-		frameCallback: Consumer<RecordingProgress>? = null,
-	): Future<PoseFrames> {
+		frameCallback: ((RecordingProgress) -> Unit)? = null,
+	): Deferred<PoseFrames> {
 		require(numFrames >= 1) { "numFrames must at least have a value of 1." }
 		require(interval > 0) { "interval must be greater than 0." }
 		require(trackers.isNotEmpty()) { "trackers must have at least one entry." }
@@ -97,7 +96,7 @@ class PoseRecorder(private val server: VRServer) {
 		ticker.interval = interval
 		ticker.reset()
 
-		val recordingFuture = CompletableFuture<PoseFrames>()
+		val recordingFuture = CompletableDeferred<PoseFrames>()
 		this.recordingFuture = recordingFuture
 		this.frameCallback = frameCallback
 
@@ -116,12 +115,12 @@ class PoseRecorder(private val server: VRServer) {
 	@Synchronized
 	private fun internalStopFrameRecording(cancel: Boolean) {
 		val currentRecording = recordingFuture
-		if (currentRecording != null && !currentRecording.isDone) {
+		if (currentRecording != null && !currentRecording.isCompleted) {
 			val currentFrames = poseFrame
 			if (cancel || currentFrames == null) {
 				// If it's supposed to be cancelled or there's actually no recording,
 				// then cancel the recording and return nothing
-				currentRecording.cancel(true)
+				currentRecording.cancel()
 			} else {
 				// Stop the recording, returning the frames recorded
 				currentRecording.complete(currentFrames)
@@ -151,12 +150,9 @@ class PoseRecorder(private val server: VRServer) {
 
 	fun hasRecording(): Boolean = recordingFuture != null
 
-	val framesAsync: Future<PoseFrames>?
+	val framesAsync: Deferred<PoseFrames>?
 		get() = recordingFuture
 
-	@get:Throws(ExecutionException::class, InterruptedException::class)
 	val frames: PoseFrames?
-		get() {
-			return recordingFuture?.get()
-		}
+		get() = runBlocking { recordingFuture?.await() }
 }

--- a/server/core/src/main/java/dev/slimevr/posestreamer/PoseDataStream.kt
+++ b/server/core/src/main/java/dev/slimevr/posestreamer/PoseDataStream.kt
@@ -5,7 +5,6 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
-import java.lang.AutoCloseable
 
 abstract class PoseDataStream protected constructor(protected val outputStream: OutputStream) : AutoCloseable {
 	var isClosed: Boolean = false

--- a/server/core/src/main/java/dev/slimevr/protocol/ProtocolHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/ProtocolHandler.kt
@@ -1,10 +1,8 @@
 package dev.slimevr.protocol
 
-import java.util.function.BiConsumer
-
 abstract class ProtocolHandler<H> {
 	@JvmField
-	val handlers: Array<BiConsumer<GenericConnection, H>?>
+	val handlers: Array<((GenericConnection, H) -> Unit)?>
 
 	init {
 		this.handlers = arrayOfNulls(this.messagesCount())
@@ -14,10 +12,14 @@ abstract class ProtocolHandler<H> {
 
 	abstract fun messagesCount(): Int
 
-	fun registerPacketListener(packetType: Byte, consumer: BiConsumer<GenericConnection, H>) {
+	fun registerPacketListener(packetType: Byte, consumer: (GenericConnection, H) -> Unit) {
 		val packetInt = packetType.toInt()
 		if (handlers[packetInt] != null) {
-			handlers[packetInt] = handlers[packetInt]!!.andThen(consumer)
+			val previous = handlers[packetInt]!!
+			handlers[packetInt] = { conn, msg ->
+				previous(conn, msg)
+				consumer(conn, msg)
+			}
 		} else {
 			handlers[packetInt] = consumer
 		}

--- a/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedBuilder.kt
@@ -30,7 +30,6 @@ import solarxr_protocol.datatypes.hardware_info.HardwareStatus
 import solarxr_protocol.datatypes.math.Quat
 import solarxr_protocol.datatypes.math.Vec3f
 import java.nio.ByteBuffer
-import java.util.function.Consumer
 
 fun createHardwareInfo(fbb: FlatBufferBuilder, device: Device): Int {
 	val nameOffset = if (device.firmwareVersion != null) {
@@ -296,14 +295,12 @@ fun createTrackersData(
 		}
 
 	DeviceData.startTrackersVector(fbb, trackersOffsets.size)
-	trackersOffsets.forEach(
-		Consumer { offset: Int ->
-			DeviceData.addTrackers(
-				fbb,
-				offset,
-			)
-		},
-	)
+	trackersOffsets.forEach { offset: Int ->
+		DeviceData.addTrackers(
+			fbb,
+			offset,
+		)
+	}
 	return fbb.endVector()
 }
 
@@ -383,24 +380,18 @@ fun createSyntheticTrackersData(
 	val trackerOffsets: MutableList<Int> = ArrayList()
 
 	trackers
-		.forEach(
-			Consumer { tracker: Tracker ->
-				trackerOffsets
-					.add(createTrackerData(fbb, trackerDataMaskT, tracker))
-			},
-		)
+		.forEach { tracker: Tracker ->
+			trackerOffsets
+				.add(createTrackerData(fbb, trackerDataMaskT, tracker))
+		}
 
 	DataFeedUpdate.startSyntheticTrackersVector(fbb, trackerOffsets.size)
-	trackerOffsets.forEach(
-		(
-			Consumer { tracker: Int ->
-				DataFeedUpdate.addSyntheticTrackers(
-					fbb,
-					tracker,
-				)
-			}
-			),
-	)
+	trackerOffsets.forEach { tracker: Int ->
+		DataFeedUpdate.addSyntheticTrackers(
+			fbb,
+			tracker,
+		)
+	}
 	return fbb.endVector()
 }
 

--- a/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/datafeed/DataFeedHandler.kt
@@ -15,8 +15,6 @@ import solarxr_protocol.data_feed.DataFeedMessageHeader
 import solarxr_protocol.data_feed.DataFeedUpdate
 import solarxr_protocol.data_feed.PollDataFeed
 import solarxr_protocol.data_feed.StartDataFeed
-import java.util.function.Consumer
-import java.util.stream.Collectors
 
 class DataFeedHandler(private val api: ProtocolAPI) : ProtocolHandler<DataFeedMessageHeader>() {
 	init {
@@ -79,9 +77,8 @@ class DataFeedHandler(private val api: ProtocolAPI) : ProtocolHandler<DataFeedMe
 			config.syntheticTrackersMask,
 			this.api.server
 				.allTrackers
-				.stream()
 				.filter(Tracker::isComputed)
-				.collect(Collectors.toList()),
+				.toMutableList(),
 		)
 
 		val h = this.api.server.humanPoseManager
@@ -117,48 +114,46 @@ class DataFeedHandler(private val api: ProtocolAPI) : ProtocolHandler<DataFeedMe
 	fun sendDataFeedUpdate() {
 		val currTime = System.currentTimeMillis()
 
-		this.api.apiServers.forEach(
-			Consumer { server: ProtocolAPIServer ->
-				server.apiConnections.forEach { conn: GenericConnection ->
-					var fbb: FlatBufferBuilder? = null
-					val feedList = conn.context.dataFeedList
-					synchronized(feedList) {
-						val configsCount = feedList.size
-						val data = IntArray(configsCount)
-						for (index in 0..<configsCount) {
-							val feed = feedList[index]
-							val lastTimeSent = feed.timeLastSent
-							val configT = feed.config
-							if (currTime - lastTimeSent > configT.minimumTimeSinceLast) {
-								if (fbb == null) {
-									// That way we create a buffer only when needed
-									fbb = FlatBufferBuilder(300)
-								}
-
-								val messageOffset = this.buildDatafeed(fbb, configT, index)
-
-								DataFeedMessageHeader.startDataFeedMessageHeader(fbb)
-								DataFeedMessageHeader.addMessage(fbb, messageOffset)
-								DataFeedMessageHeader.addMessageType(fbb, DataFeedMessage.DataFeedUpdate)
-								data[index] = DataFeedMessageHeader.endDataFeedMessageHeader(fbb)
-
-								feed.timeLastSent = currTime
-								val messages = MessageBundle.createDataFeedMsgsVector(fbb, data)
-								val packet = createMessage(fbb, messages)
-								fbb.finish(packet)
-								conn.send(fbb.dataBuffer())
+		this.api.apiServers.forEach { server: ProtocolAPIServer ->
+			server.apiConnections.forEach { conn: GenericConnection ->
+				var fbb: FlatBufferBuilder? = null
+				val feedList = conn.context.dataFeedList
+				synchronized(feedList) {
+					val configsCount = feedList.size
+					val data = IntArray(configsCount)
+					for (index in 0..<configsCount) {
+						val feed = feedList[index]
+						val lastTimeSent = feed.timeLastSent
+						val configT = feed.config
+						if (currTime - lastTimeSent > configT.minimumTimeSinceLast) {
+							if (fbb == null) {
+								// That way we create a buffer only when needed
+								fbb = FlatBufferBuilder(300)
 							}
+
+							val messageOffset = this.buildDatafeed(fbb, configT, index)
+
+							DataFeedMessageHeader.startDataFeedMessageHeader(fbb)
+							DataFeedMessageHeader.addMessage(fbb, messageOffset)
+							DataFeedMessageHeader.addMessageType(fbb, DataFeedMessage.DataFeedUpdate)
+							data[index] = DataFeedMessageHeader.endDataFeedMessageHeader(fbb)
+
+							feed.timeLastSent = currTime
+							val messages = MessageBundle.createDataFeedMsgsVector(fbb, data)
+							val packet = createMessage(fbb, messages)
+							fbb.finish(packet)
+							conn.send(fbb.dataBuffer())
 						}
 					}
 				}
-			},
-		)
+			}
+		}
 	}
 
 	override fun onMessage(conn: GenericConnection, message: DataFeedMessageHeader) {
 		val consumer = this.handlers[message.messageType().toInt()]
 		if (consumer != null) {
-			consumer.accept(conn, message)
+			consumer(conn, message)
 		} else {
 			LogManager
 				.info(

--- a/server/core/src/main/java/dev/slimevr/protocol/pubsub/PubSubHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/pubsub/PubSubHandler.kt
@@ -18,7 +18,6 @@ import solarxr_protocol.pub_sub.TopicId
 import solarxr_protocol.pub_sub.TopicIdT
 import solarxr_protocol.pub_sub.TopicMapping
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.function.Consumer
 
 class PubSubHandler(private val api: ProtocolAPI) : ProtocolHandler<PubSubHeader>() {
 	// Two ways maps for faster reading when handling lots of packets
@@ -66,10 +65,8 @@ class PubSubHandler(private val api: ProtocolAPI) : ProtocolHandler<PubSubHeader
 		val first = conn
 			.context
 			.subscribedTopics
-			.stream()
-			.filter { handle: Int -> handle == finalSubHandle }
-			.findFirst()
-		if (!first.isPresent) {
+			.find { it == finalSubHandle }
+		if (first == null) {
 			conn.context.subscribedTopics.add(finalSubHandle)
 		}
 
@@ -121,33 +118,31 @@ class PubSubHandler(private val api: ProtocolAPI) : ProtocolHandler<PubSubHeader
 
 		val finalSubHandle = subHandle
 
-		this.api.apiServers.forEach(
-			Consumer { server: ProtocolAPIServer ->
-				server.apiConnections.forEach { conn: GenericConnection ->
-					// Make sure that we are not sending a message to ourselves
-					// And check that the receiver has subscribed to the topic
-					if (conn.connectionId != c.connectionId &&
-						conn.context.subscribedTopics
-							.contains(finalSubHandle)
-					) {
-						val fbb = FlatBufferBuilder(32)
-						val outbound = createMessage(
-							fbb,
-							PubSubUnion.Message,
-							Message.pack(fbb, messageT),
-						)
-						fbb.finish(outbound)
-						conn.send(fbb.dataBuffer())
-					}
+		this.api.apiServers.forEach { server: ProtocolAPIServer ->
+			server.apiConnections.forEach { conn: GenericConnection ->
+				// Make sure that we are not sending a message to ourselves
+				// And check that the receiver has subscribed to the topic
+				if (conn.connectionId != c.connectionId &&
+					conn.context.subscribedTopics
+						.contains(finalSubHandle)
+				) {
+					val fbb = FlatBufferBuilder(32)
+					val outbound = createMessage(
+						fbb,
+						PubSubUnion.Message,
+						Message.pack(fbb, messageT),
+					)
+					fbb.finish(outbound)
+					conn.send(fbb.dataBuffer())
 				}
-			},
-		)
+			}
+		}
 	}
 
 	override fun onMessage(conn: GenericConnection, message: PubSubHeader) {
 		val consumer = this.handlers[message.uType().toInt()]
 		if (consumer != null) {
-			consumer.accept(conn, message)
+			consumer(conn, message)
 		} else {
 			LogManager
 				.info("[ProtocolAPI] Unhandled PubSub packet received id: " + message.uType())

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/RPCHandler.kt
@@ -369,7 +369,7 @@ class RPCHandler(private val api: ProtocolAPI) : ProtocolHandler<RpcMessageHeade
 	override fun onMessage(conn: GenericConnection, message: RpcMessageHeader) {
 		val consumer = handlers[message.messageType().toInt()]
 		if (consumer != null) {
-			consumer.accept(conn, message)
+			consumer(conn, message)
 		} else {
 			LogManager
 				.info("[ProtocolAPI] Unhandled RPC packet received id: ${message.messageType()}")

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/reset/RPCResetHandler.kt
@@ -15,7 +15,6 @@ import solarxr_protocol.rpc.ResetType
 import solarxr_protocol.rpc.RpcMessage
 import solarxr_protocol.rpc.RpcMessageHeader
 import java.nio.ByteBuffer
-import java.util.function.Consumer
 
 class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetListener {
 	val resetsConfig = api.server.configManager.vrConfig.resetsConfig
@@ -116,13 +115,11 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 		}
 
 		buildMessage(null).let {
-			this.forAllListeners(
-				Consumer { conn: GenericConnection ->
-					if (tx == null || tx.conn != conn) {
-						conn.send(it)
-					}
-				},
-			)
+			this.forAllListeners { conn: GenericConnection ->
+				if (tx == null || tx.conn != conn) {
+					conn.send(it)
+				}
+			}
 		}
 	}
 
@@ -147,16 +144,15 @@ class RPCResetHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ResetL
 		sendResetStatusResponse(resetType, ResetStatus.FINISHED, tx, bodyParts, duration, duration)
 	}
 
-	fun forAllListeners(action: Consumer<in GenericConnection?>?) {
+	fun forAllListeners(action: ((GenericConnection) -> Unit)?) {
+		if (action == null) return
 		this.api
 			.apiServers
-			.forEach(
-				Consumer { server: ProtocolAPIServer ->
-					server
-						.apiConnections
-						.forEach(action)
-				},
-			)
+			.forEach { server: ProtocolAPIServer ->
+				server
+					.apiConnections
+					.forEach(action)
+			}
 	}
 
 	companion object {

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/serial/RPCProvisioningHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/serial/RPCProvisioningHandler.kt
@@ -9,7 +9,6 @@ import dev.slimevr.serial.ProvisioningListener
 import dev.slimevr.serial.ProvisioningStatus
 import dev.slimevr.serial.SerialPort
 import solarxr_protocol.rpc.*
-import java.util.function.Consumer
 
 class RPCProvisioningHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : ProvisioningListener {
 	init {
@@ -50,19 +49,18 @@ class RPCProvisioningHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) :
 			.createRPCMessage(fbb, RpcMessage.WifiProvisioningStatusResponse, update)
 		fbb.finish(outbound)
 
-		this.forAllListeners(Consumer { conn: GenericConnection -> conn.send(fbb.dataBuffer()) })
+		this.forAllListeners { conn: GenericConnection -> conn.send(fbb.dataBuffer()) }
 	}
 
-	private fun forAllListeners(action: Consumer<in GenericConnection?>?) {
+	private fun forAllListeners(action: ((GenericConnection) -> Unit)?) {
+		if (action == null) return
 		this.api
 			.apiServers
-			.forEach(
-				Consumer { server: ProtocolAPIServer ->
-					server
-						.apiConnections
-						.filter { conn: GenericConnection -> conn.context.useProvisioning }
-						.forEach(action)
-				},
-			)
+			.forEach { server: ProtocolAPIServer ->
+				server
+					.apiConnections
+					.filter { conn: GenericConnection -> conn.context.useProvisioning }
+					.forEach(action)
+			}
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/protocol/rpc/serial/RPCSerialHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/protocol/rpc/serial/RPCSerialHandler.kt
@@ -9,8 +9,6 @@ import dev.slimevr.serial.SerialListener
 import dev.slimevr.serial.SerialPort
 import io.eiren.util.logging.LogManager
 import solarxr_protocol.rpc.*
-import java.util.*
-import java.util.function.Consumer
 
 class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : SerialListener {
 	init {
@@ -35,12 +33,10 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 		val outbound = rpcHandler.createRPCMessage(fbb, RpcMessage.SerialUpdateResponse, update)
 		fbb.finish(outbound)
 
-		this.forAllListeners(
-			Consumer { conn: GenericConnection ->
-				conn.send(fbb.dataBuffer())
-				conn.context.useSerial = false
-			},
-		)
+		this.forAllListeners { conn: GenericConnection ->
+			conn.send(fbb.dataBuffer())
+			conn.context.useSerial = false
+		}
 	}
 
 	override fun onSerialLog(str: String, server: Boolean) {
@@ -54,11 +50,9 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 		val outbound = rpcHandler.createRPCMessage(fbb, RpcMessage.SerialUpdateResponse, update)
 		fbb.finish(outbound)
 
-		this.forAllListeners(
-			Consumer { conn: GenericConnection ->
-				conn.send(fbb.dataBuffer())
-			},
-		)
+		this.forAllListeners { conn: GenericConnection ->
+			conn.send(fbb.dataBuffer())
+		}
 	}
 
 	override fun onNewSerialDevice(port: SerialPort) {
@@ -75,15 +69,13 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 
 		this.api
 			.apiServers
-			.forEach(
-				Consumer { server: ProtocolAPIServer ->
-					server
-						.apiConnections
-						.forEach { conn: GenericConnection ->
-							conn.send(fbb.dataBuffer())
-						}
-				},
-			)
+			.forEach { server: ProtocolAPIServer ->
+				server
+					.apiConnections
+					.forEach { conn: GenericConnection ->
+						conn.send(fbb.dataBuffer())
+					}
+			}
 	}
 
 	override fun onSerialConnected(port: SerialPort) {
@@ -95,11 +87,9 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 		val outbound = rpcHandler.createRPCMessage(fbb, RpcMessage.SerialUpdateResponse, update)
 		fbb.finish(outbound)
 
-		this.forAllListeners(
-			Consumer { conn: GenericConnection ->
-				conn.send(fbb.dataBuffer())
-			},
-		)
+		this.forAllListeners { conn: GenericConnection ->
+			conn.send(fbb.dataBuffer())
+		}
 	}
 
 	fun onSerialTrackerRebootRequest(
@@ -155,7 +145,7 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 
 		if (req == null || req.command() == null) return
 
-		this.api.server.serialHandler.customCommandRequest(Objects.requireNonNull(req.command()))
+		this.api.server.serialHandler.customCommandRequest(req.command()!!)
 	}
 
 	private fun onRequestSerialDevices(conn: GenericConnection, messageHeader: RpcMessageHeader) {
@@ -178,7 +168,7 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 		}
 
 		SerialDevicesResponse.startDevicesVector(fbb, devicesOffsets.size)
-		devicesOffsets.forEach(Consumer { offset: Int -> SerialDevicesResponse.addDevices(fbb, offset) })
+		devicesOffsets.forEach { offset: Int -> SerialDevicesResponse.addDevices(fbb, offset) }
 		val devices = fbb.endVector()
 		val serialDeviceOffsets = SerialDevicesResponse.createSerialDevicesResponse(fbb, devices)
 		val outbound = rpcHandler
@@ -245,17 +235,16 @@ class RPCSerialHandler(var rpcHandler: RPCHandler, var api: ProtocolAPI) : Seria
 		conn.send(fbb.dataBuffer())
 	}
 
-	fun forAllListeners(action: Consumer<in GenericConnection?>?) {
+	fun forAllListeners(action: ((GenericConnection) -> Unit)?) {
+		if (action == null) return
 		this.api
 			.apiServers
-			.forEach(
-				Consumer { server: ProtocolAPIServer ->
-					server
-						.apiConnections
-						.filter { conn: GenericConnection -> conn.context.useSerial }
-						.forEach(action)
-				},
-			)
+			.forEach { server: ProtocolAPIServer ->
+				server
+					.apiConnections
+					.filter { conn: GenericConnection -> conn.context.useSerial }
+					.forEach(action)
+			}
 	}
 
 	override fun onSerialDeviceDeleted(port: SerialPort) {

--- a/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetHandler.kt
@@ -2,7 +2,6 @@ package dev.slimevr.reset
 
 import dev.slimevr.protocol.rpc.TransactionInfo
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.function.Consumer
 
 class ResetHandler {
 	private val listeners: MutableList<ResetListener> = CopyOnWriteArrayList()

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/HumanPoseManager.kt
@@ -20,7 +20,6 @@ import io.github.axisangles.ktmath.Quaternion.Companion.IDENTITY
 import io.github.axisangles.ktmath.Vector3
 import io.github.axisangles.ktmath.Vector3.Companion.POS_Y
 import org.apache.commons.math3.util.Precision
-import java.util.function.Consumer
 import kotlin.math.*
 
 /**
@@ -29,7 +28,7 @@ import kotlin.math.*
  */
 class HumanPoseManager(val server: VRServer?) {
 	val computedTrackers: MutableList<Tracker> = FastList()
-	private val onSkeletonUpdated: MutableList<Consumer<HumanSkeleton>> = FastList()
+	private val onSkeletonUpdated: MutableList<(HumanSkeleton) -> Unit> = FastList()
 	private val skeletonConfigManager = SkeletonConfigManager(true, this)
 
 	@get:ThreadSafe
@@ -49,7 +48,7 @@ class HumanPoseManager(val server: VRServer?) {
 			// explicitly loaded into the skeleton (no need for
 			// `computeAllNodeOffsets()`)
 			loadFromConfig(server.configManager)
-			for (sc in onSkeletonUpdated) sc.accept(skeleton)
+			for (sc in onSkeletonUpdated) sc(skeleton)
 		}
 	}
 
@@ -252,9 +251,9 @@ class HumanPoseManager(val server: VRServer?) {
 	}
 
 	@VRServerThread
-	fun addSkeletonUpdatedCallback(consumer: Consumer<HumanSkeleton>) {
+	fun addSkeletonUpdatedCallback(consumer: (HumanSkeleton) -> Unit) {
 		onSkeletonUpdated.add(consumer)
-		consumer.accept(skeleton)
+		consumer(skeleton)
 	}
 
 	/**

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/TransformNode.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/TransformNode.kt
@@ -3,7 +3,6 @@ package dev.slimevr.tracking.processor
 import io.eiren.util.ann.ThreadSafe
 import io.github.axisangles.ktmath.Transform
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.function.Consumer
 
 /**
  * Represents a joint
@@ -49,11 +48,11 @@ class TransformNode(val localRotation: Boolean) {
 		}
 	}
 
-	fun depthFirstTraversal(visitor: Consumer<TransformNode?>) {
+	fun depthFirstTraversal(visitor: (TransformNode) -> Unit) {
 		for (node in children) {
 			node.depthFirstTraversal(visitor)
 		}
-		visitor.accept(this)
+		visitor(this)
 	}
 
 	private fun combineWithParentGlobalRotation(parent: Transform) {

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/HumanSkeleton.kt
@@ -32,7 +32,6 @@ import io.github.axisangles.ktmath.Vector3.Companion.NEG_Y
 import io.github.axisangles.ktmath.Vector3.Companion.NULL
 import io.github.axisangles.ktmath.Vector3.Companion.POS_Y
 import solarxr_protocol.datatypes.BodyPart
-import java.lang.IllegalArgumentException
 import kotlin.properties.Delegates
 
 class HumanSkeleton(

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/hid/HIDCommon.kt
@@ -13,7 +13,6 @@ import io.github.axisangles.ktmath.Quaternion
 import io.github.axisangles.ktmath.Quaternion.Companion.fromRotationVector
 import io.github.axisangles.ktmath.Vector3
 import java.nio.ByteBuffer
-import java.util.function.Consumer
 import kotlin.collections.set
 import kotlin.math.PI
 import kotlin.math.cos
@@ -100,7 +99,7 @@ class HIDCommon {
 			sensorType: IMUType,
 			sensorStatus: TrackerStatus,
 			magStatus: MagnetometerStatus,
-			trackersConsumer: Consumer<Tracker>,
+			trackersConsumer: (Tracker) -> Unit,
 		) {
 			// LogManager.info("[TrackerServer] Sensor $trackerId for ${device.name}, status $sensorStatus")
 			var imuTracker = device.getTracker(trackerId)
@@ -128,7 +127,7 @@ class HIDCommon {
 				// TODO: Could tracker maybe use "Timed out" status without marking as disconnecting?
 				// TODO: can be marked as "Disconnected" by timeout if the tracker has enabled activity timeouts
 				device.trackers[trackerId] = imuTracker
-				trackersConsumer.accept(imuTracker)
+				trackersConsumer(imuTracker)
 				imuTracker.status = sensorStatus
 				LogManager
 					.info(
@@ -145,7 +144,7 @@ class HIDCommon {
 			q: IntArray,
 			a: IntArray,
 			m: IntArray,
-			trackersConsumer: Consumer<Tracker>,
+			trackersConsumer: (Tracker) -> Unit,
 		) {
 			val trackerId = 0 // no concept of extensions
 

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -21,17 +21,15 @@ import java.net.SocketAddress
 import java.net.SocketTimeoutException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.*
+import java.util.Random
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.function.Consumer
 import kotlin.collections.HashMap
 import kotlin.coroutines.resume
 
 /**
  * Receives trackers data by UDP using extended owoTrack protocol.
  */
-class TrackersUDPServer(private val port: Int, name: String, private val trackersConsumer: Consumer<Tracker>) : Thread(name) {
+class TrackersUDPServer(private val port: Int, name: String, private val trackersConsumer: (Tracker) -> Unit) : Thread(name) {
 	private val random = Random()
 	private val connections: MutableList<UDPDevice> = FastList()
 	private val connectionsByAddress: MutableMap<SocketAddress, UDPDevice> = HashMap()
@@ -235,7 +233,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				trackerDataType = trackerDataType,
 			)
 			connection.trackers[trackerId] = imuTracker
-			trackersConsumer.accept(imuTracker)
+			trackersConsumer(imuTracker)
 			LogManager.info("[TrackerServer] Added sensor $trackerId for ${connection.name}, ImuType $sensorType, DataType $trackerDataType, default TrackerPosition $trackerPosition")
 		}
 		val status = UDPPacket15SensorInfo.getStatus(sensorStatus)
@@ -270,11 +268,11 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 		var ran: Boolean = false,
 	)
 
-	private val queues: MutableMap<Triple<SocketAddress, ConfigTypeId, Int>, Deque<ConfigStateWaiter>> = ConcurrentHashMap()
+	private val queues: MutableMap<Triple<SocketAddress, ConfigTypeId, Int>, ArrayDeque<ConfigStateWaiter>> = ConcurrentHashMap()
 	suspend fun setConfigFlag(device: UDPDevice, configTypeId: ConfigTypeId, state: Boolean, sensorId: Int = 255) {
 		if (device.timedOut) return
 		val triple = Triple(device.address, configTypeId, sensorId)
-		val queue = queues.computeIfAbsent(triple) { _ -> ConcurrentLinkedDeque() }
+		val queue = queues.computeIfAbsent(triple) { _ -> ArrayDeque() }
 
 		suspendCancellableCoroutine {
 			val waiter = ConfigStateWaiter(state, it)

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
@@ -2,7 +2,6 @@ package dev.slimevr.tracking.trackers.udp
 
 import java.io.IOException
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 
 class UDPProtocolParser {
 	@Throws(IOException::class)
@@ -162,7 +161,7 @@ class UDPProtocolParser {
 
 		init {
 			HANDSHAKE_BUFFER[0] = 3
-			val str = "Hey OVR =D 5".toByteArray(StandardCharsets.US_ASCII)
+			val str = "Hey OVR =D 5".toByteArray(Charsets.US_ASCII)
 			System.arraycopy(str, 0, HANDSHAKE_BUFFER, 1, str.size)
 		}
 	}

--- a/server/core/src/test/java/dev/slimevr/unit/ReferenceAdjustmentsTests.kt
+++ b/server/core/src/test/java/dev/slimevr/unit/ReferenceAdjustmentsTests.kt
@@ -14,15 +14,13 @@ import io.github.axisangles.ktmath.Vector3.Companion.POS_Y
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
-import java.util.stream.Stream
-import kotlin.streams.asStream
 
 /**
  * Tests [TrackerResetsHandler.resetFull]
  */
 class ReferenceAdjustmentsTests {
 	@get:TestFactory
-	val testsYaw: Stream<DynamicTest>
+	val testsYaw: List<DynamicTest>
 		get() = anglesSet
 			.map { p: AnglesSet ->
 				DynamicTest.dynamicTest(
@@ -40,7 +38,7 @@ class ReferenceAdjustmentsTests {
 			}
 
 	@get:TestFactory
-	val testsFull: Stream<DynamicTest>
+	val testsFull: List<DynamicTest>
 		get() = anglesSet
 			.map { p: AnglesSet ->
 				DynamicTest.dynamicTest(
@@ -61,10 +59,10 @@ class ReferenceAdjustmentsTests {
 	// TODO : Test is not passing because the test is wrong
 	// See issue https://github.com/SlimeVR/SlimeVR-Server/issues/55
 	// @TestFactory
-	val testsForRotation: Stream<DynamicTest>
+	val testsForRotation: List<DynamicTest>
 		get() = anglesSet
 			.flatMap { p: AnglesSet ->
-				yaws.asSequence().map {
+				yaws.map {
 					DynamicTest.dynamicTest(
 						"Adjustment Rotation Test of Tracker(${p.pitch},${p.yaw},${p.roll}), Ref $it",
 					) {
@@ -75,7 +73,7 @@ class ReferenceAdjustmentsTests {
 							0,
 						)
 					}
-				}.asStream()
+				}
 			}
 
 	fun checkReferenceAdjustmentFull(
@@ -295,12 +293,12 @@ class ReferenceAdjustmentsTests {
 		private var errors = 0
 		private var successes = 0
 
-		val anglesSet: Stream<AnglesSet>
+		val anglesSet: List<AnglesSet>
 			get() = yaws.asSequence()
 				.zip(pitches.asSequence())
 				.zip(rolls.asSequence()) { (yaw, pitch), roll ->
 					AnglesSet(pitch, yaw, roll)
-				}.asStream()
+				}.toList()
 
 		private fun name(
 			yaw: Int,

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/ProtobufBridge.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/ProtobufBridge.kt
@@ -15,8 +15,6 @@ import io.eiren.util.collections.FastList
 import io.eiren.util.logging.LogManager
 import io.github.axisangles.ktmath.Quaternion
 import io.github.axisangles.ktmath.Vector3
-import java.util.Queue
-import java.util.concurrent.LinkedBlockingQueue
 import kotlin.collections.HashMap
 
 abstract class ProtobufBridge(@JvmField protected val bridgeName: String) : ISteamVRBridge {
@@ -25,10 +23,10 @@ abstract class ProtobufBridge(@JvmField protected val bridgeName: String) : ISte
 	protected val sharedTrackers: MutableList<Tracker> = FastList()
 
 	@ThreadSafe
-	private val inputQueue: Queue<ProtobufMessage> = LinkedBlockingQueue()
+	private val inputQueue: ArrayDeque<ProtobufMessage> = ArrayDeque()
 
 	@ThreadSafe
-	private val outputQueue: Queue<ProtobufMessage> = LinkedBlockingQueue()
+	private val outputQueue: ArrayDeque<ProtobufMessage> = ArrayDeque()
 
 	@Synchronize("self")
 	private val remoteTrackersBySerial: MutableMap<String, Tracker> = HashMap()
@@ -62,7 +60,7 @@ abstract class ProtobufBridge(@JvmField protected val bridgeName: String) : ISte
 	@BridgeThread
 	protected fun updateMessageQueue() {
 		var message: ProtobufMessage?
-		while ((outputQueue.poll().also { message = it }) != null) {
+		while ((outputQueue.removeFirstOrNull().also { message = it }) != null) {
 			if (!sendMessageReal(message)) return
 		}
 	}
@@ -71,7 +69,7 @@ abstract class ProtobufBridge(@JvmField protected val bridgeName: String) : ISte
 	override fun dataRead() {
 		hadNewData = false
 		var message: ProtobufMessage?
-		while ((inputQueue.poll().also { message = it }) != null) {
+		while ((inputQueue.removeFirstOrNull().also { message = it }) != null) {
 			processMessageReceived(message)
 			hadNewData = true
 		}

--- a/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/serial/DesktopSerialHandler.kt
@@ -9,7 +9,6 @@ import io.eiren.util.logging.LogManager
 import java.io.IOException
 import java.io.OutputStreamWriter
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.stream.Stream
@@ -222,7 +221,7 @@ class DesktopSerialHandler :
 		when (event.eventType) {
 			SerialPort.LISTENING_EVENT_DATA_RECEIVED -> {
 				val newData = event.receivedData
-				val s = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(newData)).toString()
+				val s = Charsets.UTF_8.decode(ByteBuffer.wrap(newData)).toString()
 				addLog(s, false)
 			}
 

--- a/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/tracking/trackers/hid/DesktopHIDManager.kt
@@ -19,12 +19,11 @@ import org.hid4java.event.HidServicesEvent
 import org.hid4java.jna.HidApi
 import org.hid4java.jna.HidDeviceInfoStructure
 import java.nio.ByteBuffer
-import java.util.function.Consumer
 
 /**
  * Handles desktop USB HID dongles and receives tracker data from them.
  */
-class DesktopHIDManager(name: String, private val trackersConsumer: Consumer<Tracker>) :
+class DesktopHIDManager(name: String, private val trackersConsumer: (Tracker) -> Unit) :
 	Thread(name),
 	HidServicesListener {
 	private val devices: MutableList<HIDDevice> = mutableListOf()


### PR DESCRIPTION
This commit replaces some JVM library calls with cross platform kotlin calls.

It would be great to move towards KMP.

## Replaced imports

| Java Import | Replacement | Files |
|---|---|---|
| `java.util.function.Consumer` | `(T) -> Unit` | 18 |
| `java.util.function.BiConsumer` | `(A, B) -> Unit` | 1 |
| `java.util.function.Function` | `(T) -> R` | 1 |
| `java.util.stream.Collectors` | Kotlin collection ops (`.filter().toList()` etc.) | 2 |
| `java.util.concurrent.CompletableFuture` | `kotlinx.coroutines.CompletableDeferred` | 1 |
| `java.util.concurrent.Future` | `kotlinx.coroutines.Deferred` | 1 |
| `java.util.concurrent.ExecutionException` | Removed (coroutines throw directly) | 1 |
| `java.util.concurrent.LinkedBlockingQueue` | `ArrayDeque` + `.removeFirstOrNull()` | 2 |
| `java.util.concurrent.ConcurrentLinkedDeque` | `ArrayDeque` | 1 |
| `java.util.Queue` / `java.util.Deque` | `ArrayDeque` | 3 |
| `java.nio.charset.StandardCharsets` | `Charsets` (kotlin.text) | 2 |
| `java.lang.IllegalArgumentException` | `IllegalArgumentException` (kotlin-stdlib) | 1 |
| `java.io.Closeable` | `Closeable` (kotlin.io) | 1 |
| `java.util.ArrayList` | `ArrayList` (kotlin.collections) | 1 |
| `java.util.Objects` | Kotlin `!!` non-null assertion | 1 |
| SAM `Consumer { }` patterns | Kotlin lambda `{ }` with `forEach` | 6 |
| `.stream().filter().collect(Collectors.toList())` | `.filter().toList()` | 2 |

## Other changes

- Replaced `.accept(x)` / `.apply(x)` calls with direct invocations where `Consumer`/`BiConsumer`/`Function` were removed
- Replaced `.stream().filter().findFirst()` with `.find { }` where `Stream` → `Sequence` conversion was possible
- Kept `java.util.stream.Stream` on `ProtocolAPIServer` and `SerialHandler` interfaces that Java classes implement