### PR TITLE
Fix settings scroll target positioning

### DIFF
--- a/gui/src/components/settings/SettingsPageLayout.tsx
+++ b/gui/src/components/settings/SettingsPageLayout.tsx
@@ -21,24 +21,20 @@ export function SettingsPageLayout({
       `#${typedState.scrollTo}`
     ) as HTMLElement | null;
     if (elem) {
-      // stupid way of doing this, just get the closest overflow-y-auto
-      // usually its just the parentElem
-      const closestScroll = elem.closest(
-        '.overflow-y-auto'
-      ) as HTMLElement | null;
-      if (closestScroll) {
-        elem.scrollIntoView({
-          block: 'start',
-          behavior: 'smooth',
-        });
-      }
+      elem.scrollIntoView({
+        block: 'start',
+        behavior: 'smooth',
+      });
     }
   }, [state]);
 
   return (
     <div
       ref={pageRef}
-      className={classNames('settings-page-layout', className)}
+      className={classNames(
+        '[&_[id]]:scroll-mt-[45px] mobile:[&_[id]]:scroll-mt-[80px]',
+        className
+      )}
       {...props}
     >
       {children}

--- a/gui/src/components/settings/SettingsPageLayout.tsx
+++ b/gui/src/components/settings/SettingsPageLayout.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import { ReactNode, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useBreakpoint } from '@/hooks/breakpoint';
 
 export function SettingsPageLayout({
   children,
@@ -12,7 +11,6 @@ export function SettingsPageLayout({
 } & React.HTMLAttributes<HTMLDivElement>) {
   const pageRef = useRef<HTMLDivElement | null>(null);
   const { state } = useLocation();
-  const { isMobile } = useBreakpoint('mobile');
 
   useEffect(() => {
     const typedState: { scrollTo: string } = state;
@@ -29,10 +27,8 @@ export function SettingsPageLayout({
         '.overflow-y-auto'
       ) as HTMLElement | null;
       if (closestScroll) {
-        // The 45 is just enough padding for making the scroll look perfect
-        const topPadding = isMobile ? 80 : 45;
-        closestScroll.scroll({
-          top: elem.offsetTop - topPadding,
+        elem.scrollIntoView({
+          block: 'start',
           behavior: 'smooth',
         });
       }
@@ -40,7 +36,11 @@ export function SettingsPageLayout({
   }, [state]);
 
   return (
-    <div ref={pageRef} className={className} {...props}>
+    <div
+      ref={pageRef}
+      className={classNames('settings-page-layout', className)}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/gui/src/components/settings/SettingsPageLayout.tsx
+++ b/gui/src/components/settings/SettingsPageLayout.tsx
@@ -29,14 +29,7 @@ export function SettingsPageLayout({
   }, [state]);
 
   return (
-    <div
-      ref={pageRef}
-      className={classNames(
-        '[&_[id]]:scroll-mt-[45px] mobile:[&_[id]]:scroll-mt-[80px]',
-        className
-      )}
-      {...props}
-    >
+    <div ref={pageRef} className={className} {...props}>
       {children}
     </div>
   );
@@ -54,7 +47,7 @@ export function SettingsPagePaneLayout({
   return (
     <div
       className={classNames(
-        'bg-background-70 rounded-lg px-4 py-8 flex xs:gap-4 w-full relative',
+        'bg-background-70 rounded-lg px-4 py-8 flex xs:gap-4 w-full relative scroll-mt-12 mobile:scroll-mt-20',
         className
       )}
       {...props}

--- a/gui/src/components/settings/pages/MagnetometerToggleSetting.tsx
+++ b/gui/src/components/settings/pages/MagnetometerToggleSetting.tsx
@@ -94,7 +94,10 @@ export function MagnetometerToggleSetting({
 
   return settingType === 'general' ? (
     <>
-      <div className="flex flex-col pt-5 pb-3" id={id}>
+      <div
+        className="flex flex-col pt-5 pb-3 scroll-mt-12 mobile:scroll-mt-20"
+        id={id}
+      >
         <Typography variant="section-title">
           {l10n.getString(
             'settings-general-tracker_mechanics-use_mag_on_all_trackers'

--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -14,6 +14,14 @@ body {
   scrollbar-width: thin;
 }
 
+.settings-page-layout [id] {
+  scroll-margin-top: 45px;
+
+  @screen mobile {
+    scroll-margin-top: 80px;
+  }
+}
+
 @font-face {
   font-family: 'OpenDyslexic';
   src: url('/fonts/OpenDyslexic-Regular.woff') format('woff');

--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -14,14 +14,6 @@ body {
   scrollbar-width: thin;
 }
 
-.settings-page-layout [id] {
-  scroll-margin-top: 45px;
-
-  @screen mobile {
-    scroll-margin-top: 80px;
-  }
-}
-
 @font-face {
   font-family: 'OpenDyslexic';
   src: url('/fonts/OpenDyslexic-Regular.woff') format('woff');


### PR DESCRIPTION
## Summary
- Fix settings-page scrolling to nested targets.
- Calculate the target position relative to the scroll container instead of relying on `offsetTop`.

## Why
The magnetometer link from a tracker settings page navigates to `/settings/trackers` with `scrollTo: "mechanics-magnetometer"`. That target is nested inside the settings page, so `offsetTop` can be relative to a nearer offset parent and scroll to the wrong place.

## Testing
- Ran `pnpm --filter slimevr --dir gui lint`.
- Started the server and GUI locally with a fake UDP tracker that supports magnetometer.
- Opened the fake tracker's settings page, clicked `click here to go to the setting`, and confirmed it scrolls to the global magnetometer setting.

## AI disclosure
AI-assisted for debugging and PR text, tested locally.

Fixes #1764
