### PR TITLE
Retain VRMv0 extension in vrmJson

### DIFF
--- a/gui/src/components/settings/pages/VMCSettings.tsx
+++ b/gui/src/components/settings/pages/VMCSettings.tsx
@@ -408,7 +408,7 @@ async function parseVRMFile(
   /* eslint-disable camelcase */
   const vrmJson = {
     extensions: {
-      vrmV0: data.extensions.vrmV0,
+      VRM: data.extensions.VRM,
       VRMC_vrm: data.extensions.VRMC_vrm,
     },
     extensionsUsed: data.extensionsUsed,


### PR DESCRIPTION
Fixes VRM name display & mocap mode with version 0 VRMs.