### PR TITLE
Remove some leftover log messages

### DIFF
--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -327,11 +327,9 @@ export function GeneralSettings() {
     tapDetection.yawResetEnabled = values.tapDetection.yawResetEnabled;
     tapDetection.yawResetTaps = values.tapDetection.yawResetTaps;
     tapDetection.yawResetTracker = Number(values.tapDetection.yawResetTracker);
-    console.log(tapDetection.yawResetTracker);
     tapDetection.mountingResetTracker = Number(
       values.tapDetection.mountingResetTracker
     );
-    console.log(tapDetection.mountingResetTracker);
     tapDetection.fullResetTracker = Number(
       values.tapDetection.fullResetTracker
     );

--- a/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/processor/skeleton/TapDetectionManager.kt
@@ -72,7 +72,6 @@ class TapDetectionManager(
 		tapDetectors.clear()
 		registerSingleTapDetectors()
 		registerResetsDetectors()
-		LogManager.info(yawResetTracker.toString())
 	}
 
 	fun update() {


### PR DESCRIPTION
The one in the TapDetectionManager is particularly annoying as it is logged every time a tracker is connected/disconnected, reassigned, or when changing tap detection settings. On startup it gets logged ~10 times.