### PR TITLE
Make sure bridge threads properly handle interrupts and cleanup

### DIFF
--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
@@ -66,7 +66,7 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 	public void run() {
 		try {
 			this.server = createSocket();
-			while (true) {
+			while (!Thread.interrupted()) {
 				if (this.channel == null) {
 					reportDisconnected();
 					this.selector = Selector.open();
@@ -100,20 +100,23 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 					} catch (IOException ioError) {
 						this.resetChannel();
 						ioError.printStackTrace();
-						try {
-							Thread.sleep(10);
-						} catch (InterruptedException e) {
-							e.printStackTrace();
-						}
+						Thread.sleep(10);
 					}
 				}
 			}
-		} catch (ClosedByInterruptException e) {
-			// We've been told to stop
+		} catch (ClosedByInterruptException | InterruptedException e) {
+			// Exit the thread gracefully.
 		} catch (IOException e) {
 			LogManager.severe("[" + bridgeName + "] Exception in runner thread", e);
 		}
 
+		if (this.channel != null) {
+			try {
+				this.resetChannel();
+			} catch (IOException e) {
+				// Ignore the exception, we're shutting down anyway.
+			}
+		}
 		this.socketFile.delete();
 	}
 

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/linux/UnixSocketBridge.java
@@ -108,16 +108,16 @@ public class UnixSocketBridge extends SteamVRBridge implements AutoCloseable {
 			// Exit the thread gracefully.
 		} catch (IOException e) {
 			LogManager.severe("[" + bridgeName + "] Exception in runner thread", e);
-		}
-
-		if (this.channel != null) {
-			try {
-				this.resetChannel();
-			} catch (IOException e) {
-				// Ignore the exception, we're shutting down anyway.
+		} finally {
+			if (this.channel != null) {
+				try {
+					this.resetChannel();
+				} catch (IOException e) {
+					// Ignore the exception, we're shutting down anyway.
+				}
 			}
+			this.socketFile.delete();
 		}
-		this.socketFile.delete();
 	}
 
 	@Override

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
@@ -47,7 +47,7 @@ public class WindowsNamedPipeBridge extends SteamVRBridge
 	public void run() {
 		try {
 			pipe = new WindowsNamedPipe(this.pipeName, 1);
-			while (true) {
+			while (!Thread.interrupted()) {
 				boolean pipesUpdated = false;
 				if (connection == null) {
 					// Report that our pipe is disconnected right now
@@ -73,18 +73,21 @@ public class WindowsNamedPipeBridge extends SteamVRBridge
 					if (connection != null && connection.getState() == PipeState.OPEN) {
 						connection.waitForData(10);
 					} else {
-						try {
-							Thread.sleep(10);
-						} catch (InterruptedException e) {
-							// Do nothing.
-						}
+						Thread.sleep(10);
 					}
 				}
 			}
 		} catch (IOException e) {
 			LogManager.severe("[" + bridgeName + "] Exception in runner thread", e);
+		} catch (InterruptedException e) {
+			// Exit the thread gracefully.
 		}
-		pipe.close();
+
+		LogManager.info("[" + bridgeName + "] Bridge thread exiting");
+		if (pipe != null) {
+			pipe.close();
+			pipe = null;
+		}
 	}
 
 	@Override

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeBridge.java
@@ -81,12 +81,12 @@ public class WindowsNamedPipeBridge extends SteamVRBridge
 			LogManager.severe("[" + bridgeName + "] Exception in runner thread", e);
 		} catch (InterruptedException e) {
 			// Exit the thread gracefully.
-		}
-
-		LogManager.info("[" + bridgeName + "] Bridge thread exiting");
-		if (pipe != null) {
-			pipe.close();
-			pipe = null;
+		} finally {
+			LogManager.info("[" + bridgeName + "] Bridge thread exiting");
+			if (pipe != null) {
+				pipe.close();
+				pipe = null;
+			}
 		}
 	}
 

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeRpcBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeRpcBridge.java
@@ -62,11 +62,11 @@ public class WindowsNamedPipeRpcBridge implements WindowsNamedPipe.PipeMessageRe
 			LogManager.severe("[SolarXR RPC Bridge] Exception in runner thread", e);
 		} catch (InterruptedException e) {
 			// Exit the thread gracefully.
-		}
-
-		if (this.pipe != null) {
-			this.pipe.close();
-			this.pipe = null;
+		} finally {
+			if (this.pipe != null) {
+				this.pipe.close();
+				this.pipe = null;
+			}
 		}
 	}
 

--- a/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeRpcBridge.java
+++ b/server/desktop/src/main/java/dev/slimevr/desktop/platform/windows/WindowsNamedPipeRpcBridge.java
@@ -61,7 +61,12 @@ public class WindowsNamedPipeRpcBridge implements WindowsNamedPipe.PipeMessageRe
 		} catch (IOException e) {
 			LogManager.severe("[SolarXR RPC Bridge] Exception in runner thread", e);
 		} catch (InterruptedException e) {
-			// Do nothing.
+			// Exit the thread gracefully.
+		}
+
+		if (this.pipe != null) {
+			this.pipe.close();
+			this.pipe = null;
 		}
 	}
 


### PR DESCRIPTION
Fixes a leak of incoming Protobuf messages when the Feeder App is running while using a new enough driver.