### PR TITLE
Fix tracker battery display when UDP tracker only sends level

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -490,11 +490,15 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				// Too low or high voltage should mean there is no battery or there is a measurement error
 				// Some ESP can run at 2.3V, set a limit at 2V
 				// Below this the tracker is definitely dead if everything is working properly
-				if (packet.voltage > 2f && packet.voltage < 6f) {
-					// Assuming floor when converting to int
-					it.batteryLevel = if (packet.level < 0.01f) -1f else packet.level * 100
+				if (packet.voltage != null) {
+					if (packet.voltage!! > 2f && packet.voltage!! < 6f) {
+						// Assuming floor when converting to int
+						it.batteryLevel = if (packet.level < 0.01f) -1f else packet.level * 100
+					} else {
+						it.batteryLevel = 0f
+					}
 				} else {
-					it.batteryLevel = 0f
+					it.batteryLevel = packet.level * 100
 				}
 				// Server displays 0% if received 255 or -1, otherwise 0 will hide battery icon
 			}

--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPPacket.kt
@@ -186,17 +186,16 @@ data class UDPPacket11Serial(var serial: String = "") : UDPPacket(11) {
 }
 
 data class UDPPacket12BatteryLevel(
-	var voltage: Float = 0.0f,
+	var voltage: Float? = null,
 	var level: Float = 0.0f,
 ) : UDPPacket(12) {
 
 	override fun readData(buf: ByteBuffer) {
-		voltage = UDPUtils.getSafeBufferFloat(buf)
-		if (buf.remaining() > 3) {
+		if (buf.remaining() >= 8) {
+			voltage = UDPUtils.getSafeBufferFloat(buf)
 			level = UDPUtils.getSafeBufferFloat(buf)
 		} else {
-			level = voltage
-			voltage = 0.0f
+			level = UDPUtils.getSafeBufferFloat(buf)
 		}
 	}
 }


### PR DESCRIPTION
owoTrack omits battery voltage when sending the battery state.