### PR TITLE
Add handling for Packet 23

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/UDPProtocolParser.kt
@@ -114,6 +114,7 @@ class UDPProtocolParser {
 		PACKET_TEMPERATURE -> UDPPacket20Temperature()
 		PACKET_USER_ACTION -> UDPPacket21UserAction()
 		PACKET_FEATURE_FLAGS -> UDPPacket22FeatureFlags()
+		PACKET_ROTATION_AND_ACCELERATION -> UDPPacket23RotationAndAcceleration()
 		PACKET_ACK_CONFIG_CHANGE -> UDPPacket24AckConfigChange()
 		PACKET_FLEX_DATA -> UDPPacket26FlexData()
 		PACKET_POSITION -> UDPPacket27Position()


### PR DESCRIPTION
PR #1001 Implemented a compact rotation + acceleration packet (number 23), however it didn't add it to the "getNewPacket" method, so it was non-functional.

This PR solves that.