### PR TITLE
Fix disconnected UDP tracker sensors being marked as OK on reconnect

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -357,13 +357,6 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 									LogManager.info("[TrackerServer] Tracker timed out: $conn")
 								}
 							} else {
-								for (value in conn.trackers.values) {
-									if (value.status == TrackerStatus.DISCONNECTED ||
-										value.status == TrackerStatus.TIMED_OUT
-									) {
-										value.status = TrackerStatus.OK
-									}
-								}
 								conn.timedOut = false
 							}
 
@@ -404,7 +397,6 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 	}
 
 	private fun processPacket(received: DatagramPacket, packet: UDPPacket, connection: UDPDevice?) {
-		val tracker: Tracker?
 		when (packet) {
 			is UDPPacket0Heartbeat, is UDPPacket1Heartbeat, is UDPPacket25SetConfigFlag -> {}
 
@@ -413,8 +405,8 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			is RotationPacket -> {
 				var rot = packet.rotation
 				rot = AXES_OFFSET.times(rot)
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
+				if (tracker.status == TrackerStatus.DISCONNECTED) tracker.status = TrackerStatus.OK
 				tracker.setRotation(rot)
 				if (packet is UDPPacket23RotationAndAcceleration) {
 					// sensorOffset is applied correctly since protocol 22
@@ -429,8 +421,8 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			}
 
 			is UDPPacket17RotationData -> {
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
+				if (tracker.status == TrackerStatus.DISCONNECTED) tracker.status = TrackerStatus.OK
 				var rot17 = packet.rotation
 				rot17 = AXES_OFFSET * rot17
 				when (packet.dataType) {
@@ -453,8 +445,8 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			is UDPPacket18MagnetometerAccuracy -> {}
 
 			is UDPPacket4Acceleration -> {
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
+				if (tracker.status == TrackerStatus.DISCONNECTED) tracker.status = TrackerStatus.OK
 				// sensorOffset is applied correctly since protocol 22
 				// See: https://github.com/SlimeVR/SlimeVR-Tracker-ESP/pull/480
 				if (connection.protocolVersion >= 22) {
@@ -504,8 +496,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			}
 
 			is UDPPacket13Tap -> {
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
 				LogManager.info(
 					"[TrackerServer] Tap packet received from ${tracker.name}: ${packet.tap}",
 				)
@@ -515,8 +506,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				LogManager.severe(
 					"[TrackerServer] Error received from ${received.socketAddress}: ${packet.errorNumber}",
 				)
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
 				tracker.status = TrackerStatus.ERROR
 			}
 
@@ -548,7 +538,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			}
 
 			is UDPPacket20Temperature -> {
-				tracker = connection?.getTracker(packet.sensorId) ?: return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
 				tracker.temperature = packet.temperature
 			}
 
@@ -616,8 +606,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			}
 
 			is UDPPacket26FlexData -> {
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
 				if (tracker.trackerDataType == TrackerDataType.FLEX_RESISTANCE) {
 					tracker.trackerFlexHandler.setFlexResistance(packet.flexData)
 				} else if (tracker.trackerDataType == TrackerDataType.FLEX_ANGLE) {
@@ -627,8 +616,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 			}
 
 			is UDPPacket27Position -> {
-				tracker = connection?.getTracker(packet.sensorId)
-				if (tracker == null) return
+				val tracker = connection?.getTracker(packet.sensorId) ?: return
 				tracker.position = packet.position
 				// dont call dataTick here as this is just position update
 			}


### PR DESCRIPTION
On firmware that sends SensorInfo packets every second / on reconnect, setUpSensor should take care of setting the status, otherwise for older firmware versions (or if a sensor info packet is dropped) marking the sensor as OK if we receive rotation info should be sufficient.

Closes #871