### PR TITLE
Set skipCheckUdev feature flag to true by default

### DIFF
--- a/server/core/src/main/java/dev/slimevr/FeatureFlags.kt
+++ b/server/core/src/main/java/dev/slimevr/FeatureFlags.kt
@@ -2,5 +2,5 @@ package dev.slimevr
 
 data class FeatureFlags(
 	var steam: Boolean = false,
-	var skipCheckUdev: Boolean = false,
+	var skipCheckUdev: Boolean = true,
 )


### PR DESCRIPTION
Android doesn't pass in a featureFlagsProvider, so the defaults end up being used. This results in the server attempting to spawn udevadm when the GUI starts up on Android, which obviously fails.