### PR TITLE
Tolerate dragging during button presses for easier VR controller usage (disable link dragging on buttons) closes #1873

### DIFF
--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ export function NavButton({
       className={classnames(
         'flex flex-col justify-center xs:gap-4 mobile:gap-2',
         'mobile:w-[65px] mobile:h-[65px]',
-        'xs:py-3 mobile:py-4 rounded-md mobile:rounded-b-none group select-text',
+        'xs:py-3 mobile:py-4 rounded-md mobile:rounded-b-none group',
         {
           'bg-accent-background-50 fill-accent-background-20': doesMatch,
           'hover:bg-background-70': !doesMatch,

--- a/gui/src/components/onboarding/pages/body-proportions/BodyProportions.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/BodyProportions.tsx
@@ -28,7 +28,7 @@ function IncrementButton({
     <div
       onClick={onClick}
       className={classNames(
-        'p-3 rounded-lg xs:w-10 xs:h-10 flex flex-col justify-center items-center cursor-pointer',
+        'no-user-drag p-3 rounded-lg xs:w-10 xs:h-10 flex flex-col justify-center items-center cursor-pointer',
         'hover:bg-opacity-50 active:bg-accent-background-30',
         { 'bg-background-60': bgDark, 'bg-background-40': !bgDark }
       )}

--- a/gui/src/components/onboarding/pages/body-proportions/HeightInput.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/HeightInput.tsx
@@ -34,7 +34,7 @@ function IncrementButton({
   return (
     <div
       className={classNames(
-        'flex rounded-md items-center justify-center flex-row xs:flex-col w-full gap-1 p-3 xs:p-2 xs:w-[75px] xs:h-[75px]',
+        'no-user-drag flex rounded-md items-center justify-center flex-row xs:flex-col w-full gap-1 p-3 xs:p-2 xs:w-[75px] xs:h-[75px]',
         {
           'cursor-not-allowed bg-background-80 opacity-50': disabled,
           'bg-background-50 hover:bg-background-40 cursor-pointer': !disabled,

--- a/gui/src/components/onboarding/pages/body-proportions/HeightInput.tsx
+++ b/gui/src/components/onboarding/pages/body-proportions/HeightInput.tsx
@@ -74,7 +74,7 @@ function UnitSelector({
           'bg-accent-background-30': active,
           'hover:bg-background-40 bg-background-40': !active,
         },
-        'flex items-center justify-center rounded-md outline-background-10 cursor-pointer'
+        'no-user-drag flex items-center justify-center rounded-md outline-background-10 cursor-pointer'
       )}
       onClick={onClick}
     >

--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -427,7 +427,7 @@ div {
   -webkit-app-region: drag;
 }
 
-a {
+a, .no-user-drag {
   -webkit-user-drag: none;
   -webkit-user-select: none;
   user-select: none;

--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -426,3 +426,9 @@ div {
 [data-electron-drag-region='true'] {
   -webkit-app-region: drag;
 }
+
+a {
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  user-select: none;
+}

--- a/gui/src/index.scss
+++ b/gui/src/index.scss
@@ -427,7 +427,8 @@ div {
   -webkit-app-region: drag;
 }
 
-a, .no-user-drag {
+a,
+.no-user-drag {
   -webkit-user-drag: none;
   -webkit-user-select: none;
   user-select: none;


### PR DESCRIPTION
This is a small change to add user-select and user-drag none to `<Link to=` and `<Button to=` components in order to tolerate dragging a little when pressing buttons with a VR motion controller (in the vr overlay for example).

As it is right now, any movement while clicking, even within the button, causes a link drag instead of button activation, making it hard to press buttons in VR.

I target `Link` and `Button`s using router links (`to=`), because they produce draggle anchor elements, by just applying the CSS rules to all anchor elements. This covers most cases such as:
* Left nav bar
* Settings section button
* Wizard back out button ("previous step" button to back out of automatic mounting wizard, "go back to manual" button)
* Checklist open stay aligned button

Most other buttons using onclick and not the router seem to not have this issue, as long as they don't contain text. I did find 2 onclick buttons that had text and also needed the rule to be applied - the HeightInput, HeightInput unit selector buttons, and BodyProportions, so I added another classname `no-user-drag` to target these.

This seems to work perfectly afaict, as long as your click down and up are within the button (even if you leave and return), the button still can be pressed. It no longer drags a link, and no text selection happens. If your mouseup is outside the button, then it still doesn't get pressed.

I tested this in VR and it made it way easier to press the buttons.

I would really appreciate it if you would consider merging this because it drives me nuts.

closes #1873