### PR TITLE
Fix order of tap detection tracker settings

### DIFF
--- a/gui/src/components/settings/pages/GeneralSettings.tsx
+++ b/gui/src/components/settings/pages/GeneralSettings.tsx
@@ -1333,20 +1333,6 @@ export function GeneralSettings() {
                 <div>
                   <Typography variant="section-title">
                     {l10n.getString(
-                      'settings-general-gesture_control-mountingResetTracker'
-                    )}
-                  </Typography>
-                  <Dropdown
-                    display="block"
-                    control={control}
-                    placeholder={''}
-                    name="tapDetection.mountingResetTracker"
-                    items={bodyParts}
-                  />
-                </div>
-                <div>
-                  <Typography variant="section-title">
-                    {l10n.getString(
                       'settings-general-gesture_control-fullResetTracker'
                     )}
                   </Typography>
@@ -1355,6 +1341,20 @@ export function GeneralSettings() {
                     control={control}
                     placeholder={''}
                     name="tapDetection.fullResetTracker"
+                    items={bodyParts}
+                  />
+                </div>
+                <div>
+                  <Typography variant="section-title">
+                    {l10n.getString(
+                      'settings-general-gesture_control-mountingResetTracker'
+                    )}
+                  </Typography>
+                  <Dropdown
+                    display="block"
+                    control={control}
+                    placeholder={''}
+                    name="tapDetection.mountingResetTracker"
                     items={bodyParts}
                   />
                 </div>


### PR DESCRIPTION
Full reset was under mounting reset toggle, and vice versa.