### PR TITLE
Add motion detection to perform full & mounting resets only when keeping still

### DIFF
--- a/gui/public/i18n/en/translation.ftl
+++ b/gui/public/i18n/en/translation.ftl
@@ -254,6 +254,7 @@ reset-mounting = Mounting Calibration
 reset-mounting-feet = Feet Calibration
 reset-mounting-fingers = Fingers Calibration
 reset-yaw = Yaw Reset
+reset-wait_still = Keep Still !
 reset-error-no_feet_tracker = No feet tracker assigned
 reset-error-no_fingers_tracker = No finger tracker assigned
 reset-error-mounting-need_full_reset = Need a full reset before mounting

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { Typography } from './commons/Typography';
 import classNames from 'classnames';
+import { Localized } from '@fluent/react';
 import { ResetType } from 'solarxr-protocol';
 import {
   BODY_PARTS_GROUPS,
@@ -59,6 +60,8 @@ function BasicResetButton(options: UseResetOptions & { customName?: string }) {
     disabled,
     duration,
     error,
+    waitingStill,
+    velocity,
   } = useReset(options);
 
   const progress = status === 'counting' ? resetProress / duration : 0;
@@ -91,10 +94,16 @@ function BasicResetButton(options: UseResetOptions & { customName?: string }) {
         className={classNames(
           MAINBUTTON_CLASSES({ disabled }),
           'rounded-lg',
-          'absolute'
+          'absolute',
+          'transition-[box-shadow] duration-500 ease-in-out'
         )}
         style={{
           animationIterationCount: 1,
+          ...(waitingStill && {
+            boxShadow: `0px 0px ${Math.floor(velocity * 8)}px ${Math.floor(
+              velocity * 8
+            )}px rgb(var(--accent-background-30))`,
+          }),
         }}
         onClick={() => !disabled && triggerReset()}
       >
@@ -128,14 +137,20 @@ function BasicResetButton(options: UseResetOptions & { customName?: string }) {
           className={classNames(
             {
               'opacity-0': status !== 'counting',
-              'animate-timer-tick': status === 'counting',
+              'animate-timer-tick': status === 'counting' && !waitingStill,
             },
             'absolute top-0 h-full flex items-center justify-center'
           )}
         >
-          <Typography variant="main-title" textAlign="text-center">
-            {timer}
-          </Typography>
+          {waitingStill ? (
+            <Typography variant="section-title" textAlign="text-center">
+              <Localized id="reset-wait_still" />
+            </Typography>
+          ) : (
+            <Typography variant="main-title" textAlign="text-center">
+              {timer}
+            </Typography>
+          )}
         </div>
       </button>
     </Tooltip>

--- a/gui/src/components/home/ResetButton.tsx
+++ b/gui/src/components/home/ResetButton.tsx
@@ -41,11 +41,16 @@ export function ResetButton({
   onReseted?: () => void;
   onFailed?: () => void;
 } & UseResetOptions) {
-  const { triggerReset, status, timer, disabled, name, error } = useReset(
-    options,
-    onReseted,
-    onFailed
-  );
+  const {
+    triggerReset,
+    status,
+    timer,
+    disabled,
+    name,
+    error,
+    waitingStill,
+    velocity,
+  } = useReset(options, onReseted, onFailed);
 
   return (
     <Tooltip
@@ -73,9 +78,18 @@ export function ResetButton({
           'border-2 py-[5px]',
           status === 'finished'
             ? 'border-status-success'
-            : 'transition-[border-color] duration-500 ease-in-out border-transparent',
+            : 'transition-[box-shadow,border-color] duration-500 ease-in-out border-transparent',
           className
         )}
+        style={
+          waitingStill
+            ? {
+                boxShadow: `0px 0px ${Math.floor(velocity * 8)}px ${Math.floor(
+                  velocity * 8
+                )}px rgb(var(--accent-background-30))`,
+              }
+            : undefined
+        }
         variant="primary"
         disabled={disabled}
       >
@@ -83,9 +97,13 @@ export function ResetButton({
           <div className="opacity-0 h-0">
             {children || <Localized id={name} />}
           </div>
-          {status !== 'counting' || options.type === ResetType.Yaw
-            ? children || <Localized id={name} />
-            : String(timer)}
+          {status !== 'counting' || options.type === ResetType.Yaw ? (
+            children || <Localized id={name} />
+          ) : waitingStill ? (
+            <Localized id="reset-wait_still" />
+          ) : (
+            String(timer)
+          )}
         </div>
       </Button>
     </Tooltip>

--- a/gui/src/hooks/reset.ts
+++ b/gui/src/hooks/reset.ts
@@ -12,6 +12,7 @@ import { useAtomValue } from 'jotai';
 import { assignedTrackersAtom, serverGuardsAtom } from '@/store/app-store';
 import { FEET_BODY_PARTS, FINGER_BODY_PARTS } from './body-parts';
 import { useLocaleConfig } from '@/i18n/config';
+import { trackerCardVelocitiesAtom } from './tracker';
 import * as Sentry from '@sentry/react';
 
 export type ResetBtnStatus = 'idle' | 'counting' | 'finished';
@@ -41,10 +42,18 @@ export function useReset(
   const [status, setStatus] = useState<ResetBtnStatus>('idle');
   const [progress, setProgress] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [waitingStill, setWaitingStill] = useState(false);
 
   const parts = BODY_PARTS_GROUPS['group' in options ? options.group : 'default'];
 
+  const cardVelocities = useAtomValue(trackerCardVelocitiesAtom);
+  const velocity = useMemo(
+    () => Math.max(0, ...cardVelocities.values()),
+    [cardVelocities]
+  );
+
   const triggerReset = () => {
+    setWaitingStill(false);
     const req = new ResetRequestT();
     req.resetType = options.type;
     req.bodyParts = parts;
@@ -65,6 +74,7 @@ export function useReset(
 
   const onResetCanceled = () => {
     if (status !== 'finished') setStatus('idle');
+    setWaitingStill(false);
     if (onFailed) onFailed();
   };
 
@@ -82,7 +92,7 @@ export function useReset(
   }, [status]);
 
   const onResetProgress = (progress: number, duration: number) => {
-    setProgress(progress / 1000);
+    setProgress(Math.max(progress / 1000, 0));
     setDuration(duration / 1000);
   };
 
@@ -100,11 +110,13 @@ export function useReset(
       onResetProgress(progress, duration);
       switch (status) {
         case ResetStatus.FINISHED: {
+          setWaitingStill(false);
           onResetFinished();
           break;
         }
         case ResetStatus.STARTED: {
           setStatus('counting');
+          setWaitingStill(progress < 0);
           break;
         }
       }
@@ -167,6 +179,8 @@ export function useReset(
     disabled,
     name,
     error,
-    timer: localized.format(duration - progress),
+    waitingStill,
+    velocity,
+    timer: localized.format(Math.ceil(duration - Math.max(progress, 0))),
   };
 }

--- a/gui/src/hooks/tracker.ts
+++ b/gui/src/hooks/tracker.ts
@@ -5,9 +5,10 @@ import { ReactLocalization, useLocalization } from '@fluent/react';
 import { useDataFeedConfig } from './datafeed-config';
 import { Quaternion, Vector3 } from 'three';
 import { Vector3FromVec3fT } from '@/maths/vector3';
-import { useAtomValue } from 'jotai';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { trackerFromIdAtom } from '@/store/app-store';
 
+export const trackerCardVelocitiesAtom = atom(new Map<string, number>());
 export function getTrackerName(l10n: ReactLocalization, info: TrackerInfoT | null) {
   if (info?.customName) return info?.customName;
   if (info?.bodyPart) return l10n.getString('body_part-' + BodyPart[info?.bodyPart]);
@@ -44,6 +45,7 @@ export function useTracker(tracker: TrackerDataT) {
       );
       const [velocity, setVelocity] = useState<number>(0);
       const [deltas] = useState<number[]>([]);
+      const setCardVelocities = useSetAtom(trackerCardVelocitiesAtom);
 
       useEffect(() => {
         if (tracker.rotation) {
@@ -77,6 +79,24 @@ export function useTracker(tracker: TrackerDataT) {
           previousAcc.current = Vector3FromVec3fT(tracker.linearAcceleration);
         }
       }, [tracker.rotation]);
+
+      // Store the velocity for reset buttons to use
+      const key = `${tracker.trackerId?.deviceId}-${tracker.trackerId?.trackerNum}`;
+      useEffect(() => {
+        setCardVelocities((prev) => {
+          const next = new Map(prev);
+          next.set(key, velocity);
+          return next;
+        });
+        return () => {
+          setCardVelocities((prev) => {
+            if (!prev.has(key)) return prev;
+            const next = new Map(prev);
+            next.delete(key);
+            return next;
+          });
+        };
+      }, [velocity, key]);
 
       return velocity;
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "cd gui && pnpm lint:fix",
     "skipbundler": "cd gui && pnpm run skipbundler",
     "build": "cd gui && pnpm build",
+    "package:build": "cd gui && pnpm package:build",
     "update-solarxr": "cd solarxr-protocol && pnpm run build",
     "prepare": "husky && pnpm run update-solarxr",
     "preinstall": "npx only-allow pnpm"

--- a/server/core/src/main/java/dev/slimevr/VRServer.kt
+++ b/server/core/src/main/java/dev/slimevr/VRServer.kt
@@ -21,6 +21,7 @@ import dev.slimevr.protocol.rpc.TransactionInfo
 import dev.slimevr.protocol.rpc.settings.RPCSettingsHandler
 import dev.slimevr.reset.ResetHandler
 import dev.slimevr.reset.ResetTimerManager
+import dev.slimevr.reset.TrackerMotionDetector
 import dev.slimevr.reset.resetTimer
 import dev.slimevr.serial.ProvisioningHandler
 import dev.slimevr.serial.SerialHandler
@@ -113,6 +114,7 @@ class VRServer @JvmOverloads constructor(
 	val protocolAPI: ProtocolAPI
 	private val timer = Timer()
 	private val resetTimerManager = ResetTimerManager()
+	private val trackerMotionDetector = TrackerMotionDetector { trackers.filter { it.trackerPosition != null } }
 	val fpsTimer = NanoTimer()
 
 	@JvmField
@@ -363,7 +365,9 @@ class VRServer @JvmOverloads constructor(
 	fun scheduleResetTrackersFull(resetSourceName: String?, delay: Long, bodyParts: List<Int> = ArrayList(), tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
+			if (delay > 0) (configManager.vrConfig.resetsConfig.keepStillDelay * 1000).toLong() else 0,
 			delay,
+			isUserStatic = { !trackerMotionDetector.isMoving() },
 			onTick = { progress ->
 				resetHandler.sendStarted(ResetType.Full, tx, bodyParts, progress, delay.toInt())
 			},
@@ -379,7 +383,9 @@ class VRServer @JvmOverloads constructor(
 	fun scheduleResetTrackersYaw(resetSourceName: String?, delay: Long, bodyParts: List<Int> = TrackerUtils.allBodyPartsButFingers, tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
+			if (delay > 0) (configManager.vrConfig.resetsConfig.keepStillDelay * 1000).toLong() else 0,
 			delay,
+			isUserStatic = { !trackerMotionDetector.isMoving() },
 			onTick = { progress ->
 				resetHandler.sendStarted(ResetType.Yaw, tx, bodyParts, progress, delay.toInt())
 			},
@@ -395,7 +401,9 @@ class VRServer @JvmOverloads constructor(
 	fun scheduleResetTrackersMounting(resetSourceName: String?, delay: Long, bodyParts: List<Int>? = null, tx: TransactionInfo? = null) {
 		resetTimer(
 			resetTimerManager,
+			if (delay > 0) (configManager.vrConfig.resetsConfig.keepStillDelay * 1000).toLong() else 0,
 			delay,
+			isUserStatic = { !trackerMotionDetector.isMoving() },
 			onTick = { progress ->
 				resetHandler.sendStarted(ResetType.Mounting, tx, bodyParts, progress, delay.toInt())
 			},

--- a/server/core/src/main/java/dev/slimevr/config/ResetsConfig.kt
+++ b/server/core/src/main/java/dev/slimevr/config/ResetsConfig.kt
@@ -66,6 +66,7 @@ class ResetsConfig {
 
 	var lastMountingMethod = MountingMethods.AUTOMATIC
 
+	var keepStillDelay = 1.0f
 	var yawResetDelay = 0.0f
 	var fullResetDelay = 3.0f
 	var mountingResetDelay = 3.0f

--- a/server/core/src/main/java/dev/slimevr/reset/ResetTimer.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/ResetTimer.kt
@@ -2,7 +2,7 @@ package dev.slimevr.reset
 
 import java.util.Timer
 import java.util.TimerTask
-import kotlin.concurrent.schedule
+import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.math.floor
 import kotlin.math.min
 
@@ -15,7 +15,14 @@ class ResetTimerManager {
 	}
 }
 
-fun resetTimer(resetTimerManager: ResetTimerManager, delay: Long, onTick: (progress: Int) -> Unit, onComplete: () -> Unit) {
+fun resetTimer(
+	resetTimerManager: ResetTimerManager,
+	stillTime: Long,
+	delay: Long,
+	isUserStatic: () -> Boolean = { true },
+	onTick: (progress: Int) -> Unit,
+	onComplete: () -> Unit,
+) {
 	resetTimerManager.cancelTimers()
 
 	if (delay == 0L) {
@@ -23,18 +30,32 @@ fun resetTimer(resetTimerManager: ResetTimerManager, delay: Long, onTick: (progr
 		return
 	}
 
-	val ticks: Int = floor(delay / 1000f).toInt()
-	for (tick in 0..ticks) {
-		if (tick * 1000L == delay) continue
-		resetTimerManager.timers.add(
-			resetTimerManager.timer.schedule(tick * 1000L) {
-				onTick(tick * 1000)
-			},
-		)
+	val tickMs: Long = 100L
+	var elapsed: Long = 0L
+	var lastGuiTick: Int = -1
+	val task: TimerTask = resetTimerManager.timer.scheduleAtFixedRate(tickMs, tickMs) {
+		try {
+			if (stillTime > 0 && !isUserStatic()) {
+				// Trackers are in motion
+				elapsed = -stillTime
+				lastGuiTick = -1
+				onTick(-stillTime.toInt())
+				return@scheduleAtFixedRate
+			}
+			elapsed = min(elapsed + tickMs, delay)
+			if (elapsed >= delay) {
+				onComplete()
+				cancel()
+			} else {
+				val nextTick = floor(elapsed / 1000f).toInt()
+				if (nextTick > lastGuiTick) {
+					onTick(nextTick * 1000)
+					lastGuiTick = nextTick
+				}
+			}
+		} catch (e: Exception) {
+			cancel()
+		}
 	}
-	resetTimerManager.timers.add(
-		resetTimerManager.timer.schedule(delay) {
-			onComplete()
-		},
-	)
+	resetTimerManager.timers.add(task)
 }

--- a/server/core/src/main/java/dev/slimevr/reset/TrackerMotionDetector.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/TrackerMotionDetector.kt
@@ -76,8 +76,10 @@ class TrackerMotionDetector(private val trackersProvider: () -> List<Tracker>) {
 			val rot = tracker.getRawRotation() * state.rot.inv()
 			val acc = tracker.getAcceleration() - state.acc
 			val dif = (
-				(rot.x * rot.x + rot.y * rot.y + rot.z * rot.z) * 50f +
-					(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z) / 1000f
+				(rot.x * rot.x + rot.y * rot.y + rot.z * rot.z) *
+					50f +
+					(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z) /
+					1000f
 				).coerceAtMost(1f)
 			if (state.deltas.size >= WINDOW_SAMPLES) state.deltas.removeFirst()
 			state.deltas.addLast(dif)
@@ -95,6 +97,6 @@ class TrackerMotionDetector(private val trackersProvider: () -> List<Tracker>) {
 		private const val SAMPLE_MS = 100L
 		private const val WINDOW_SAMPLES = 5
 		private const val IDLE_STOP_MS = 5000L
-		private const val MOVEMENT_THRESHOLD = 0.125f
+		private const val MOVEMENT_THRESHOLD = 4 * 0.125f
 	}
 }

--- a/server/core/src/main/java/dev/slimevr/reset/TrackerMotionDetector.kt
+++ b/server/core/src/main/java/dev/slimevr/reset/TrackerMotionDetector.kt
@@ -1,0 +1,100 @@
+package dev.slimevr.reset
+
+import dev.slimevr.tracking.trackers.Tracker
+import io.github.axisangles.ktmath.Quaternion
+import io.github.axisangles.ktmath.Vector3
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.concurrent.scheduleAtFixedRate
+
+class TrackerMotionDetector(private val trackersProvider: () -> List<Tracker>) {
+
+	private class MotionState {
+		var rot: Quaternion = Quaternion.IDENTITY
+		var acc: Vector3 = Vector3(0f, 0f, 0f)
+		val deltas = ArrayDeque<Float>()
+	}
+
+	@Volatile
+	private var maxVelocity = 0f
+
+	private var timer: Timer? = null
+	private var task: TimerTask? = null
+
+	@Volatile
+	private var lastPolled = 0L
+	private val states = HashMap<String, MotionState>()
+
+	@Synchronized
+	fun isMoving(): Boolean {
+		lastPolled = System.currentTimeMillis()
+		if (task == null) {
+			start()
+		}
+		return maxVelocity >= MOVEMENT_THRESHOLD
+	}
+
+	@Synchronized
+	private fun start() {
+		states.clear()
+		timer = Timer("TrackerMotionDetector", true)
+		task = timer!!.scheduleAtFixedRate(SAMPLE_MS, SAMPLE_MS) {
+			if (System.currentTimeMillis() - lastPolled > IDLE_STOP_MS) {
+				stop()
+			} else {
+				try {
+					sample()
+				} catch (e: Exception) {
+					stop()
+				}
+			}
+		}
+	}
+
+	@Synchronized
+	private fun stop() {
+		task?.cancel()
+		timer?.cancel()
+		task = null
+		timer = null
+		states.clear()
+		maxVelocity = 0f
+	}
+
+	private fun sample() {
+		var max = 0f
+		for (tracker in trackersProvider()) {
+			if (!tracker.hasRotation) continue
+			var state = states[tracker.name]
+			if (state == null) {
+				state = MotionState()
+				state.rot = tracker.getRawRotation()
+				state.acc = tracker.getAcceleration()
+				states[tracker.name] = state
+				continue
+			}
+			val rot = tracker.getRawRotation() * state.rot.inv()
+			val acc = tracker.getAcceleration() - state.acc
+			val dif = (
+				(rot.x * rot.x + rot.y * rot.y + rot.z * rot.z) * 50f +
+					(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z) / 1000f
+				).coerceAtMost(1f)
+			if (state.deltas.size >= WINDOW_SAMPLES) state.deltas.removeFirst()
+			state.deltas.addLast(dif)
+			var sum = 0f
+			for (delta in state.deltas) sum += delta
+			max = maxOf(max, sum.coerceIn(0f, 1f))
+			state.rot = tracker.getRawRotation()
+			state.acc = tracker.getAcceleration()
+		}
+		maxVelocity = max
+	}
+
+	companion object {
+		// Values matched with GUI tracker.ts
+		private const val SAMPLE_MS = 100L
+		private const val WINDOW_SAMPLES = 5
+		private const val IDLE_STOP_MS = 5000L
+		private const val MOVEMENT_THRESHOLD = 0.125f
+	}
+}


### PR DESCRIPTION
Currently the reset only waits for a fixed timeout before taking the calibration data, which may cause bad data if the user accidentally moves during reset. Also the user would be in a rush to get into the mounting reset position.

This PR adds motion detection to the server and corresponding visual markers to the reset buttons in the GUI. Now during full & mounting resets, if the user is in large motion, the reset button would show a "Keep Still !" info, with the button edge reflecting motion strength identical to the tracker cards. After the motion stops, the countdown would return to normal.

With this PR the reset process should be less tricky and less likely to need for a retry.