### PR TITLE
Apply signal strength to the tracker it names

### DIFF
--- a/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
+++ b/server/core/src/main/java/dev/slimevr/tracking/trackers/udp/TrackersUDPServer.kt
@@ -271,7 +271,7 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 	)
 
 	private val queues: MutableMap<Triple<SocketAddress, ConfigTypeId, Int>, Deque<ConfigStateWaiter>> = ConcurrentHashMap()
-	suspend fun setConfigFlag(device: UDPDevice, configTypeId: ConfigTypeId, state: Boolean, sensorId: Int = 255) {
+	suspend fun setConfigFlag(device: UDPDevice, configTypeId: ConfigTypeId, state: Boolean, sensorId: Int = TRACKER_ID_ALL) {
 		if (device.timedOut) return
 		val triple = Triple(device.address, configTypeId, sensorId)
 		val queue = queues.computeIfAbsent(triple) { _ -> ConcurrentLinkedDeque() }
@@ -533,8 +533,20 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 				)
 			}
 
-			is UDPPacket19SignalStrength -> connection?.trackers?.values?.forEach {
-				it.signalStrength = packet.signalStrength
+			is UDPPacket19SignalStrength -> {
+				// Id 255 addresses the device as a whole rather than one of its trackers: that
+				// is what the ESP firmware sends for signal strength, since a device has one
+				// radio however many trackers it exposes. Any other id names a single tracker,
+				// and applying the value to all of them let whichever tracker reported last
+				// overwrite the rest.
+				if (packet.sensorId == TRACKER_ID_ALL) {
+					connection?.trackers?.values?.forEach {
+						it.signalStrength = packet.signalStrength
+					}
+				} else {
+					val tracker = connection?.getTracker(packet.sensorId) ?: return
+					tracker.signalStrength = packet.signalStrength
+				}
 			}
 
 			is UDPPacket20Temperature -> {
@@ -656,6 +668,16 @@ class TrackersUDPServer(private val port: Int, name: String, private val tracker
 		// 270 deg (-90 deg) default for officials
 		private val SENSOR_OFFSET_CORRECTION = Quaternion.rotationAroundZAxis(-FastMath.HALF_PI)
 		private const val RESET_SOURCE_NAME = "TrackerServer"
+
+		/**
+		 * Id meaning "every tracker on this device" rather than one of them.
+		 *
+		 * Signal strength is the only packet the ESP firmware sends this way
+		 * (`Connection::sendSignalStrength`): a device has one radio however many trackers it
+		 * exposes. Device-wide values that need no id at all simply carry none — the battery
+		 * packet has no id field. [setConfigFlag] defaults to this to address a whole device.
+		 */
+		const val TRACKER_ID_ALL = 255
 
 		private val hexFormat = HexFormat {
 			bytes.byteSeparator = ","


### PR DESCRIPTION
`UDPPacket19SignalStrength` parses a tracker id, but the handler ignored it and wrote the value to every tracker on the connection — so on a device reporting more than one, whichever sent last set the signal strength for all of them. Every neighbouring handler resolves the id; `UDPPacket20Temperature`, right below it, does `getTracker(packet.sensorId)`.

Id 255 still means the device as a whole, which is what the ESP firmware sends here, so existing trackers are unaffected. Any other id now updates only the tracker it names. The 255 convention gets a name, which `setConfigFlag`'s default reuses.

This matters for a proxy device relaying several wireless trackers over one connection: each tracker has its own id there, and today they all display one arbitrary tracker's signal — exactly the value you need per tracker when one is at the edge of range.

`:server:core:compileKotlin` and `:server:spotlessCheck` pass (JDK 21). No test: there's no harness for the UDP path, and this handler needs a live `UDPDevice` plus the `VRServer` singleton — happy to add one if you want it.

Per CONTRIBUTING: I used Claude Code to draft this patch (the commit carries a `Co-Authored-By` trailer). I found the behaviour on my own device and reviewed the change.
